### PR TITLE
Ebuild keywords

### DIFF
--- a/meta/gentoo/rvm-99999.ebuild
+++ b/meta/gentoo/rvm-99999.ebuild
@@ -12,7 +12,7 @@ DESCRIPTION="RVM facilitates easy installation and management of multiple Ruby e
 HOMEPAGE="http://rvm.beginrescueend.com/"
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~x86"
+KEYWORDS="~x86 ~amd64"
 IUSE="mono java"
 
 RDEPEND="net-misc/curl

--- a/meta/gentoo/rvm.ebuild.template
+++ b/meta/gentoo/rvm.ebuild.template
@@ -16,7 +16,7 @@ DESCRIPTION="RVM facilitates easy installation and management of multiple Ruby e
 HOMEPAGE="http://rvm.beginrescueend.com/"
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~x86"
+KEYWORDS="~x86 ~amd64"
 IUSE="mono java"
 
 RDEPEND="net-misc/curl


### PR DESCRIPTION
Minor update to the ebuild templates.  ~x86 (already in there) is used for 32-bit systems.  ~amd64 is needed for 64-bit systems.  I have already tested this on my own system, and it is fine.
