### PR TITLE
Minor bugfix in installation script

### DIFF
--- a/scripts/rvm
+++ b/scripts/rvm
@@ -4,7 +4,7 @@
 # http://rvm.beginrescueend.com
 # http://github.com/wayneeseguin/rvm
 
-grep -q '^rvm ()' < <( declare -f ) # Is RVM is a shell function?
+\grep -q '^rvm ()' < <( declare -f ) # Is RVM is a shell function?
 
 if [[ $? -gt 0 || ${rvm_reload_flag:-0} -eq 1 ]] ; then
 


### PR DESCRIPTION
The installation script `scripts/rvm` uses just plain `grep` in the first line. All the other `grep`s are escaped with the `\` so it's cool. This one is not and it breaks on some systems. I personally alias `ack-grep` to `grep` so it broke on my my system.
