### PR TITLE
Ubuntu doc fix

### DIFF
--- a/scripts/notes
+++ b/scripts/notes
@@ -26,13 +26,13 @@ if [[ "Linux" = "$system" ]] ; then
     printf "
 dependencies:
 # For RVM
-  rvm: bash curl git-core
+  rvm: bash curl git
 
 # For JRuby (if you wish to use it) you will need:
   jruby: aptitude install curl sun-java6-bin sun-java6-jre sun-java6-jdk
 
 # For MRI & ree (if you wish to use it) you will need (depending on what you are installing):
-  ruby: aptitude install build-essential bison openssl libreadline5 libreadline-dev curl git-core zlib1g zlib1g-dev libssl-dev libsqlite3-0 libsqlite3-dev sqlite3 libxml2-dev
+  ruby: aptitude install build-essential bison openssl libreadline5 libreadline-dev curl git zlib1g zlib1g-dev libssl-dev libsqlite3-0 libsqlite3-dev sqlite3 libxml2-dev
   ruby-head: git subversion autoconf
 
 # For IronRuby (if you wish to use it) you will need:


### PR DESCRIPTION
Wayne,
Amazing work! Just wanted to add a small correction to the docs that come up for rvm's post-installation. The 'git' package is now preferable to 'git-core' (find change in my ubuntu_doc_fix branch) on Ubuntu. Not sure if this applies only to Ubuntu, but thought it worth mentioning.

-Daniel
