### PR TITLE
stop __rvm_cleanup_temp_for littering the output with glob warnings under ZSH

### DIFF
--- a/scripts/utility
+++ b/scripts/utility
@@ -452,7 +452,13 @@ __rvm_cleanup_temp_for()
 
   if [[ -d "${rvm_tmp_path}/" ]]; then
 
-    \rm -rf "${rvm_tmp_path}/$1"* >/dev/null 2>&1
+    if [[ -n "${ZSH_VERSION:-""}" ]] ; then
+      # It's a ZSH shell, we need to change the glob to suppress a warning message
+      \rm -rf "${rvm_tmp_path}/$1"*(N) >/dev/null 2>&1
+    else
+      # It's not ZSH, just glob normally
+      \rm -rf "${rvm_tmp_path}/$1"* >/dev/null 2>&1
+    fi
 
   fi
 


### PR DESCRIPTION
ZSH outputs a warning to the shell if you use a glob that doesn't match anything:

```
__rvm_cleanup_temp_for:8: no matches found: /Users/caius/.rvm/tmp/25111*
```

Unfortunately this glob doesn't match anything unless the process actually left something behind in the tmp folder, which means practically all rvm commands output that warning at least once per invocation.

The solution is to append `(N)` to the glob to suppress the warning, but of course that only works under ZSH. I've copied the check to see if it's running under a ZSH from elsewhere in the utility file, and changed the glob to suppress the warning under ZSH.
