### PR TITLE
disk-usage gives bad results with symlinks

### DIFF
--- a/scripts/disk-usage
+++ b/scripts/disk-usage
@@ -13,7 +13,7 @@ usage()
 
 disk_usage_for_directory()
 {
-  du -hs "$1" | awk '{print $1}'
+  du -hs "${1}/" | awk '{print $1}'
 }
 
 disk_usage()


### PR DESCRIPTION
The 'du' command will not automatically dereference a symlink passed to it as its path argument.  Option parameters are available to change this behavior, but these options appear to be somewhat system dependent.  On Mac OS 10.5, '-H' can be specified:

```
carrot:~ blandingj$ du -hs test
4.0K    test
carrot:~ blandingj$ du -Hhs test
6.6M    test
```

The version of 'du' available on CentOS 5 takes an '-H' option, but it behaves differently and displays a deprecation warning:

```
blandingj@slice31337 ~ $ du -Hhs test
du: WARNING: use --si, not -H; the meaning of the -H option will soon
change to be the same as that of --dereference-args (-D)
0   test
blandingj@slice31337 ~ $ du -Dhs test
56M test
```

Adding the trailing '/' to the path parameter instead leads to the proper output on both systems.
