### PR TITLE
Find arguments are in the wrong order in the selection script

### DIFF
--- a/scripts/selector
+++ b/scripts/selector
@@ -284,7 +284,7 @@ __rvm_use_system() {
 
     "$rvm_path/scripts/alias" delete default &> /dev/null
 
-    \find "${rvm_bin_path:-"$rvm_path/bin"}" -name 'default_*' -maxdepth 0 -delete
+    \find "${rvm_bin_path:-"$rvm_path/bin"}" -maxdepth 0 -name 'default_*' -delete
     \rm -f "$rvm_path/config/default"
     \rm -f "$rvm_path/environments/default"
     \rm -rf "$rvm_path/wrappers/default"


### PR DESCRIPTION
I get the following error when running rvm on Debian Squeeze:
find: warning: you have specified the -maxdepth option after a non-option argument -name, but options are not positional (-maxdepth affects tests specified before it as well as those specified after it).  Please specify options before other arguments.

I have committed a change to my github fork that fixes the find args in the selection script. Please pull.

Thanks,
wt
