### PR TITLE
Use the corrent way to enable extended glob on zsh

### DIFF
--- a/scripts/functions/cleanup
+++ b/scripts/functions/cleanup
@@ -8,7 +8,11 @@ __rvm_rm_rf()
   local result=1 target="${1%%+(/|.)}"
 
   #NOTE: RVM Requires extended globbing shell feature turned on.
-  shopt -s extglob
+  if [[ -n "${ZSH_VERSION:-}" ]] ; then
+    setopt extendedglob
+  else
+    shopt -s extglob
+  fi
   case "${target}" in
 
     (*(/|.)@(|/Applications|/Developer|/Guides|/Information|/Library|/Network|/System|/User|/Users|/Volumes|/backups|/bdsm|/bin|/boot|/cores|/data|/dev|/etc|/home|/lib|/lib64|/mach_kernel|/media|/misc|/mnt|/net|/opt|/private|/proc|/root|/sbin|/selinux|/srv|/sys|/tmp|/usr|/var))


### PR DESCRIPTION
In https://github.com/wayneeseguin/rvm/pull/236 you stated that simply removing "shopt -s extglob" was not the correct way to fix it. As you haven't answered why setting it in scripts/initialize is not enough I'm sending another pull request. This time scripts/functions/cleanup enables extended globbing correcly for both zsh and bash.
