### PR TITLE
Fix 191 version

### DIFF
--- a/config/known
+++ b/config/known
@@ -4,7 +4,7 @@
 [ruby-]1.8.7[-p302]
 [ruby-]1.8.7-head
 [ruby-]1.9.1-p243
-[ruby-]1.9.1[-p376]
+[ruby-]1.9.1[-p378]
 [ruby-]1.9.1-p429
 [ruby-]1.9.1-head
 [ruby-]1.9.2-preview1


### PR DESCRIPTION
This updates config/known with the correct patchlevel for the default Ruby 1.9.1 install.
