### PR TITLE
Updated "notes" for Ubuntu re: jruby-head

### DIFF
--- a/scripts/notes
+++ b/scripts/notes
@@ -38,16 +38,17 @@ dependencies:
   rvm: bash curl git
 
 # For Ruby (MRI & ree)  you should install the following OS dependencies:
-  ruby: aptitude install build-essential bison openssl libreadline6 libreadline6-dev curl git-core zlib1g zlib1g-dev libssl-dev libyaml-dev libsqlite3-0 libsqlite3-dev sqlite3 libxml2-dev libxslt-dev autoconf libc6-dev
+  ruby: ${rvm_aptitude_binary} install build-essential bison openssl libreadline6 libreadline6-dev curl git-core zlib1g zlib1g-dev libssl-dev libyaml-dev libsqlite3-0 libsqlite3-dev sqlite3 libxml2-dev libxslt-dev autoconf libc6-dev
 
 # For JRuby (if you wish to use it) you will need:
-  jruby: aptitude install curl g++ openjdk-6-jre-headless
+  jruby: ${rvm_aptitude_binary} install curl g++ openjdk-6-jre-headless
+  jruby-head: ${rvm_aptitude_binary} install ant openjdk-6-jdk
 
 # In addition to ruby: dependencies,
   ruby-head: subversion
 
 # For IronRuby (if you wish to use it) you will need:
-  ironruby: aptitude install curl mono-2.0-devel
+  ironruby: ${rvm_aptitude_binary} install curl mono-2.0-devel
 "
 
   elif [[ ! -z "$rvm_emerge_binary" ]] ; then
@@ -137,4 +138,3 @@ elif [[ "Darwin" = "$system"  ]] ; then
 fi
 
 echo
-


### PR DESCRIPTION
jruby-head needs ant and a jdk to install (updated for Ubuntu).

Additionally, changed Ubuntu notes to use $rvm_aptitude_binary instead of just "aptitude", as aptitude is not guaranteed to be installed.
