### PR TITLE
Remove shopt -s extglob for compatibility.

### DIFF
--- a/scripts/functions/cleanup
+++ b/scripts/functions/cleanup
@@ -8,7 +8,6 @@ __rvm_rm_rf()
   local result=1 target="${1%%+(/|.)}"
 
   #NOTE: RVM Requires extended globbing shell feature turned on.
-  shopt -s extglob
   case "${target}" in
 
     (*(/|.)@(|/Applications|/Developer|/Guides|/Information|/Library|/Network|/System|/User|/Users|/Volumes|/backups|/bdsm|/bin|/boot|/cores|/data|/dev|/etc|/home|/lib|/lib64|/mach_kernel|/media|/misc|/mnt|/net|/opt|/private|/proc|/root|/sbin|/selinux|/srv|/sys|/tmp|/usr|/var))


### PR DESCRIPTION
Small fix for zsh users.

It looks like shopt -s extglob should be already set in scripts/initialize, so is not even needed here.
