### PR TITLE
added full path to usermod for CentOS

### DIFF
--- a/contrib/install-system-wide
+++ b/contrib/install-system-wide
@@ -86,7 +86,7 @@ __rvm_add_user_to_group() {
       if [[ -f "/etc/SuSE-release" ]] ; then
         groupmod -A "$1" "$2"
       else
-        usermod -a -G "$2" "$1"
+        /usr/sbin/usermod -a -G "$2" "$1"
       fi
     ;;
     "Darwin")  dscl . -append "/Groups/$2" GroupMembership "$1";;


### PR DESCRIPTION
For some reason the system $PATH wasn't getting pulled in so I added the absolute path to usermod (/usr/sbin/usermod) to make it work. Is there a more acceptable solution to get this to work properly?  I am writing a wiki article for installing RVM using your script, with attribution, for a (dv) 4.0 server from mediatemple.net. This seems to be the only part that failed.
