### PR TITLE
Fix to add rvm/environment/wrapper to RVM::Environment

### DIFF
--- a/lib/rvm/environment.rb
+++ b/lib/rvm/environment.rb
@@ -6,7 +6,7 @@ module RVM
   class Environment
     extend Forwardable
 
-    %w(configuration utility alias list gemset rubies cleanup sets env tools info).each do |key|
+    %w(configuration utility alias list gemset rubies cleanup sets env tools info wrapper).each do |key|
       require File.join("rvm", "environment", key)
     end
 


### PR DESCRIPTION
This just looks like an oversight, but fills out all the environment functionality.
