### PR TITLE
Fix rbx selector

### DIFF
--- a/scripts/selector
+++ b/scripts/selector
@@ -64,7 +64,7 @@ __rvm_select()
         rvm_ruby_patch_level=${rvm_ruby_patch_level:-$(__rvm_db "rbx_patch_level")}
         rvm_ruby_string="${rvm_ruby_string/-prc/-rc}"
         rvm_ruby_string="$(echo "$rvm_ruby_string" | \sed 's#-p*#-#')"
-        rvm_ruby_package_file="$(echo "rubinius-${rvm_ruby_version}-${rvm_ruby_patch_level}.${rvm_archive_extension}" | \sed 's#-p*#-#' )"
+        rvm_ruby_package_file="$(echo "rubinius-${rvm_ruby_version}-${rvm_ruby_patch_level}.${rvm_archive_extension}" | \sed 's#-p*#-#' | \sed 's#-$##' )"
         __rvm_db "rbx_url" "rvm_ruby_url"
         rvm_ruby_url="$rvm_ruby_url/$rvm_ruby_package_file"
 

--- a/test/integration/rvm_install
+++ b/test/integration/rvm_install
@@ -5,7 +5,7 @@ if [[ ! -s ./scripts/rvm ]] ; then
   exit 1
 fi
 
-rubies=(1.8.7 1.9.2 ree rbx)
+rubies=(1.8.7 1.9.2 ree rbx rbx-1.2.0)
 
 if [[ "Darwin" = "$(uname)" ]] ; then
 

--- a/test/rubies/rbx-1.2.0
+++ b/test/rubies/rbx-1.2.0
@@ -1,0 +1,3 @@
+ruby_version=^rubinius 1.2.0 \(1.8.7
+gem_home=rbx/1.2.0
+ruby_home=rbx-1.2.0

--- a/test/unit/selector_test
+++ b/test/unit/selector_test
@@ -40,6 +40,7 @@ rvm_ruby_string="ree-head"      ; valid_string="ree-1.8.7-head"     ; heat "rvm_
 rvm_ruby_string="jruby-1.4.0"   ; valid_string="jruby-1.4.0RC3"     ; heat "rvm_ruby_string=$rvm_ruby_string ; __rvm_select" ; validate_select
 rvm_ruby_string="jruby-1.3.1"   ; valid_string="jruby-1.3.1"        ; heat "rvm_ruby_string=$rvm_ruby_string ; __rvm_select" ; validate_select
 rvm_ruby_string="jruby"         ; valid_string="jruby-1.3.1"        ; heat "rvm_ruby_string=$rvm_ruby_string ; __rvm_select" ; validate_select
+rvm_ruby_string="rbx-1.2.0-"     ; valid_string="rbx-1.2.0"          ; heat "rvm_ruby_string=$rvm_ruby_string ; __rvm_select" ; validate_select
 
 valid_string="ruby-1.8.6-p160" ; heat "rvm 1.8.7 -l 160 ; version=\$(ruby -v)"
 assert "match" '^ruby 1.8.7 \(2009-04-08 patchlevel 160\)' "$version" ; unset version


### PR DESCRIPTION
Trying to run "rvm install rbx-1.2.0" fails trying to fetch "rbx-1.2.0-.tar.gz". Added a sed pipe to remove trailing dashes.

The underlying problem might be something related with RVM failing to access the patchlevel or something like that, though. WDYT?
