### PR TITLE
Fix sed

### DIFF
--- a/scripts/cli
+++ b/scripts/cli
@@ -105,8 +105,8 @@ __rvm_parse_args()
           if [[ -n "$next_token" ]] ; then rvm_gemset_name="$next_token" ; else rvm_gemset_name="" ; fi
 
           if echo $rvm_gemset_name | \grep -q ${rvm_gemset_separator:-"@"} ; then
-            rvm_ruby_string=$(echo $rvm_gemset_name | sed -e 's/\(.*\)'"${rvm_gemset_separator:-"@"}"'.*/\1/')
-            rvm_gemset_name=$(echo $rvm_gemset_name | sed -e 's/.*'"${rvm_gemset_separator:-"@"}"'\(.*\)/\1/')
+            rvm_ruby_string=$(echo $rvm_gemset_name | \sed -e 's/\(.*\)'"${rvm_gemset_separator:-"@"}"'.*/\1/')
+            rvm_gemset_name=$(echo $rvm_gemset_name | \sed -e 's/.*'"${rvm_gemset_separator:-"@"}"'\(.*\)/\1/')
 
             if [[ "${rvm_ruby_string:-""}" != "${rvm_gemset_name:-""}" ]] ; then
               rvm_ruby_string="$rvm_ruby_string${rvm_gemset_separator:-"@"}$rvm_gemset_name"
@@ -123,8 +123,8 @@ __rvm_parse_args()
           if [[ $# -gt 0 ]] ; then next_token="$1" ; shift ; else next_token="" ; fi
 
           if echo "$rvm_gemset_name" | \grep -q "${rvm_gemset_separator:-"@"}" ; then
-            rvm_ruby_string=$(echo "$rvm_gemset_name" | sed 's/\(.*\)'"${rvm_gemset_separator:-"@"}"'.*/\1/')
-            rvm_gemset_name=$(echo "$rvm_gemset_name" | sed 's/.*'"${rvm_gemset_separator:-"@"}"'\(.*\)/\1/')
+            rvm_ruby_string=$(echo "$rvm_gemset_name" | \sed 's/\(.*\)'"${rvm_gemset_separator:-"@"}"'.*/\1/')
+            rvm_gemset_name=$(echo "$rvm_gemset_name" | \sed 's/.*'"${rvm_gemset_separator:-"@"}"'\(.*\)/\1/')
 
             if [[ "$rvm_ruby_string" != "$rvm_gemset_name" ]] ; then
               rvm_ruby_string="$rvm_ruby_string${rvm_gemset_separator:-"@"}$rvm_gemset_name"

--- a/scripts/environment-convertor
+++ b/scripts/environment-convertor
@@ -12,7 +12,7 @@ convert_path_to_fish()
   local parts path_parts
 
   path_part="$1"
-  parts="$(echo "$path_part" | sed -e 's#:\$PATH##' -e "s#:#\" \"#g" -e "s#^export \\([^[:space:]]*\\)=##")"
+  parts="$(echo "$path_part" | \sed -e 's#:\$PATH##' -e "s#:#\" \"#g" -e "s#^export \\([^[:space:]]*\\)=##")"
 
   printf "\
 for path_part in $parts
@@ -31,7 +31,7 @@ convert_unset_to_fish()
 
 convert_exports_to_fish()
 {
-  sed -e "s#:#' '#g" -e "s#^\\(export \\)\\{0,1\\}\\([^[:space:]]*\\)=#set -x \\2 #"
+  \sed -e "s#:#' '#g" -e "s#^\\(export \\)\\{0,1\\}\\([^[:space:]]*\\)=#set -x \\2 #"
 }
 
 contents_of_environment_file()

--- a/scripts/gemsets
+++ b/scripts/gemsets
@@ -486,7 +486,7 @@ gemset_unpack()
 
   unset -f gem
 
-  gems=($(command gem list | sed 's#[\(|\)]##g' | sed -e 's#, #,#g' -e 's/ /;/g'))
+  gems=($(command gem list | \sed 's#[\(|\)]##g' | sed -e 's#, #,#g' -e 's/ /;/g'))
 
   for gem in ${gems[@]} ; do
 
@@ -537,7 +537,7 @@ gemset_export()
   echo "# $rvm_file_name generated gem export file. Note that any env variable settings will be missing. Append these after using a ';' field separator" \
     > "$rvm_file_name"
 
-  gems=($(gem list | sed 's#[\(|\)]##g' | sed 's#, #,#g' | tr ' ' ';'))
+  gems=($(gem list | \sed 's#[\(|\)]##g' | sed 's#, #,#g' | tr ' ' ';'))
 
   for gem in "${gems[@]}" ; do
 
@@ -823,7 +823,7 @@ gemset_prune()
   do
     gem_name="$(echo "$used_gem" | sed -e 's/ .*//')"
 
-    versions="$(echo "${used_gem//, / }" | sed -e 's/.* (//' -e 's/)//')"
+    versions="$(echo "${used_gem//, / }" | \sed -e 's/.* (//' -e 's/)//')"
 
     for version in $versions; do
 

--- a/scripts/info
+++ b/scripts/info
@@ -47,9 +47,9 @@ info_ruby()
   ruby:
     interpreter:  \"$(printf "${full_version}" | awk '{print $1}')\"
     version:      \"$(printf "${full_version}" | awk '{print $2}')\"
-    date:         \"$(printf "${full_version}" | sed 's/^.*(\([0-9]\{4\}\(-[0-9][0-9]\)\{2\}\).*$/\1/')\"
-    platform:     \"$(printf "${full_version}" | sed 's/^.*\[//' | sed 's/\].*$//')\"
-    patchlevel:   \"$(printf "${full_version}" | sed 's/^.*(//' | sed 's/).*$//')\"
+    date:         \"$(printf "${full_version}" | \sed 's/^.*(\([0-9]\{4\}\(-[0-9][0-9]\)\{2\}\).*$/\1/')\"
+    platform:     \"$(printf "${full_version}" | \sed 's/^.*\[//' | \sed 's/\].*$//')\"
+    patchlevel:   \"$(printf "${full_version}" | \sed 's/^.*(//' | \sed 's/).*$//')\"
     full_version: \"${full_version}\"
 "
 

--- a/scripts/install
+++ b/scripts/install
@@ -5,7 +5,7 @@ set -o errtrace
 export PS4='+[${BASH_SOURCE}] : ${LINENO} : ${FUNCNAME[0]:+${FUNCNAME[0]}() $ }'
 
 if [[ -z "$rvm_selfcontained" ]]; then
-  if [[ $(id | sed -e 's/(.*//' | awk -F= '{print $2}') -eq 0 || \
+  if [[ $(id | \sed -e 's/(.*//' | awk -F= '{print $2}') -eq 0 || \
     -n "$rvm_prefix" && "$rvm_prefix" != "$HOME"/* ]]; then
     export rvm_selfcontained=0
   else
@@ -126,7 +126,7 @@ andand_return_warning()
 thank_you()
 {
   printf "
-${name:-"${USER:-$(id | sed -e 's/^[^(]*(//' -e 's/).*$//')}"},
+${name:-"${USER:-$(id | \sed -e 's/^[^(]*(//' -e 's/).*$//')}"},
 
 Thank you very much for using RVM! I sincerely hope that RVM helps to
 make your work both easier and more enjoyable.

--- a/scripts/list
+++ b/scripts/list
@@ -44,7 +44,7 @@ list_gemsets()
     [[ "$all_rubies" != *"$ruby_version_name"* ]] && continue
 
     if echo "$version" | grep -q '^jruby-' ; then
-      string="[ $("$rvm_path/rubies/$ruby_version_name/bin/ruby" -v | awk '{print $NF}' | sed -e 's/\[//' -e 's/\]//') ]"
+      string="[ $("$rvm_path/rubies/$ruby_version_name/bin/ruby" -v | awk '{print $NF}' | \sed -e 's/\[//' -e 's/\]//') ]"
 
     elif [[ -n "$(echo "$version" | awk '/^maglev-|^macruby-/')" ]] ; then
       string="[ x86_64 ]"
@@ -184,7 +184,7 @@ list_gemset_strings()
 # This is meant to be used with scripting.
 list_known_strings()
 {
-  sed -e 's/#.*$//g' -e 's#\[##g' -e 's#\]##g' < "$rvm_path/config/known" | sort -r | uniq
+  \sed -e 's/#.*$//g' -e 's#\[##g' -e 's#\]##g' < "$rvm_path/config/known" | sort -r | uniq
 
   return $?
 }
@@ -236,7 +236,7 @@ list_rubies()
 
     if echo "$version" | grep -q '^jruby-' ; then
 
-      string="[ $("$rvm_path/rubies/$version/bin/ruby" -v | awk '{print $NF}' | sed -e 's/\[//' -e 's/\]//') ]"
+      string="[ $("$rvm_path/rubies/$version/bin/ruby" -v | awk '{print $NF}' | \sed -e 's/\[//' -e 's/\]//') ]"
 
     elif [[ ! -z "$(echo "$version" | awk '/^maglev-|^macruby-/')" ]] ; then
 

--- a/scripts/rvm
+++ b/scripts/rvm
@@ -34,7 +34,7 @@ if ! declare -f rvm > /dev/null || [[ ${rvm_reload_flag:-0} -eq 1 ]] ; then
   # Set the default sandboxed value.
   if [[ -z "$rvm_selfcontained" ]]; then
 
-    if [[ $(id | sed -e 's/(.*//' | awk -F= '{print $2}') -eq 0 || \
+    if [[ $(id | \sed -e 's/(.*//' | awk -F= '{print $2}') -eq 0 || \
       -n "$rvm_prefix" && "$rvm_prefix" != "$HOME"/* ]]; then
 
       rvm_selfcontained=0
@@ -60,7 +60,7 @@ if ! declare -f rvm > /dev/null || [[ ${rvm_reload_flag:-0} -eq 1 ]] ; then
     else
 
       echo "No \$rvm_prefix was provided and "
-      echo "$(id | sed -e's/^[^(]*(//' -e 's/).*//') has no \$HOME defined."
+      echo "$(id | \sed -e's/^[^(]*(//' -e 's/).*//') has no \$HOME defined."
       echo "Exploding violently."
       exit 1
 

--- a/scripts/selector
+++ b/scripts/selector
@@ -391,7 +391,7 @@ __rvm_use()
 
       if [[ "system" != "$rvm_ruby_interpreter" ]] ; then
 
-        RUBY_VERSION="$("$rvm_ruby_home/bin/ruby" -v | sed 's#^\(.*\) (.*$#\1#')"
+        RUBY_VERSION="$("$rvm_ruby_home/bin/ruby" -v | \sed 's#^\(.*\) (.*$#\1#')"
 
         export GEM_HOME GEM_PATH MY_RUBY_HOME RUBY_VERSION
 


### PR DESCRIPTION
I was getting this error:
    ~ $ rvm --default 1.8.7  
    sed: 1: "s#^(._) (._$#\1#": RE error: parentheses not balanced
apparently because I have sed aliased to "sed -E", which switches the meaning of "(" and "\(". This pull request changes all relevant "sed"s to "\sed"s.
