### PR TITLE
Fixing zsh completion

### DIFF
--- a/scripts/zsh/Completion/_rvm
+++ b/scripts/zsh/Completion/_rvm
@@ -34,7 +34,7 @@ _arguments -C \
 
 case $state in
 	cmds)
-		cmds=( ${(f)"$(_call_program commands rvm help 2> /dev/null | sed -e '/^Action/,/^Implementation/!d; / - /!d; s/^\W*\([-_a-zA-Z0-9]*\) *- /\1:/')"} )
+		cmds=( ${(f)"$(_call_program commands rvm help 2> /dev/null | sed -e '/^Action/,/^Implementation/!d; / - /!d; s/^[ *]*\([^ ]*\) *\- *\(.*\)/\1:\2/')"} )
 		cmds+=( $(rvm list strings) )
 		_describe -t commands 'rvm command' cmds && ret=0
 		;;


### PR DESCRIPTION
I was having trouble with zsh completion with no arguments (i.e., rvm <tab>)

I think this is because of my version of sed and/or zsh (4.3.9 on Snow Leopard) was not correctly interpreting the \W in the sed regex replacement.

I've replaced the regex with something that should be more lenient and, hopefully, more future-compatible for the help screen text formatting.
