### PR TITLE
Append instead of over-write.

### DIFF
--- a/scripts/utility
+++ b/scripts/utility
@@ -323,7 +323,7 @@ __rvm_run_with_env()
 
   \touch "$log" # for zsh :(
 
-  printf "[$(date +'%Y-%m-%d %H:%M:%S')] $command # under $environment\n" > "${log}"
+  printf "[$(date +'%Y-%m-%d %H:%M:%S')] $command # under $environment\n" >> "${log}"
 
   if [[ ${rvm_niceness:-0} -gt 0 ]] ; then
     command="nice -n $rvm_niceness $command"


### PR DESCRIPTION
One more identical change -- same as recently committed by wayne -- at a different line of the same file.

(I still don't understand the noclobber for zsh, since it should have the same problem that I had: namely, that my .bashrc was resetting noclobber when unset in __rvm_setup. But I cannot test zsh.)
