### PR TITLE
Fixed condition of which decided to add --no-tcmalloc to default rvm_ree_options parameter

### DIFF
--- a/scripts/manage
+++ b/scripts/manage
@@ -495,7 +495,7 @@ RubyWrapper
           rvm_configure_flags="${rvm_configure_flags//--/-c --}"
         fi
 
-        if [[ "Darwin" = "$(uname)" && "1.8.6" = "$rvm_ruby_version" \
+        if [[ "Darwin" = "$(uname)" && ("1.8.6" = "$rvm_ruby_version" || "1.8.7" = "$rvm_ruby_version") \
           && -z "$rvm_ree_options" ]] ; then
           rvm_ree_options="${rvm_ree_options} --no-tcmalloc"
         fi


### PR DESCRIPTION
I've stucked with rvm and fresh ree-1.8.7-2011.01: I've got some issues because it compiles with tcmalloc on my Mac OS X (10.6.6).

RVM just don't want to "listen" about my --ree-options --no-tcmalloc params and compiles ree with tcmalloc. I've started to investigate why it has such behavior, but found another part of rvm where you determine current OS (scripts/manage:498 - ... "Darwin" = "$(uname)" ...) and see that here you're checking both for Darwin and ruby version 1.8.6, but I have 1.8.7 default interpreter on my Mac and this part of code didn't run, so I got empty rvm_ree_options variable.

I've added checking for both Darwin OS and rubies 1.8.6 or 1.8.7 installed.
## 

Best regards,
Sergey Kuznetsov.
