### PR TITLE
Doing site-wide, and I'd like to specify the rvm revision to install

### DIFF
--- a/contrib/install-system-wide
+++ b/contrib/install-system-wide
@@ -55,6 +55,12 @@ git clone --depth 1 git://github.com/wayneeseguin/rvm.git || git clone http://gi
 
 builtin cd rvm
 
+rvm_revision=${rvm_revision:-""}
+if [[ "$rvm_revision" ]]; then
+  echo "Checking out revision $rvm_revision"
+  git checkout $rvm_revision
+fi
+
 echo "Running the install script."
 bash ./scripts/install "$@"
 


### PR DESCRIPTION
Hi Wayne/Darcy,
Thanks a lot for RVM - it's been a big help!

I'm working on adding it to our production infrastructure, and I want to be able to repeatably install exactly the version we've been testing; I've tweaked the install-system-wide script to allow me to specify the git revision I want.

Any chance you'd pull this?

Best,
...Bryan Stearns
