### PR TITLE
Rvm current

### DIFF
--- a/README
+++ b/README
@@ -56,6 +56,7 @@ Action
   reset      - remove current and stored default & system settings.
                (If you experience odd behavior try this second)
   info       - show the *current* environment information for current ruby
+  current    - print the *current* ruby version and the name of any gemset being used.
   debug      - show info plus additional information for common issues
 
   install    - install one or many ruby versions

--- a/help/current
+++ b/help/current
@@ -1,0 +1,4 @@
+
+∴ rvm current
+
+Print the current Ruby version and the name of any gemset being used.

--- a/scripts/cli
+++ b/scripts/cli
@@ -156,7 +156,7 @@ __rvm_parse_args()
         fi
       ;;
 
-      inspect|list|info|strings|get)
+      inspect|list|info|strings|get|current)
         rvm_action="$rvm_token"
         rvm_ruby_args="$next_token $@"
         rvm_parse_break=1
@@ -685,11 +685,12 @@ rvm()
     inspect)         __rvm_inspect    ;;
     implode|seppuku) __rvm_implode    ;;
 
-    list)  "$rvm_path/scripts"/list $rvm_ruby_args ;;
+    list)   "$rvm_path/scripts"/list $rvm_ruby_args ;;
     # TODO: Make debug run in the current environment.
-    debug) "$rvm_path/scripts/info" '' debug ;;
-    help)  "$rvm_path/scripts/help" $rvm_ruby_args ;;
-    env)   "$rvm_path/scripts/env" "$rvm_ruby_string"  ;;
+    debug)  "$rvm_path/scripts/info" '' debug ;;
+    help)   "$rvm_path/scripts/help" $rvm_ruby_args ;;
+    env)    "$rvm_path/scripts/env" "$rvm_ruby_string" ;;
+    current) "$rvm_path/scripts/current" ;;
     info)
       if [[ $# -gt 0 ]] ; then next_token="$1" ; shift ; else next_token="" ; fi
       if [[ "$next_token" = "info" ]]; then shift; fi

--- a/scripts/current
+++ b/scripts/current
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+if [[ "$rvm_trace_flag" -eq 2 ]] ; then set -x ; export rvm_trace_flag ; fi
+
+source "$rvm_path/scripts/base"
+
+printf "$(__rvm_environment_identifier)\n"
+exit 0


### PR DESCRIPTION
I've added a `current` command to rvm that outputs `__rvm_environment_identifier`. The idea being I don't keep rvm info in my prompt and sometimes just want to know which Ruby I'm using as well as the gemset.

I've added the command to the README so it shows up in the basic help output and I've added a help/current file with pretty much exactly the same message.

I didn't add any tests although I would have liked to because I'm a stickler for those kinds of things. Just couldn't quite get my head around where to put unit tests for a particular command (or for that matter how exactly to write them).

I hope this will make it in to an up-coming release because I always want to print `__rvm_environment_identifier` and think maybe others would find it useful.

Regards,
James
