### PR TITLE
Check the destination gemset before copy

### DIFF
--- a/scripts/gemsets
+++ b/scripts/gemsets
@@ -362,6 +362,19 @@ gemset_copy()
     return 1
   fi
 
+  # Verify the destination gemset exists before attempting to use it.
+  (
+    rvm_ruby_string="$destination_ruby"
+    { __rvm_ruby_string && __rvm_gemset_select; } 2> /dev/null
+  )
+  result=$?
+
+  if [[ $result -ne 0 ]]; then
+    "$rvm_path/scripts/log" "error" \
+      "Destination gemset '$destination_ruby' does not yet exist."
+    return 1
+  fi
+
   # TODO: Account for more possibilities:
   #   rvm gemset copy 1.9.2 @gemsetb        # From 1.9.2 default to current ruby, 1.9.2 exists.
   #   rvm gemset copy @gemseta @gemsetb     # Current ruby, gemseta exists.


### PR DESCRIPTION
Verify that the destination gemset specified to the 'copy' command exists before taking any serious action. Currently, files are copied into the default "null" gemset before an error is generated:

```
$ rvm gemset copy '1.8.7-p302@valid' '1.8.7-p302@nonexistant'
Copying gemset from 1.8.7-p302@valid to 1.8.7-p302@nonexistant
Making gemset for 1.8.7-p302@nonexistant pristine.
Gemset 'nonexistant' does not exist, rvm gemset create 'nonexistant' first.
```

In the command above, the files from existing gemset '1.8.7-p302@valid' are copied into the null gemset directory ('~/.rvm/gems/ruby-1.8.7-p302'). It is only when the 'gemset pristine' command fails that the error is generated.  There is no indication that files have been copied into the null gemset directory.

This issue occurs because, in scripts/gemsets:gemset_copy(), the command used to set destination_path returns the null gemset path if the gemset does not exist.  Perhaps this issue would be better addressed by changing that behavior, however, I am submitting this patch as what I believe to be a reasonable work-around.
