### PR TITLE
bug fix

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -435,7 +435,7 @@ if [[ ${rvm_auto_flag:-0} -eq 1 ]] ; then
 
         printf "
 # rvm install added:
-[[ -s \"$rvm_path/.rvm/scripts/rvm\" ]] && . \"$rvm_path/.rvm/scripts/rvm\"
+[[ -s \"$rvm_path/scripts/rvm\" ]] && . \"$rvm_path/scripts/rvm\"
 " >> "$rcfile"
 
       fi


### PR DESCRIPTION
The --auto flag was generating paths like this:

/home/foo/.rvm/.rvm/scripts/rvm

I fixed it. Not sure if there's a point, though, since it seems that the install script is now being run automatically without user intervention.
