### PR TITLE
Fix test suite

### DIFF
--- a/test/suite
+++ b/test/suite
@@ -2,7 +2,7 @@
 
 source ./test/setup
 rvm_test_suite_flag=1
-for file in test/rvm/*_test ; do
+for file in test/unit/*_test ; do
   source $file
 done
 btu_summary


### PR DESCRIPTION
Test suite used to refer to an unexisting rvm dir. Now running "rake" runs the unit tests.
