### PR TITLE
Gemsets import

### DIFF
--- a/scripts/gemsets
+++ b/scripts/gemsets
@@ -618,14 +618,20 @@ gemset_import()
     )
     # rvm_ruby_gem_list="${rvm_ruby_gem_list//.\/}"
 
-    while read -r line
-    do # Keep this on 2nd line :(
+    # Read the file into an array by changing the IFS temporarily.
+    local oldifs="${IFS}"
+    # Yes, that's a newline....edit with care.
+    IFS="
+"
+    local -a lines=( $(cat /tmp/foo.sh.test) )
+    IFS="${oldifs}"
 
-      if [[ -n "${line// /}" ]] ; then
+    # Parse the lines, throwing out comments and empty lines.
+    for line in "${lines[@]}"; do
+      if [[ "${line}" != '#'* && -n "${line// /}" ]]; then
         gems_args="$line" ; gem_install
       fi
-
-    done < <(awk '/^[^#]+/{print}' "${rvm_file_name}")
+    done
 
     printf "\nProcessing of $rvm_file_name is complete.\n\n"
 


### PR DESCRIPTION
This uses IFS and some bash-flavored line checking to read in the .gems files instead of using awk.  This should be faster and avoids some variable-scoping woes the other code could have had in older versions of bash (3.early).
