### PR TITLE
Typo when cloning ruby via https

### DIFF
--- a/scripts/manage
+++ b/scripts/manage
@@ -1371,7 +1371,7 @@ __rvm_fetch_ruby()
 
         rm -rf "${rvm_repos_path:-"$rvm_path/repos"}/$rvm_ruby_string"
 
-        rvm_ruby_repo_http_url="${rvm_ruby_repo_url//git:/https:/}"
+        rvm_ruby_repo_http_url="${rvm_ruby_repo_url//git:/https:}"
 
         rvm_log "Cloning from $rvm_ruby_repo_url, this may take a while depending on your connection..."
 


### PR DESCRIPTION
Hey guys,

I just discovered a type when it impossible to clone ruby via the git protocol. You are switching to https then. But was one slash too much.

cloning from git://github.com/jruby/jruby.git failed, now attempting to clone from https:**///**github.com/jruby/jruby.git, this may take a while depending on your connection...
Cloning into /usr/local/rvm/repos/jruby-head...
error: Could not resolve host: https (Domain name not found) while accessing https:**///**github.com/jruby/jruby.git/info/refs
