### PR TITLE
Hard-coded "/usr/local/rvm" in install-system-wide should instead be "${rvm_path}"?

### DIFF
--- a/contrib/install-system-wide
+++ b/contrib/install-system-wide
@@ -235,8 +235,8 @@ cat > "$rvm_parent_dir/lib/rvm" <<END_OF_RVM_SH
 # Automatically source rvm
 if [[ -s "\$HOME/.rvm/scripts/rvm" ]]; then
   source "\$HOME/.rvm/scripts/rvm"
-elif [[ -s "/usr/local/rvm/scripts/rvm" ]]; then
-  source "/usr/local/rvm/scripts/rvm"
+elif [[ -s "${rvm_path}/scripts/rvm" ]]; then
+  source "${rvm_path}/scripts/rvm"
 fi
 END_OF_RVM_SH
 


### PR DESCRIPTION
If I'm not mistaken, the "/usr/local/rvm" in what ultimately becomes $rvm_parent_dir/lib/rvm should instead be $rvm_path.  This becomes important if the user installs to a directory other than /usr/local by setting the $rvm_path and $rvm_prefix environment variables.

Thanks for your consideration, and thanks for the work you've put into RVM.
