### PR TITLE
Updating the ps1_set to not distort the prompt if the separator is not a newline

### DIFF
--- a/contrib/ps1_functions
+++ b/contrib/ps1_functions
@@ -26,9 +26,9 @@
 ps1_identity()
 {
   if [[ $UID -eq 0 ]]  ; then
-    printf " \033[31m\\\u\033[0m@\033[36m\\h\033[35m:\w\033[0m "
+    printf "\[\033[31m\]\\\u\[\033[0m\]@\[\033[36m\]\\h\[\033[35m\]:\w\[\033[0m\] "
   else
-    printf " \033[32m\\\u\033[0m@\033[36m\\h\033[35m:\w\033[0m "
+    printf "\[\033[32m\]\\\u\[\033[0m\]@\[\033[36m\]\\h\[\033[35m\]:\w\[\033[0m\] "
   fi
 }
 
@@ -70,9 +70,10 @@ ps1_git()
   esac
 
   if [[ $color -gt 0 ]] ; then
-    printf " \033[${attr}${color}m(git:${branch}:$sha1)\033[0m "
+    printf "\[\033[${attr}${color}m\](git:${branch}:$sha1)\[\033[0m\] "
   fi
 }
+
 
 ps1_rvm()
 {
@@ -81,17 +82,18 @@ ps1_rvm()
   fi
 }
 
-ps1_set()
+ps1_update()
 {
   local prompt_char='$'
   local separator="\n"
+  local notime=0
 
   if [[ $UID -eq 0 ]] ; then
     prompt_char='#'
   fi
 
   while [[ $# -gt 0 ]] ; do
-    token="$1" ; shift
+    local token="$1" ; shift
 
     case "$token" in
       --trace)
@@ -102,9 +104,15 @@ ps1_set()
         prompt_char="$1"
         shift
         ;;
+      --noseparator)
+        separator=""
+        ;;
       --separator)
         separator="$1"
         shift
+        ;;
+      --notime)
+        notime=1
         ;;
       *)
         true # Ignore everything else.
@@ -112,7 +120,11 @@ ps1_set()
     esac
   done
 
-  PS1="\D{%H:%M:%S}$(ps1_identity)\$(ps1_git)\$(ps1_rvm)${separator}${prompt_char} "
+  if [[ $notime -gt 0 ]] ; then
+    PS1="$(ps1_identity)$(ps1_git)$(ps1_rvm)${separator}${prompt_char} "
+  else
+    PS1="\D{%H:%M:%S} $(ps1_identity)$(ps1_git)$(ps1_rvm)${separator}${prompt_char} "
+  fi
 }
 
 ps2_set()
@@ -124,3 +136,23 @@ ps4_set()
 {
   export PS4="+ \${BASH_SOURCE##\${rvm_path:-}} : \${FUNCNAME[0]:+\${FUNCNAME[0]}()}  \${LINENO} > "
 }
+
+# WARNING:  This clobbers your PROMPT_COMMAND so if you need to write your own, call 
+#           ps1_update within your PROMPT_COMMAND with the same arguments you pass 
+#           to ps1_set
+#
+# The PROMPT_COMMAND is used to help the prompt work if the separator is not a new line.
+# In the event that the separtor is not a new line, the prompt line may become distored if
+# you add or delete a certian number of characters, making the string wider than the
+# $COLUMNS + len(your_input_line).
+# This orginally was done with callbacks within the PS1 to add in things like the git
+# commit, but this results in the PS1 being of an unknown width which results in the prompt
+# being distored if you add or remove a certain number of characters. To work around this
+# it now uses the PROMPT_COMMAND callback to re-set the PS1 with a known width of chracters
+# each time a new command is entered. see PROMPT_COMMAND for more details.
+#
+ps1_set()
+{
+    PROMPT_COMMAND="ps1_update $@"
+}
+


### PR DESCRIPTION
parts so you can use a separator that is not a new 
line and not mess up your prompt. See 
contrib/ps1_functions for more detail.
