### PR TITLE
Tweak rvm's cd completion just a little more

### DIFF
--- a/scripts/cd
+++ b/scripts/cd
@@ -57,7 +57,10 @@ if [[ ${rvm_project_rvmrc:-1} -ne 0 ]] ; then
       current="${COMP_WORDS[COMP_CWORD]}"
       if [[ -n "$CDPATH" && ${current:0:1} != "/" ]] ; then
         index=0
-        for directory in $(printf "%s" "$CDPATH" | tr -s ':' ' ') ; do
+        # The change to IFS above means that the tr below should replace ':'
+        # with a newline rather than a space. A space would be ignored, breaking
+        # TAB completion based on CDPATH again
+        for directory in $(printf "%s" "$CDPATH" | tr -s ':' '\n') ; do
           for item in $( compgen -d "$directory/$current" ) ; do
             COMPREPLY[index++]=${item#$directory/}
           done


### PR DESCRIPTION
The last change to this function alters IFS which in turn seems to break the handling of CDPATH-based completions. This commit adjusts to match the new IFS.
