### PR TITLE
Installer issues

### DIFF
--- a/binscripts/rvm-installer
+++ b/binscripts/rvm-installer
@@ -210,6 +210,7 @@ export PS4="+ \${BASH_SOURCE##\${rvm_path:-}} : \${FUNCNAME[0]:+\${FUNCNAME[0]}(
 rvm_src_path="$rvm_path/src"
 rvm_archives_path="$rvm_path/archives"
 rvm_releases_url="http://rvm.beginrescueend.com/releases"
+rvm_prefix="$(dirname $rvm_path)/"
 
 for dir in  "$rvm_src_path" "$rvm_archives_path" ; do
   [[ ! -d "$dir" ]] && mkdir -p "$dir/"
@@ -244,4 +245,4 @@ flags=""
 [[ ${rvm_debug_flag:-0} -eq 1 ]] && flags="$flags --debug"
 
 # Now we yield to the RVM installer.
-exec ./scripts/install ${flags} --path "$rvm_path"
+exec ./scripts/install ${flags} --prefix "$rvm_prefix" --path "$rvm_path"


### PR DESCRIPTION
Hi Wayne,

This patch set adapts the installer do allow to install RVM fully contained into some other directory than `/usr/local/rvm`. It also contains a fix to specify stable for the installer (which didn't work because of a missing shift).

--Holger
