### PR TITLE
Add make to dependency notes for arch linux

### DIFF
--- a/scripts/notes
+++ b/scripts/notes
@@ -63,8 +63,8 @@ dependencies:
   rvm: bash curl git
 
   # For MRI based rubies you will need:
-  ruby: pacman -Sy --noconfirm patch curl bison zlib readline libxml2 git
-  ruby-head: pacman -Sy --noconfirm subversion autoconf diffutils patch bison
+  ruby: pacman -Sy --noconfirm patch curl bison zlib readline libxml2 git make
+  ruby-head: pacman -Sy --noconfirm subversion autoconf diffutils patch bison make
 
   # For JRuby (if you wish to use it) you will need:
   jruby: pacman -Sy --noconfirm jdk jre curl


### PR DESCRIPTION
The make package is also required under arch. This one just caught me out!
