### PR TITLE
Allow to use characters in prompt like virtualenv for python

### DIFF
--- a/binscripts/rvm-prompt
+++ b/binscripts/rvm-prompt
@@ -1,23 +1,48 @@
 #!/usr/bin/env bash
 
-add(){
+previous_is_format_var=0
 
+add(){
+  
   token=${1:-""}
 
   eval "${token}_flag=1" ; shift
 
   if [[ -n "$format" ]] ; then
 
-    format="${format}-\$${token}"
+    if [ $previous_is_format_var = 1 ]; then
+        format="${format}-\$${token}"
+    else
+        format="${format}\$${token}"
+    fi
 
   else
 
     format="\$${token}"
 
   fi
+  previous_is_format_var=1
+  return 0
+}
+
+add_raw_token(){
+  previous_is_format_var=0
+  
+  token=${1:-""}
+
+  if [[ -n "$format" ]] ; then
+
+    format="${format}${token}"
+
+  else
+
+    format="${token}"
+
+  fi
 
   return 0
 }
+
 
 rvm_gemset_separator="${rvm_gemset_separator:-"@"}"
 
@@ -51,7 +76,7 @@ if [[ -n "$ruby" && -n "$(echo "$ruby" | awk '/rvm/{print}')" ]] ; then
 
       -d|--no-default) no_default=1      ;;
 
-      *) echo "Unrecognized command line option '$token' for $0" ; exit 1 ;;
+      *) add_raw_token $token ;;
 
     esac
 


### PR DESCRIPTION
This patch allow other characters in rvm prompt.

For example you can type:
./binscripts/rvm-prompt '(' i v a ')'

And get this prompt:
(ruby-1.9.2-x86_64-darwin10.6.0)

Or:
./binscripts/rvm-prompt 'RVM:' i v '>'

RVM:ruby-1.9.2>
