### PR TITLE
Hotfix/unknown user variable

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -124,9 +124,16 @@ andand_return_warning()
 }
 
 thank_you()
-{
+{ 
+  RVM_USER = "not defined"
+	if test -n "$USER" ; then
+		RVM_USER = $USER
+	else
+		RVM_USER = `who am i`
+	fi
+	
   printf "
-${name:-"$USER"},
+${name:-"$RVM_USER"},
 
 Thank you very much for using RVM! I sincerely hope that RVM helps to
 make your work both easier and more enjoyable.


### PR DESCRIPTION
Hi,

from 1.0.17 I cannot install, since the thank_you method in script/install has changed. 
I couldn't manage to get the ebuild to pull from my repo so I couldn't verify my fix.

The error message from gentoo is

./install: line 155: USER: unbound variable
- ERROR: dev-ruby/rvm-1.0.17 failed:
-   Installation failed.

Previously it was `who am i`

If you have a new version, I'm happy to try out the install

Christian
BTW, either cherry-pick 82412aedd71b5b32d9577c074d93c2be70897bc1 or merge the hotfix branch, it was based off tag 1.0.18
