### PR TITLE
Line Numbers In Default IRBRC prompt?

### DIFF
--- a/scripts/irbrc.rb
+++ b/scripts/irbrc.rb
@@ -41,10 +41,10 @@ rvm_ruby_string = ENV["rvm_ruby_string"] || `rvm tools identifier`.strip.split("
 
 # Set up the prompt to be RVM specific.
 @prompt = {
-  :PROMPT_I => "#{rvm_ruby_string} > ",  # default prompt
-  :PROMPT_S => "#{rvm_ruby_string}%l> ", # known continuation
-  :PROMPT_C => "#{rvm_ruby_string} > ",
-  :PROMPT_N => "#{rvm_ruby_string} ?> ", # unknown continuation
+  :PROMPT_I => "#{rvm_ruby_string} :%03n > ",  # default prompt
+  :PROMPT_S => "#{rvm_ruby_string} :%03n%l> ", # known continuation
+  :PROMPT_C => "#{rvm_ruby_string} :%03n > ",
+  :PROMPT_N => "#{rvm_ruby_string} :%03n?> ", # unknown continuation
   :RETURN => " => %s \n",
   :AUTO_INDENT => true
 }


### PR DESCRIPTION
Trivial update, though I think it's really helpful.  Most people have irbrc's already.  In my case, when I deploy rvm on a server, I don't think to deploy any irbrc's and end up having to go add these lines to it when I'm doing irb work there.
