### PR TITLE
Quote $PATH when used with printf

### DIFF
--- a/scripts/info
+++ b/scripts/info
@@ -77,7 +77,7 @@ info_environment() {
 info_debug() {
   rvm_info=$(__rvm_version)
   rvm_info="$rvm_info\n$("$rvm_scripts_path/info" "$rvm_ruby_string" "" )"
-  rvm_info="$rvm_info\nPATH:\n$(printf $PATH | awk -F":" '{print $1":"$2":"$3":"$4":"$5}' )"
+  rvm_info="$rvm_info\nPATH:\n$(printf "$PATH" | awk -F":" '{print $1":"$2":"$3":"$4":"$5}' )"
   rvm_info="$rvm_info\nuname -a: $(uname -a)"
   rvm_info="$rvm_info\npermissions: $(\ls -la $rvm_path{,/rubies})"
 

--- a/scripts/selector
+++ b/scripts/selector
@@ -230,7 +230,7 @@ __rvm_use() {
 
     unset GEM_HOME GEM_PATH BUNDLE_PATH MY_RUBY_HOME RUBY_VERSION IRBRC
 
-    new_path="$rvm_bin_path:$(__rvm_remove_rvm_from_path ; printf $PATH)"
+    new_path="$rvm_bin_path:$(__rvm_remove_rvm_from_path ; printf "$PATH")"
     if [[ -s $rvm_config_path/system ]] ; then
       \grep "MY_RUBY_HOME='$rvm_rubies_path" "$rvm_config_path/system" > /dev/null
       if [[ $? -eq 0 ]] ; then
@@ -283,7 +283,7 @@ __rvm_use() {
       "$rvm_scripts_path/log" "info" "Using $(basename $GEM_HOME | \tr '-' ' ' | sed 's/'${rvm_gemset_separator}'/ with gemset /')"
     fi
 
-    new_path="$GEM_HOME/bin:$rvm_ruby_global_gems_path/bin:$MY_RUBY_HOME/bin:$rvm_bin_path:$(__rvm_remove_rvm_from_path ; printf $PATH)"
+    new_path="$GEM_HOME/bin:$rvm_ruby_global_gems_path/bin:$MY_RUBY_HOME/bin:$rvm_bin_path:$(__rvm_remove_rvm_from_path ; printf "$PATH")"
   fi
 
   # Export ruby string and gem set me for extrenal scripts to take advantage of them.


### PR DESCRIPTION
Hi, I hit a bug when trying to get the RSpec TextMate bundle and this leads me to find a problem with the way the new_path is set when switching ruby version if the $PATH contains spaces. 

Given the following :
     PATH="/my path/bin:/usr/bin"

before this patch:

```
rvm ruby-1.9.2-head@mygemset
echo $PATH
# rvm_paths:/my
```

after this patch:

```
rvm ruby-1.9.2-head@mygemset
echo $PATH
# rvm_paths:/my path/bin:/usr/bin
```

Thanks for the awesome work you've done with rvm.
