### PR TITLE
gentoo notes fixed

### DIFF
--- a/scripts/notes
+++ b/scripts/notes
@@ -58,7 +58,7 @@ dependencies:
   rvm: bash curl git
 
   # For MRI based rubies you will need:
-  ruby: emerge libiconv readline zlib openssl curl git libyaml sqlite libxml libxslt
+  ruby: emerge libiconv readline zlib openssl curl git libyaml sqlite libxslt
   ruby-head: gcc bison autoconf automake m4
 
   # For JRuby (if you wish to use it) you will need:


### PR DESCRIPTION
Hey,

Thanks a lot for the great project!

I fixed small issue in gentoo notes:

libxml is a gentoo package dev-ruby/libxml which required ruby 1.8.7 to be installed. We don't need ruby 1.8.7 to be installed to install rvm! ;-)

Best,
Yury
