### PR TITLE
Darwin notes: how to abandon system ruby

### DIFF
--- a/scripts/notes
+++ b/scripts/notes
@@ -126,6 +126,12 @@ elif [[ "Darwin" = "$system"  ]] ; then
     If you intend on installing MacRuby you must install LLVM first.
     If you intend on installing JRuby you must install the JDK.
     If you intend on installing IronRuby you must install Mono (version 2.6 or greater is recommended).
+
+    To seamlessly abandon the Apple-installed system ruby (ruby 1.8.7 patchlevel 174 for Snow Leopard):
+
+    rvm install 1.8.7 # installs patch 302: closest supported version
+    rvm system ; rvm gemset export system.gems ; rvm 1.8.7 ; rvm gemset import system # migrate your gems
+    rvm --default 1.8.7
   "
 fi
 


### PR DESCRIPTION
Added a 3-line recipe: install 1.8.7, migrate gems (with bugfix I submitted earlier to rvm-site), set rvm 1.8.7 to default for Darwin

Thanks again for rvm!
- Bill
