### PR TITLE
Fixed straying $rvm_head_flag

### DIFF
--- a/scripts/selector
+++ b/scripts/selector
@@ -464,7 +464,7 @@ __rvm_ruby_string()
   gemset_name=${rvm_gemset_name:-""}
   repo_url=${rvm_ruby_repo_url:-""}
 
-  __rvm_unset_ruby_variables
+  __rvm_unset_ruby_variables && unset rvm_head_flag
 
   rvm_ruby_repo_url=${repo_url:-""}
 


### PR DESCRIPTION
Using a set of rubies like `rbx-head,ruby-1.9.2` will cause problems, because `$rvm_head_flag` is not reset after each ruby.

For example calling `rvm rbx-head,ruby-1.9.2 ruby -v` will result in the following error:

```
rubinius 1.1.0 (1.8.7 6f0f6446 2010-09-23 JI) [x86_64-apple-darwin10.4.0]
'ruby not found for ruby-1.9.2-head' either does not exist or is not executable? :(
```

The attached patch resets `$rvm_head_flag` together with the `$rvm_ruby_*` variables.
