### PR TITLE
More traditional behavior for './install --help'

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -42,7 +42,7 @@ usage()
 
     --version : display rvm package version
 
-  "
+  \n"
 }
 
 check_rubyopt_conditions()
@@ -192,7 +192,12 @@ while [[ $# -gt 0 ]] ; do
       env | grep '^rvm_'
       set -o xtrace
       ;;
-    --help|*)  usage ;;
+    --help)  usage ; exit ;;
+    *)
+      echo "Unrecognized option: $token"
+      usage
+      exit
+      ;;
   esac
 done
 


### PR DESCRIPTION
It's nice that the installer has a '--help' option, but it's rather surprising that it goes through with the installation after showing the usage information.  It's similarly surprising to do this after encountering an unrecognized parameter.  This sort of surprise may not be welcome by some...
