### PR TITLE
Speed up cd hook

### DIFF
--- a/scripts/utility
+++ b/scripts/utility
@@ -1662,26 +1662,26 @@ __rvm_export()
 
 __rvm_unset_exports()
 {
-  for pair in $(env); do
-
+  env | while read pair; do
     # ignore everything except for wrapped variables.
-    if echo "$pair" | \grep -q "rvm_old_"; then
+    case "$pair" in
+      rvm_old_*)
+        local wrap_name=${pair%%=*}
+        local name=${wrap_name#rvm_old_}
+        local value=${!wrap_name}
 
-      local wrap_name=${pair%%=*}
-      local name=${wrap_name#rvm_old_}
-      local value=${!wrap_name}
+        # if the old value is non-empty, restore it.
+        if [[ -n $value ]]; then
+          export $name=${value}
 
-      # if the old value is non-empty, restore it.
-      if [[ -n $value ]]; then
-        export $name=${value}
+        # otherwise, just remove it.
+        else
+          unset $name
+        fi
 
-      # otherwise, just remove it.
-      else
-        unset $name
-      fi
-
-      # unset the wrapped variable.
-      unset $wrap_name
-    fi
+        # unset the wrapped variable.
+        unset $wrap_name
+        ;;
+    esac
   done
 }


### PR DESCRIPTION
The rvm cd hook was noticeably slow in my Ubuntu VM running zsh. I took a look at what was happening (using set -x), and it turned out the cd hook was creating a grep process for every entry in $(env).

I replaced this with a case match, and also fixed a bug where env vars containing whitespace would confuse the loop.
