### PR TITLE
FIX PS1_functions - fatal: Not a git repository

### DIFF
--- a/contrib/ps1_functions
+++ b/contrib/ps1_functions
@@ -43,6 +43,11 @@ ps1_git()
     exit 0
   fi
 
+  # catch fatal error when not in a git repo
+  if ! git rev-parse 2>/dev/null; then
+      exit 0; 
+  fi 
+
   branch=$(git symbolic-ref -q HEAD)
   branch=${branch##refs/heads/}
 


### PR DESCRIPTION
Heywhen using ps1_functions on OSX and not in a git repo I would receive fatal: Not a git repository... error. So I have added a catch/exit with `git rev-parse` which returns 0 if in a working tree and errors out otherwise. 
