### PR TITLE
Log percent substitution

### DIFF
--- a/scripts/log
+++ b/scripts/log
@@ -7,7 +7,7 @@ if [[ "$rvm_trace_flag" -eq 2 ]] ; then set -x ; export rvm_trace_flag ; fi
 
 if [[ ! -z "$2" ]] ; then level=$1 ; shift ; else level="info" ; fi
 
-message="${1//%/%%}"
+message="${1//\%/%%}"
 
 if [[ ${rvm_pretty_print_flag:-0} -eq 0 ]] ; then
 


### PR DESCRIPTION
The substitution introduced by wayneeseguin/rvm@d0fa9391845532188db41147955afcdc07b60b86 doesn't work right on older bashes. The commit makes this replacement.

```
-message="$(echo "$1" | sed 's/%/%%/g')"
+message="${1//%/%%}"
```

I am guessing the substitution should be (escape the first %):

```
message="${1//\%/%%}"
```

Now test drive with these commands:

```
bash --version
msg=abc
echo $msg | sed 's/%/%%/g'
echo ${msg//%/%%}
echo ${msg//\%/%%}
msg=a%c
echo $msg | sed 's/%/%%/g'
echo ${msg//%/%%}
echo ${msg//\%/%%}
```

What you can see below is that on older bashes the current substitution adds '%%' to the end of the message rather than replacing '%' with '%%'. The end result is log messages like:

```
Using /usr/local/rvm/gems/ruby-1.8.6-p399 with gemset chiangs%
```

Here goes...

```
chiangs:~> bash --version
GNU bash, version 3.1.17(1)-release (i586-suse-linux)
Copyright (C) 2005 Free Software Foundation, Inc.
chiangs:~> msg=abc
chiangs:~> echo $msg | sed 's/%/%%/g'
abc
chiangs:~> echo ${msg//%/%%}
abc%%
chiangs:~> echo ${msg//\%/%%}
abc
chiangs:~> msg=a%c
chiangs:~> echo $msg | sed 's/%/%%/g'
a%%c
chiangs:~> echo ${msg//%/%%}
a%c%%
chiangs:~> echo ${msg//\%/%%}
a%%c
chiangs:~> 
```

This effect is apparently not an issue on newer bashes.

```
Simon:~>bash --version
GNU bash, version 3.2.17(1)-release (i386-apple-darwin9.0)
Copyright (C) 2005 Free Software Foundation, Inc.
Simon:~>msg=abc
Simon:~>echo $msg | sed 's/%/%%/g'
abc
Simon:~>echo ${msg//%/%%}
abc
Simon:~>echo ${msg//\%/%%}
abc
Simon:~>msg=a%c
Simon:~>echo $msg | sed 's/%/%%/g'
a%%c
Simon:~>echo ${msg//%/%%}
a%%c
Simon:~>echo ${msg//\%/%%}
a%%c
Simon:~>
```
