### PR TITLE
Backslash "grep"s (\grep)

### DIFF
--- a/scripts/alias
+++ b/scripts/alias
@@ -185,7 +185,7 @@ result=0
 
 if [[ ! -f "$rvm_path/config/alias" ]] ; then touch "$rvm_path/config/alias" ; fi
 
-if printf "$alias_name" | grep -q "${rvm_gemset_separator:-"@"}" ; then
+if printf "$alias_name" | \grep -q "${rvm_gemset_separator:-"@"}" ; then
   gemset_name="${alias_name/*${rvm_gemset_separator:-"@"}/}"
   alias_name="${alias_name/${rvm_gemset_separator:-"@"}*/}"
 else

--- a/scripts/gemsets
+++ b/scripts/gemsets
@@ -42,7 +42,7 @@ gemset_update()
     rvm_ruby_strings="$(
       builtin cd "${rvm_gems_path:-"$rvm_path/gems"}" ;
       find . -maxdepth 1 -mindepth 1 -type d -print 2>/dev/null \
-        | grep -v '^\(doc\|cache\|@\|system\)' | \tr '\n' ','
+        | \grep -v '^\(doc\|cache\|@\|system\)' | \tr '\n' ','
     )"
 
     rvm_ruby_strings="${rvm_ruby_strings/%,}"
@@ -636,7 +636,7 @@ __rvm_parse_gems_args()
 {
   gem="${gems_args/;*}" ; gem_prefix=""
 
-  if echo "$gems_args" | grep -q ';' ; then
+  if echo "$gems_args" | \grep -q ';' ; then
     gem_prefix="${gems_args/*;}"
   fi
 
@@ -783,7 +783,7 @@ gemset_info()
 {
   if [[ ${rvm_user_flag:-0} -eq 1 ]] ; then
 
-    echo $(rvm system ; gem env | grep "\- $HOME" | awk '{print $NF}')
+    echo $(rvm system ; gem env | \grep "\- $HOME" | awk '{print $NF}')
 
   elif [[ ${rvm_system_flag:-0} -eq 1 ]] ; then
 
@@ -941,7 +941,7 @@ rvm_sticky_flag=1
 
 if [[ -z "$rvm_ruby_string" ]] ; then
 
-  if echo "${GEM_HOME:-""}" | grep -q 'rvm' ; then
+  if echo "${GEM_HOME:-""}" | \grep -q 'rvm' ; then
 
     rvm_ruby_string="${GEM_HOME##*/}"
 

--- a/scripts/install
+++ b/scripts/install
@@ -190,7 +190,7 @@ while [[ $# -gt 0 ]] ; do
       ;;
     --trace)
       echo "$*"
-      env | grep '^rvm_'
+      env | \grep '^rvm_'
       set -o xtrace
       ;;
     --help)
@@ -231,8 +231,8 @@ fi
 
 source scripts/initialize
 
-if grep -q 'scripts/rvm' "$HOME"/.bash* 2>/dev/null \
-  || grep -q 'scripts/rvm' "$HOME"/.zsh* 2>/dev/null ; then
+if \grep -q 'scripts/rvm' "$HOME"/.bash* 2>/dev/null \
+  || \grep -q 'scripts/rvm' "$HOME"/.zsh* 2>/dev/null ; then
 
   if [[ -d "$rvm_path" ]] && [[ -s "${rvm_path}/scripts/rvm" ]] ; then
 
@@ -383,7 +383,7 @@ if [[ ${rvm_auto_flag:-0} -eq 1 ]] ; then
 
       if [[ -s "$HOME/.profile" ]] ; then
 
-        if ! grep -q '.profile' "$rcfile" ; then
+        if ! \grep -q '.profile' "$rcfile" ; then
 
           echo "    Adding profile sourcing line to $rcfile."
 
@@ -396,7 +396,7 @@ if [[ ${rvm_auto_flag:-0} -eq 1 ]] ; then
 
       fi
 
-      if ! grep -q "scripts\/rvm" "$rcfile" ; then
+      if ! \grep -q "scripts\/rvm" "$rcfile" ; then
 
         echo "    Adding rvm loading line to $rcfile."
 
@@ -511,8 +511,8 @@ if [[ -d "$rvm_path/environments" ]] ; then
   #
   environments=($( find "$rvm_path/environments" -maxdepth 1 -mindepth 1 -type f ))
   for file in "${environments[@]}" ; do
-    if grep 'BUNDLE_PATH' "$file" > /dev/null ; then
-      grep -v 'BUNDLE_PATH' "$file" > "$file.new"
+    if \grep 'BUNDLE_PATH' "$file" > /dev/null ; then
+      \grep -v 'BUNDLE_PATH' "$file" > "$file.new"
       mv "$file.new" "$file"
     fi
   done
@@ -565,7 +565,7 @@ done
 # Move from legacy defaults to the new, alias based system.
 if [[ -s "$rvm_path/config/default" ]]; then
 
-  original_version="$(basename "$(grep GEM_HOME "$rvm_path/config/default" \
+  original_version="$(basename "$(\grep GEM_HOME "$rvm_path/config/default" \
     | awk -F"'" '{print $2}' | sed "s#\%#${rvm_gemset_separator:-"@"}#")")"
 
   if [[ -n "$original_version" ]]; then
@@ -651,7 +651,7 @@ else
 
   fi
 
-  if [[ -s "$HOME/.bashrc" ]] && grep -q '&& return' "$HOME/.bashrc" ; then
+  if [[ -s "$HOME/.bashrc" ]] && \grep -q '&& return' "$HOME/.bashrc" ; then
 
     andand_return_warning
 

--- a/scripts/list
+++ b/scripts/list
@@ -43,7 +43,7 @@ list_gemsets()
 
     [[ "$all_rubies" != *"$ruby_version_name"* ]] && continue
 
-    if echo "$version" | grep -q '^jruby-' ; then
+    if echo "$version" | \grep -q '^jruby-' ; then
       string="[ $("$rvm_path/rubies/$ruby_version_name/bin/ruby" -v | awk '{print $NF}' | sed -e 's/\[//' -e 's/\]//') ]"
 
     elif [[ -n "$(echo "$version" | awk '/^maglev-|^macruby-/')" ]] ; then
@@ -72,7 +72,7 @@ list_gemsets()
 
   if [[ -f "$rvm_path/config/default" && -s "$rvm_path/config/default" ]] ; then
 
-    version=$(grep 'MY_RUBY_HOME' "$rvm_path/config/default" | head -n1 | awk -F"'" '{print $2}' | xargs basename --)
+    version=$(\grep 'MY_RUBY_HOME' "$rvm_path/config/default" | head -n1 | awk -F"'" '{print $2}' | xargs basename --)
 
     if [[ -n "$version" ]] ; then
 
@@ -234,7 +234,7 @@ list_rubies()
 
     [[ ! -x "$rvm_path/rubies/$version/bin/ruby" ]] && continue
 
-    if echo "$version" | grep -q '^jruby-' ; then
+    if echo "$version" | \grep -q '^jruby-' ; then
 
       string="[ $("$rvm_path/rubies/$version/bin/ruby" -v | awk '{print $NF}' | sed -e 's/\[//' -e 's/\]//') ]"
 
@@ -267,7 +267,7 @@ list_rubies()
 
   if [[ -f "$rvm_path/config/default" ]] && [[ -s "$rvm_path/config/default" ]] ; then
 
-    version=$(grep 'MY_RUBY_HOME' "$rvm_path/config/default" | head -n 1 | awk -F"'" '{print $2}' | xargs basename --)
+    version=$(\grep 'MY_RUBY_HOME' "$rvm_path/config/default" | head -n 1 | awk -F"'" '{print $2}' | xargs basename --)
 
     if [[ -n "$version" ]] ; then
 

--- a/scripts/manage
+++ b/scripts/manage
@@ -46,7 +46,7 @@ __rvm_current_patch_names()
     level=1
     name="$patch_name"
 
-    if echo "$name" | grep -q "$separator"; then
+    if echo "$name" | \grep -q "$separator"; then
       level="${name/*${separator}/}"
       name="${name//${separator}*/}"
     fi

--- a/scripts/repair
+++ b/scripts/repair
@@ -31,8 +31,8 @@ repair_gemsets()
     builtin cd "${rvm_gems_path:-"rvm_path/gems"}"
 
     directories=(
-      $( find . -mindepth 1 -maxdepth 1 -type d | grep '@$' )
-      $( find . -mindepth 1 -maxdepth 1 -type d | grep '^./@')
+      $( find . -mindepth 1 -maxdepth 1 -type d | \grep '@$' )
+      $( find . -mindepth 1 -maxdepth 1 -type d | \grep '^./@')
     )
 
     for directory in "${directories[@]//.\/}" ; do

--- a/scripts/selector
+++ b/scripts/selector
@@ -509,7 +509,7 @@ __rvm_ruby_string()
 
   if [[ ${#strings[@]} -eq 0 ]] ; then
 
-    if echo "${GEM_HOME:-""}" | grep -q "rvm" ; then
+    if echo "${GEM_HOME:-""}" | \grep -q "rvm" ; then
       # Current Ruby
       strings="${GEM_HOME##*\/}"
       strings="${strings/%${rvm_gemset_separator:-"@"}*}"
@@ -752,7 +752,7 @@ __rvm_gemset_select()
     fi
 
     if [[ -n "${rvm_gemset_name:-""}" ]] &&
-      ! echo "${rvm_gemset_name:-""}" | grep -q "^[[:digit:]]\.[[:digit:]]" ; then
+      ! echo "${rvm_gemset_name:-""}" | \grep -q "^[[:digit:]]\.[[:digit:]]" ; then
 
       rvm_ruby_gem_home="${rvm_gems_path:-"$rvm_path/gems"}/${rvm_ruby_string}${rvm_gemset_separator:-"@"}${rvm_gemset_name}"
 


### PR DESCRIPTION
Hi,
I have <code>alias grep="ack"</code> in my zshrc, and so "grep -q" fails since ack doesn't support that option. I have therefore replaced all occurrences of "grep" in rvm/scripts with "\grep", which seems to fix it.
Thanks,
Gabe
