### PR TITLE
Allows _rvm_cd_complete to work even in the presence of missing directories in CDPATH

### DIFF
--- a/scripts/cd
+++ b/scripts/cd
@@ -79,7 +79,7 @@ if [[ ${rvm_project_rvmrc:-1} -ne 0 ]] ; then
 
     }
 
-    complete -o filenames -o nospace -F _rvm_cd_complete cd
+    complete -o filenames -o dirnames -o nospace -F _rvm_cd_complete cd
 
   fi
 


### PR DESCRIPTION
I was mystified as to why I couldn't autocomplete any directories after cd after updating my RVM installation, until I realized that the fact that a directory I have in CDPATH isn't present on this machine. This allows cd autocompletion to continue to work in such scenarios.
