### PR TITLE
Fetch more history in install-system-wide when called with --revision.

### DIFF
--- a/contrib/install-system-wide
+++ b/contrib/install-system-wide
@@ -137,7 +137,16 @@ while [[ $# -gt 0 ]] ; do
       rvm_trace_flag=1
       set -o verbose
       ;;
-    --version|--revision)
+    --version)
+      if [[ -n "${2:-""}" ]] ; then
+        version="$2"
+        shift
+      else
+        usage
+        exit 1
+      fi
+      ;;
+    --revision)
       if [[ -n "${2:-""}" ]] ; then
         revision="$2"
         shift
@@ -188,7 +197,11 @@ builtin cd rvm
 
 if [[ "${revision:-""}" ]]; then
   echo "Checking out revision $revision"
+  git fetch --depth=256
   git checkout $revision
+elif [[ "${version:-""}" ]]; then
+  echo "Checking out version $version"
+  git checkout $version
 fi
 
 echo "Running the install script."


### PR DESCRIPTION
When the repo gets cloned with `git clone --depth 1` there may not be
enough history to checkout a prior commit. Since there already exists a
`--version` and `--revision` flag we can treat these 2 cases slightly
differently:
- if called with `--version` then behave as before, that is:
  `git checkout $version`
- if called with `--revision` then fetch more history before performing
  the checkout with `git fetch --depth=256`

Note that the depth of 256 is rather arbitrary but should be enough (on
average) to go back in time at least a couple of weeks.
