### PR TITLE
Z-shell completion

### DIFF
--- a/scripts/zsh/Completion/_rvm
+++ b/scripts/zsh/Completion/_rvm
@@ -36,7 +36,7 @@ case $state in
 
   cmds)
 
-    cmds=( ${(f)"$(_call_program commands rvm help 2> /dev/null | sed -e '/^Action/,/^Implementation/!d; / - /!d; s/^[ *]*\([^ ]*\) *\- *\(.*\)/\1:\2/')"} )
+    cmds=( ${(f)"$(_call_program commands rvm help 2> /dev/null | sed -e '/^== Action/,/^== Implementation/!d; / - /!d; s/^[ *]*\([^ ]*\) *\- *\(.*\)/\1:\2/')"} )
     cmds+=( $(rvm list strings) )
     _describe -t commands 'rvm command' cmds && ret=0
     ;;


### PR DESCRIPTION
Hi all,

I've updated the zsh completion script as the output of `rvm help` has changed.

The way we currently use `rvm help` and parse the output seems quite brittle and difficult to test. Perhaps we could add an internal API that would output a list of commands and their explanations (colon separated ideally as this is what zsh uses within it's completion system). Easier to test and far less brittle. What do you think?

In the mean time this change fixes the Z-shell completion script.

Thanks all,
James
