### PR TITLE
Fix sed redux

### DIFF
--- a/scripts/rvm
+++ b/scripts/rvm
@@ -34,7 +34,7 @@ if ! declare -f rvm > /dev/null || [[ ${rvm_reload_flag:-0} -eq 1 ]] ; then
   # Set the default sandboxed value.
   if [[ -z "$rvm_selfcontained" ]]; then
 
-    if [[ $(id | sed -e 's/(.*//' | awk -F= '{print $2}') -eq 0 || \
+    if [[ $(id | \sed -e 's/(.*//' | awk -F= '{print $2}') -eq 0 || \
       -n "$rvm_prefix" && "$rvm_prefix" != "$HOME"/* ]]; then
 
       rvm_selfcontained=0


### PR DESCRIPTION
I still get
    sed: 1: "s/(.*//\n": RE error: parentheses not balanced
on <code>rvm reload</code>, so this little patch practices even safer sed.
Here's the gist of <code>rvm --trace reload</code>: https://gist.github.com/750420
