### PR TITLE
Catch error in ps1_git when no git repository present

### DIFF
--- a/contrib/ps1_functions
+++ b/contrib/ps1_functions
@@ -45,9 +45,10 @@ ps1_git()
 
   branch=$(git symbolic-ref -q HEAD 2>&1)
   if [[ $? -ne 0 ]]; then
-      branch="" # not in a get repo
+    branch="" # not in a get repo
+  else
+    branch=${branch##refs/heads/}
   fi
-  branch=${branch##refs/heads/}
 
   # Now we display the branch.
   sha1=($(git log --no-color -1 2>/dev/null))


### PR DESCRIPTION
Hi Wayne! The latest refactor to ps1_git has a bug. The call to branch=$(git symbolic-ref) does not have any error handling in the event that we are not in a repository, and so git whines to stderr "fatal: Not a git repository (or any of the parent directories): .git".

I've fixed it, but I'm sure a quick code review wouldn't hurt. :-) My solution keeps the existing call to git symbolic-ref, but pipes 2>&1, trapping stderr in the event of error. Then I check $?, and if there was a problem, I set branch back to "" so that the following code can proceed thinking that no branch was returned.

Not sure if that's the best way to do it, but hey, I remembered to use [[  ]] instead of [ ], which I think you said saves a process or shell call? Anyway, here's 3 more lines of code bloat for your project. Enjoy! :-)
