### PR TITLE
Newline characters are interpolated when creating a new .rvmrc file

### DIFF
--- a/scripts/utility
+++ b/scripts/utility
@@ -499,12 +499,12 @@ fi
 #
 #   # Ensure that Bundler is installed, install it if it is not.
 #   if ! command -v bundle ; then
-#      printf \"The rubygem 'bundler' is not installed, installing it now.\n\"
+#      printf \"The rubygem 'bundler' is not installed, installing it now.\\\n\"
 #      gem install bundler
 #   fi
 #
 #   # Bundle while redcing excess noise.
-#   printf \"Bundling your gems this may take a few minutes on a fresh clone.\n\"
+#   printf \"Bundling your gems this may take a few minutes on a fresh clone.\\\n\"
 #   bundle | grep -v 'Using' | grep -v 'complete' | sed '/^$/d'
 #
 


### PR DESCRIPTION
... they should be printed literally.
