### PR TITLE
Improve clarity of rvm_prefix / rvm_path error message(s)

### DIFF
--- a/scripts/rvm
+++ b/scripts/rvm
@@ -52,9 +52,14 @@ if ! declare -f rvm > /dev/null || [[ ${rvm_reload_flag:-0} -eq 1 ]] ; then
 
       rvm_prefix="/usr/local/"
 
-    else
+    elif [[ -n "$HOME" ]] ; then
 
       rvm_prefix="$HOME/."
+
+    else
+
+      echo "No \$rvm_prefix was provided and $(id -un) has no \$HOME defined to find it with. Exploding violently."
+      exit 1
 
     fi
 
@@ -111,7 +116,7 @@ if ! declare -f rvm > /dev/null || [[ ${rvm_reload_flag:-0} -eq 1 ]] ; then
     __rvm_conditionally_add_bin_path
 
   else
-    printf "\n\$rvm_path is not set. rvm cannot load."
+    printf "\n\$rvm_path ($rvm_path) does not exist."
   fi
 
   unset rvm_prefix_needs_trailing_slash rvm_bin_path rvm_man_path rvm_rc_files rvm_gems_path rvm_gems_cache_path rvm_interactive_flag rvm_gems_path rvm_project_rvmrc_default rvm_gemset_separator


### PR DESCRIPTION
This patch seeks to improve the clarity of error message(s) when .rvm/scripts/rvm is sourced without enough information in the environment to determine where rvm is.

Incidentally, it seems kind of strange that you could source, for example, /home/mcantor/.rvm/scripts/rvm, and subsequently receive one of these errors.  Should rvm fall back on munging $0 to determine where it lives if all else fails?
