### PR TITLE
Properly detect if its a 64-bit Solaris-x86 machine or not

### DIFF
--- a/scripts/maglev
+++ b/scripts/maglev
@@ -3,7 +3,6 @@
 if [[ "$rvm_trace_flag" -eq 2 ]] ; then set -x ; export rvm_trace_flag ; fi
 
 system="$(uname -s)"
-if [[ $system = "SunOS" ]] && [[ "$(uname -m)" = "i86pc" ]] ; then system="Solaris-x86" ; fi
 version="MagLev-${1}.${system}"
 gsname="GemStone-${1}.${system}"
 zipfile=${version}.zip
@@ -30,10 +29,9 @@ case "$system" in
     exit 1
   fi
   ;;
-  Solaris-x86)
-  if [[ "$(uname -sm)" != "SunOS i86pc" ]]; then
+  SunOS)
+  if [[ "$(uname -p)" != "i386" ]] || [[ "$(isainfo -b)" != "64" ]]; then
     "$rvm_path/scripts/log" "error" "This script only works on a 64-bit Solaris-x86 OS."
-    echo "The result from \"uname -sm\" is \"`uname -sm`\" not \"SunOS i86pc\""
     exit 1
   fi
   ;;


### PR DESCRIPTION
`uname -m` is i86pc on x86 systems, including both 32-bit and 64-bit. `uname -m` reports `i86pv` on Xem domU's.

This patch does the following:
- Makes sure its a x86 system, including Xem domU's. 
- Make sure its a 64-bit system and not 32-bit.
