### PR TITLE
Fix cd tab-completion, again.

### DIFF
--- a/scripts/cd
+++ b/scripts/cd
@@ -53,7 +53,7 @@ if [[ ${rvm_project_rvmrc:-1} -ne 0 ]] ; then
       local directory current matches item index
       COMPREPLY=()
       current="${COMP_WORDS[COMP_CWORD]}"
-      if [[ -n "$CDPATH" ]] ; then
+      if [[ -n "$CDPATH" && ${current:0:1} != "/" ]] ; then
         index=0
         for directory in $(printf "$CDPATH" | tr -s ':' ' ') ; do
           for item in $( compgen -d "$directory/$current" ) ; do


### PR DESCRIPTION
This has been a bit of a contentious feature, especially as bash tab-completion has more gotchas than I (and albus522) had originally considered, apparently. However, I think I've finally cracked this, and it works for pretty much every case I can throw at it.

Fixes explained in the commit message and feature explained in the script.
