### PR TITLE
Create and add $rvm_bin_path if necessary

### DIFF
--- a/scripts/functions/installer
+++ b/scripts/functions/installer
@@ -276,6 +276,7 @@ create_install_paths()
   for install_path in "${install_paths[@]}" ; do
     [[ -d "$rvm_path/$install_path" ]] || mkdir -p "$rvm_path/$install_path"
   done
+  [[ -d "$rvm_bin_path" ]] || mkdir -p "$rvm_bin_path"
   return 0
 }
 
@@ -765,6 +766,14 @@ if [ -n \"\${BASH_VERSION:-}\" -o -n \"\${ZSH_VERSION:-}\" ] ; then
 
     if command -v ps1_set >/dev/null 2>&1 ; then
       ps1_set
+    fi
+  fi
+
+  # Add $rvm_bin_path to $PATH in necessary
+  if [[ \"\${rvm_bin_path}\" != \"\${rvm_path}/bin\" ]] ; then
+    regex=\"^([^:]*:)*\${rvm_bin_path}(:[^:]*)*\$\"
+    if [[ ! \"\${PATH}\" =~ \$regex ]] ; then
+      export PATH=\"\${rvm_bin_path}:\${PATH}\"
     fi
   fi
 fi


### PR DESCRIPTION
This patch creates $rvm_bin_path during installation if necessary. Also it adds it to the $PATH during loading if it is not already there. This mainly caters installs that are not in `/usr/local/rvm` or `$HOME/.rvm`.
