### PR TITLE
Fix ZSH warning about non-matching globs properly

### DIFF
--- a/scripts/utility
+++ b/scripts/utility
@@ -9,6 +9,10 @@ __rvm_setup()
     setopt | \grep -qs '^noclobber$'
     rvm_zsh_clobber=$?
     setopt clobber
+    # Set no_nomatch so globs that don't match any files don't print out a warning
+    setopt | \grep -qs '^nonomatch$'
+    rvm_zsh_nomatch=$?
+    setopt no_nomatch
   else
     __shell_array_start=0 # bash array indexes are 0 based.
   fi ; export __shell_array_start
@@ -28,7 +32,14 @@ __rvm_teardown()
 
     fi
 
+    if [[ ${rvm_zsh_nomatch:-0} -eq 0 ]] ; then
+
+      setopt nomatch
+
+    fi
+
     unset rvm_zsh_clobber
+    unset rvm_zsh_nomatch
 
   else
     : # currently we are not doing any option setting for bash.


### PR DESCRIPTION
Unfortunately my earlier commit that fixed this also broke rvm under bash, which I forgot to test before committing finally. I've reverted that earlier commit, and then figured out a different way to stop ZSH warning. rvm now sets the "no_nomatch" option in ZSH, and resets it after it's done, mirroring how it handles the "noclobber" option.

Sorry for breaking it, I've tested this new commit under both ZSH and bash on Snow Leopard and it's working great under both shells for me now.
