### PR TITLE
Patch to fix cd autocompletion

### DIFF
--- a/scripts/cd
+++ b/scripts/cd
@@ -57,7 +57,7 @@ if [[ ${rvm_project_rvmrc:-1} -ne 0 ]] ; then
       current="${COMP_WORDS[COMP_CWORD]}"
       if [[ -n "$CDPATH" && ${current:0:1} != "/" ]] ; then
         index=0
-        for directory in $(printf "$CDPATH" | tr -s ':' ' ') ; do
+        for directory in $(printf "%s" "$CDPATH" | tr -s ':' ' ') ; do
           for item in $( compgen -d "$directory/$current" ) ; do
             COMPREPLY[index++]=${item#$directory/}
           done


### PR DESCRIPTION
Fixes a problem where tab completion didn't work when a directory in the path contained a space.
Also fixed a potential format string vulnerability.

Before the patch:
$ cd ~/Documents/Work/Scho<tab>
data    School  

After the patch:
$ cd ~/Documents/Work/Scho<tab>
$ cd ~/Documents/Work/School\ data
