### PR TITLE
Use an alternate method to save irb history

### DIFF
--- a/scripts/irbrc.rb
+++ b/scripts/irbrc.rb
@@ -10,8 +10,28 @@ end
 require "irb/completion" rescue nil
 
 # Turn on history saving.
-require "irb/ext/save-history"
-IRB.conf[:HISTORY_FILE] = File.join(ENV["HOME"], ".irb-history")
+# require "irb/ext/save-history"
+# IRB.conf[:HISTORY_FILE] = File.join(ENV["HOME"], ".irb-history")
+
+# Use an alternate way to on history saving until save-history is fixed.
+#
+#   bug:   http://redmine.ruby-lang.org/issues/show/1556
+#   patch: http://pastie.org/513500
+#
+# This technique was adopted from /etc/irbrc on OS X.
+histfile = File::expand_path(".irb-history", ENV["HOME"])
+maxhistsize = 100
+
+if File::exists?(histfile)
+  lines = IO::readlines(histfile).collect { |line| line.chomp }
+  Readline::HISTORY.push(*lines)
+end
+
+Kernel::at_exit do
+  lines = Readline::HISTORY.to_a.reverse.uniq.reverse
+  lines = lines[-maxhistsize, maxhistsize] if lines.nitems > maxhistsize
+  File::open(histfile, File::WRONLY|File::CREAT|File::TRUNC) { |io| io.puts lines.join("\n") }
+end
 
 # Calculate the ruby string.
 rvm_ruby_string = ENV["rvm_ruby_string"] || "#{RUBY_ENGINE rescue 'ruby'}-#{RUBY_VERSION}-#{(RUBY_PATCHLEVEL) ? "p#{RUBY_PATCHLEVEL}" : "r#{RUBY_REVISION}"}"


### PR DESCRIPTION
The accepted way of turning on irb save history doesn't work on 1.8.6-p399 and 1.87-p302 (at least) because of a known bug in 'irb/ext/save-history'.  This branch uses an alternate method of saving an irb history file that is patterned after what OS X does by default.

There is a patch for the bug, and it is apparently easy to apply, but I'd guess most people will not have the patch.  Moreover I think you'd have to patch each installed version of ruby, so this may be a nicer way forward.

See:
- bug:   http://redmine.ruby-lang.org/issues/show/1556
- patch: http://pastie.org/513500
- how to apply the patch (comment 2): http://stackoverflow.com/questions/2065923/irb-history-not-working
