### PR TITLE
Bash tabcomplete for CD

### DIFF
--- a/scripts/cd
+++ b/scripts/cd
@@ -42,7 +42,7 @@ if [[ ${rvm_project_rvmrc:-1} -ne 0 ]] ; then
 
       COMPREPLY=( $(compgen -W "${matches}" -- ${cur}) )
     }
-    complete -o bashdefault -o default -o dirnames -o plusdirs -F _rvm_cd_complete cd
+    complete -o bashdefault -o default -o dirnames -o filenames -o nospace -o plusdirs -F _rvm_cd_complete cd
   fi
 fi
 


### PR DESCRIPTION
Adds a tab-complete function to the cd that's supplied with RVM that will honor bash's CDPATH variable and still let the .rvmrc switching continue to work.
