### PR TITLE
Fix bug where "rvm gemdir" was throwing an "unknown action" error

### DIFF
--- a/scripts/cli
+++ b/scripts/cli
@@ -112,7 +112,7 @@ __rvm_parse_args()
 
           gemdir|gempath|gemhome)
             rvm_ruby_args="$rvm_token"
-            rvm_action="gemsets"
+            rvm_action="gemset"
             rvm_gemdir_flag=1
 
             if [[ "system" = "$next_token" ]] ; then


### PR DESCRIPTION
Fix for:

```
$ rvm gemdir
ERROR: unknown action 'gemsets'
```
