### PR TITLE
Fix ri Generation

### DIFF
--- a/scripts/docs
+++ b/scripts/docs
@@ -69,7 +69,7 @@ generate_ri()
 
     rvm_log "( Errors will be logged to ${rvm_log_path}/$rvm_docs_ruby_string/docs.log )"
 
-    rdoc -a --ri --ri-site > /dev/null 2>> ${rvm_log_path}/$rvm_docs_ruby_string/docs.log
+    rdoc -a --ri-site > /dev/null 2>> ${rvm_log_path}/$rvm_docs_ruby_string/docs.log
   )
 }
 


### PR DESCRIPTION
This patch seems to fix the issue which will appear in the log (generator ri selected where --ri-site is already selected) on rdoc 3.5.3. Not sure if it makes sense for you to pull this, but I thought I would submit it anyhow.
