### PR TITLE
Maintain tab CDPATH tab completion when using RVM's cd

### DIFF
--- a/scripts/cd
+++ b/scripts/cd
@@ -29,5 +29,20 @@ if [[ ${rvm_project_rvmrc:-1} -ne 0 ]] ; then
 
       return $result
     }
+
+    _rvm_cd_complete ()
+    {
+      local cur matches
+      COMPREPLY=()
+      cur="${COMP_WORDS[COMP_CWORD]}"
+
+      matches=$(for dir in `echo $CDPATH | tr -s ':' ' '`; do
+        find $dir/* -type d -maxdepth 0 -exec basename {} \;
+      done | sort | uniq)
+
+      COMPREPLY=( $(compgen -W "${matches}" -- ${cur}) )
+    }
+    complete -o bashdefault -o default -o dirnames -o plusdirs -F _rvm_cd_complete cd
   fi
 fi
+


### PR DESCRIPTION
Adds a tab-complete function to the cd that's supplied with RVM that will honor bash's CDPATH variable and still let the .rvmrc switching continue to work.
