### PR TITLE
Tiny change to avoid bash error.

### DIFF
--- a/scripts/gemsets
+++ b/scripts/gemsets
@@ -548,7 +548,7 @@ gemset_export()
   touch "$rvm_file_name"
 
   echo "# $rvm_file_name generated gem export file. Note that any env variable settings will be missing. Append these after using a ';' field separator" \
-    > "$rvm_file_name"
+    >> "$rvm_file_name"
 
   gems=($(gem list | sed 's#[\(|\)]##g' | sed 's#, #,#g' | tr ' ' ';'))
 


### PR DESCRIPTION
Append instead of over-write, to avoid this:

$ rvm gemset export foo
Exporting current environments gemset to foo
/Users/cdunn2001/.rvm/scripts/gemsets: line 550: foo: cannot overwrite existing file

(Just 1 commit. I re-cloned your repo so that I could remove the earlier commit with zero danger, though I think 'git reset' would have been ok.)
