### PR TITLE
Cleanup 1.9.2 pre-releases now that 1.9.2 is final and stable

### DIFF
--- a/config/known
+++ b/config/known
@@ -6,10 +6,6 @@
 [ruby-]1.9.1-p378
 [ruby-]1.9.1[-p431]
 [ruby-]1.9.1-head
-[ruby-]1.9.2-preview1
-[ruby-]1.9.2-preview3
-[ruby-]1.9.2-rc1
-[ruby-]1.9.2-rc2
 [ruby-]1.9.2[-p180]
 [ruby-]1.9.2-head
 ruby-head


### PR DESCRIPTION
Remove all the 1.9.2 pre-releases from the list of known rubies.
