### PR TITLE
Update installation procedure in README

### DIFF
--- a/README
+++ b/README
@@ -147,7 +147,7 @@ See http://rvm.beginrescueend.com/rvm/install/
 
 or just use:
 
-    bash < <( curl http://rvm.beginrescueend.com/releases/rvm-install-latest )
+    bash < <( curl http://rvm.beginrescueend.com/releases/rvm-install-head )
 
 == LICENSE:
 


### PR DESCRIPTION
I was running `rvm implode` want to remove all the gemsets/rubies until I realize that I also removed RVM. So I had to reinstall it by follow the instruction on Github. Apparently now you'd have to curl `http://rvm.beginrescueend.com/releases/rvm-install-head` and not `http://rvm.beginrescueend.com/releases/rvm-install-latest`.
