### PR TITLE
Update group modification support in install-system-wide for SuSE.

### DIFF
--- a/contrib/install-system-wide
+++ b/contrib/install-system-wide
@@ -44,7 +44,13 @@ __rvm_create_user_group() {
     case "$os_type" in
       "OpenBSD") groupadd "$rvm_group_name";;
       "FreeBSD") pw groupadd -q "$rvm_group_name";;
-      "Linux")   groupadd -f "$rvm_group_name";;
+      "Linux")
+        if [[ -f "/etc/SuSE-release" ]] ; then
+          groupadd "$rvm_group_name"
+        else
+          groupadd -f "$rvm_group_name"
+        fi
+      ;;
       "Darwin")
         gid="501" #only gids > 500 show up in user preferences
 
@@ -76,7 +82,13 @@ __rvm_add_user_to_group() {
   case "$os_type" in
     "OpenBSD") usermod -G "$2" "$1";;
     "FreeBSD") pw usermod "$1" -G "$2";;
-    "Linux")   usermod -a -G "$2" "$1";;
+    "Linux")
+      if [[ -f "/etc/SuSE-release" ]] ; then
+        groupmod -A "$1" "$2"
+      else
+        usermod -a -G "$2" "$1"
+      fi
+    ;;
     "Darwin")  dscl . -append "/Groups/$2" GroupMembership "$1";;
     "SunOS")
       groups="`id -G "$1"` \"$2\""


### PR DESCRIPTION
Looks like SuSE-based distros (openSuSE, SuSE Linux Enterprise Server/Desktop) don't support `groupadd -f` and `usermod -a G` by default. The `__rvm_create_user_group()` and `__rvm_add_user_to_group()` need a little extra detection to cope in this case. I've been pre-adding the rvm group to get around this previously (under SLES).
