### PR TITLE
Fixing trust/untrust for project .rvmrc files

### DIFF
--- a/scripts/utility
+++ b/scripts/utility
@@ -1360,10 +1360,11 @@ __rvm_check_rvmrc_trustworthiness()
     fi
 
   fi
+  local result=$?
 
   unset escape_flag
 
-  return $?
+  return $result
 }
 
 __rvm_ask_to_trust()

--- a/test/unit/utility_test
+++ b/test/unit/utility_test
@@ -39,5 +39,22 @@ assert number_eq 0 $result
 heat './scripts/match "1.9.1" "^.+${rvm_gemset_separator:-"@"}.+$"'
 assert number_eq 1 $result
 
+heat '
+  output=$(
+    mkdir /tmp/rvm-trust-test
+    echo "trusted=TRUSTED" > /tmp/rvm-trust-test/.rvmrc
+    rvm rvmrc trust /tmp/rvm-trust-test > /dev/null
+    cd /tmp/rvm-trust-test
+
+    echo "trusted=UNTRUSTED" > /tmp/rvm-trust-test/.rvmrc
+    rvm rvmrc untrust /tmp/rvm-trust-test > /dev/null
+    cd /tmp; cd /tmp/rvm-trust-test
+
+    echo $trusted
+    rm -rf /tmp/rvm-trust-test
+  )'
+
+assert string_eq "$output" "TRUSTED"
+
 if [[ -z "$rvm_teset_suite_flag" ]] ; then btu_summary ; fi
 


### PR DESCRIPTION
Due to an 'unset' immediately before a 'return $?', the result of the test for .rvmrc trustworthiness is being lost, causing even untrusted .rvmrc files to be loaded. I included a unit test similar in style to an existing one in test/unit/export_test, which also uses .rvmrc loading.
