### PR TITLE
Fix for MacRuby 0.10

### DIFF
--- a/scripts/selector
+++ b/scripts/selector
@@ -584,7 +584,7 @@ __rvm_ruby_string()
 
         case "$string" in
 
-          0.[[:digit:]]|0.[[:digit:]]\.[[:digit:]]|1.[[:digit:]]\.[[:digit:]]*)
+          0.[[:digit:]][[:digit:]]*|0.[[:digit:]]\.[[:digit:]]|1.[[:digit:]]\.[[:digit:]]*)
             rvm_ruby_version="$string"
             rvm_ruby_revision=""
             rvm_ruby_tag=""


### PR DESCRIPTION
MacRuby 0.10 is causing the gemset commands to fail, since the ruby version selector script can't handle the '0.xx' version string.
