### PR TITLE
Show git status

### DIFF
--- a/contrib/ps1_functions
+++ b/contrib/ps1_functions
@@ -70,10 +70,29 @@ ps1_git()
   esac
 
   if [[ $color -gt 0 ]] ; then
-    printf "\[\033[${attr}${color}m\](git:${branch}:$sha1)\[\033[0m\] "
+    printf "\[\033[${attr}${color}m\](git:${branch}$(parse_git_status):$sha1)\[\033[0m\] "
   fi
 }
 
+parse_git_status()
+{
+  printf "$(parse_git_added)$(parse_git_modified)$(parse_git_deleted)"
+}
+
+parse_git_deleted()
+{
+  [[ $(git status 2> /dev/null | grep deleted:) != "" ]] && echo "-"
+}
+
+parse_git_added()
+{
+  [[ $(git status 2> /dev/null | grep "Untracked files:") != "" ]] && echo '+'
+}
+
+parse_git_modified()
+{
+  [[ $(git status 2> /dev/null | grep modified:) != "" ]] && echo "*"
+}
 
 ps1_rvm()
 {


### PR DESCRIPTION
Show git status in PS1 using the snippets present here: https://gist.github.com/48207

Basically, it will add a character to inform the status, for example:

`(git:git_status*:866f1d6) # for modified`

`(git:git_status-:866f1d6) # for deleted`

`(git:git_status+:866f1d6) # for added`
