### PR TITLE
Gemset copy failing on non-verbose gemset names.

### DIFF
--- a/scripts/gemsets
+++ b/scripts/gemsets
@@ -383,9 +383,17 @@ gemset_copy()
   #   rvm gemset copy gemseta gemsetb       # Currenty Ruby, gemseta exists.
   #   rvm gemset copy gemseta 1.8.7@gemsetb # Currenty Ruby@gemseta, current ruby@gemseta exists.
 
-  source_path="${rvm_gems_path:-"$rvm_path/gems"}/$source_ruby"
-
-  destination_path="${rvm_gems_path:-"$rvm_path/gems"}/$destination_ruby"
+  source_path=`(
+    rvm_ruby_string="$source_ruby"
+    { __rvm_ruby_string && __rvm_gemset_select; } 2> /dev/null
+    echo $rvm_ruby_gem_home
+  )`
+   
+  destination_path=`(
+    rvm_ruby_string="$destination_ruby"
+    { __rvm_ruby_string && __rvm_gemset_select; } 2> /dev/null
+    echo $rvm_ruby_gem_home
+  )`
 
   if [[ -z "$source_path" || ! -d "$source_path" ]]; then
     "$rvm_path/scripts/log" "error" \


### PR DESCRIPTION
Post wayneeseguin@30758d00dc905898267ceed09d6b18952e1a1fa1 the gemset copy command will only work with full gemset identifiers, I.E. ruby-1.9.2-p136@gemset or ruby-1.8.7-p330@gemset. 

This patch allows use of gemset identifiers in any form that rvm can recognize. @gemset, 1.8.7@gemset, &c.

I assumed you didn't want to just revert to how it was previously where it was calling RVM itself, so it uses the selector functions.
