### PR TITLE
Fix patterns for $(git branch)

### DIFF
--- a/scripts/manage
+++ b/scripts/manage
@@ -1418,12 +1418,12 @@ __rvm_fetch_ruby()
         branches="$(git branch)" # Grab a list of the local branches
 
         case "$branches" in
-          ([[=*=]][[:space:]]${rvm_ruby_repo_branch})
+          (*\*[[:space:]]${rvm_ruby_repo_branch}*)
             # On desired branch, pull!
             git pull "$remote" "${rvm_ruby_repo_branch}"
             ;;
 
-          (*([[:space:]])${rvm_ruby_repo_branch})
+          (*[[:space:]]${rvm_ruby_repo_branch}*)
             # Not already on the desired branch, but it does exist locally.
             git checkout "${rvm_ruby_repo_branch}" # Branch is local, checkout
             git pull "$remote" "${rvm_ruby_repo_branch}" # Bring local to latest


### PR DESCRIPTION
To confirm the patch, I hope playing with following command lines help you.

```
$ case " fuga 0.10 * master hoge" in; ([[=*=]][[:space:]]master) echo match;; *) echo not match;; esac
not match
$ case " fuga 0.10 * master hoge" in; (*\*[[:space:]]master*) echo match;; *) echo not match;; esac
match
```

[=_=] seems to be preferable, but I can't solve the issue with it, so use \\_ instead.

```
$ case " fuga 0.10 * master hoge" in; (*([[:space:]])0.10) echo match;; *) echo not match;; esac
not match
$ case " fuga 0.10 * master hoge" in; (*[[:space:]]0.10*) echo match;; *) echo not match;; esac
match
```
