### PR TITLE
Fix API method typo (gemset_intial -> gemset_initial)

### DIFF
--- a/lib/rvm/environment/gemset.rb
+++ b/lib/rvm/environment/gemset.rb
@@ -58,7 +58,7 @@ module RVM
     end
 
     # Initializes gemsets for a given ruby.
-    def gemset_intial
+    def gemset_initial
       rvm(:gemset, :initial).successful?
     end
 


### PR DESCRIPTION
Hi there,

In using the API, I found a typo in the method name to initialize gemsets for a ruby. So far great library, it's making my work much saner rather than shelling out all the time.
