### PR TITLE
Bash $CDPATH autocomplete starts automatically

### DIFF
--- a/scripts/cd
+++ b/scripts/cd
@@ -77,9 +77,9 @@ if [[ ${rvm_project_rvmrc:-1} -ne 0 ]] ; then
 
       fi
 
-      complete -o filenames -o nospace -F _rvm_cd_complete cd
-
     }
+
+    complete -o filenames -o nospace -F _rvm_cd_complete cd
 
   fi
 


### PR DESCRIPTION
For some reason, the command to start autocompleteting on cd for $CDPATH was inside the completion function itself. This commit moves it so it's available to fresh terminals.
