### PR TITLE
Rvmrc fixes

### DIFF
--- a/scripts/utility
+++ b/scripts/utility
@@ -509,7 +509,7 @@ fi
 #      gem install bundler
 #   fi
 #
-#   # Bundle while redcing excess noise.
+#   # Bundle while reducing excess noise.
 #   printf \"Bundling your gems. This may take a few minutes on a fresh clone.\\\n\"
 #   bundle | grep -v '^Using ' | grep -v ' is complete' | sed '/^$/d'
 #


### PR DESCRIPTION
A few unrelated changes to the generated rvmrc, broken into separate commits for your convenience:
1. Don't output the path to bundler when checking for bundler. (It's possible this was deliberate but I assume it's an oversight.)
2. Clean up some run-on sentences. (Sorry to be that guy.)
3. Don't accidentally filter out gem names when filtering bundler output (e.g., a gem named autocomplete would be filtered out by `grep -v 'complete'` before this fix).
4. A typo.

Cheers!
