### PR TITLE
install-system-wide FreeBSD support

### DIFF
--- a/contrib/install-system-wide
+++ b/contrib/install-system-wide
@@ -42,13 +42,8 @@ __rvm_create_user_group() {
     echo "Creating the group '$1'"
 
     case "$os_type" in
-      "FreeBSD")
-        echo "FreeBSD pw groupadd"
-        pw groupadd -q "$rvm_group_name"
-      ;;
-      "Linux")
-        groupadd -f "$rvm_group_name"
-      ;;
+      "FreeBSD") pw groupadd -q "$rvm_group_name";;
+      "Linux")   groupadd -f "$rvm_group_name";;
     esac
   fi
 
@@ -61,12 +56,8 @@ __rvm_add_user_to_group() {
   echo "Adding '$1' to the group '$2'"
   
   case "$os_type" in
-    "FreeBSD")
-      pw usermod "$1" -G "$2"
-    ;;
-    "Linux")
-      usermod -a -G "$2" "$1"
-    ;;
+    "FreeBSD") pw usermod "$1" -G "$2";;
+    "Linux")   usermod -a -G "$2" "$1";;
   esac
 
   return 0


### PR DESCRIPTION
Added support for FreeBSD system wide installation to the install-system-wide script, tested with FreeBSD 8.1.
