### PR TITLE
Zsh ctrl c fix

### DIFF
--- a/binscripts/rvm
+++ b/binscripts/rvm
@@ -72,6 +72,4 @@ fi
 
 source "${rvm_scripts_path:="$rvm_path/scripts"}/rvm"
 
-export rvm_interactive_flag=0
-
 rvm "$@"

--- a/scripts/cli
+++ b/scripts/cli
@@ -727,7 +727,7 @@ rvm()
   # Detect wheter or not the shell is interactive.
   case $- in *i*) rvm_interactive_flag=1 ;;
     *) rvm_interactive_flag=0 ;;
-  esac ; export rvm_interactive_flag
+  esac ;
 
   if [[ -z "${ZSH_VERSION:-""}" ]] ; then
 

--- a/scripts/functions/logging
+++ b/scripts/functions/logging
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
 
 # Logging functions
-if [[ ${rvm_interactive_flag:-0} -eq 1 ]]; then
+
+# Detect wheter or not the shell is interactive.
+case $- in *i*) rvm_interactive_flag=1 ;;
+  *) rvm_interactive_flag=0 ;;
+esac ;
+
+if [[ ${rvm_interactive_flag} -eq 1 ]]; then
   eval "rvm_log()   { printf \"\$(tput setaf 2)\$*\$(tput sgr0)\n\" ; }"
   eval "rvm_debug() { printf \"\$(tput setaf 5)DEBUG: \$*\$(tput sgr0)\n\" ; }"
   eval "rvm_warn()  { printf \"\$(tput setaf 3)WARN: \$*\$(tput sgr0)\n\" ; }"

--- a/scripts/list
+++ b/scripts/list
@@ -198,7 +198,13 @@ list_known()
     return 0
   fi
 
-  if [[ ${rvm_interactive_flag:-0} -eq 0 ]] ; then
+
+  # Detect wheter or not the shell is interactive.
+  case $- in *i*) rvm_interactive_flag=1 ;;
+    *) rvm_interactive_flag=0 ;;
+  esac ;
+
+  if [[ ${rvm_interactive_flag} -eq 0 ]] ; then
 
     cat "$rvm_config_path/known"
 

--- a/scripts/rvm
+++ b/scripts/rvm
@@ -130,7 +130,13 @@ if ! declare -f rvm > /dev/null || [[ ${rvm_reload_flag:-0} -eq 1 ]] ; then
 
 fi
 
-if [[ "screen" = $TERM || ${rvm_interactive_flag:-0} -gt 0 ]]; then
+
+# Detect wheter or not the shell is interactive.
+case $- in *i*) rvm_interactive_flag=1 ;;
+  *) rvm_interactive_flag=0 ;;
+esac ;
+
+if [[ "screen" = $TERM || ${rvm_interactive_flag} -gt 0 ]]; then
   # Reload the rvmrc, use promptless ensuring shell processes does not prompt
   # if .rvmrc trust value is not stored.
   rvm_promptless=1 __rvm_project_rvmrc

--- a/scripts/selector
+++ b/scripts/selector
@@ -874,7 +874,12 @@ __rvm_gemset_use()
       fi
     fi
 
-    if [[ ${rvm_interactive_flag:-0} -gt 0 && ${rvm_verbose_flag:-1} -ne 0 ]] ; then
+    # Detect wheter or not the shell is interactive.
+    case $- in *i*) rvm_interactive_flag=1 ;;
+      *) rvm_interactive_flag=0 ;;
+    esac ;
+
+    if [[ ${rvm_interactive_flag} -gt 0 && ${rvm_verbose_flag:-1} -ne 0 ]] ; then
       rvm_log "Now using gemset '${rvm_gemset_name:-default}'"
     fi
 


### PR DESCRIPTION
Problem: ctrl-c in zsh sometimes doesn't work

Cause: rvm_interactive_flag is sometimes exported with "0" for interactive sessions

Solution: avoid exporting rvm_interactive_flag and add interactive mode detection wherever rvm_interactive_flag is used

Notes: tested but needs refactoring and another pair of eyeballs ;)
