### PR TITLE
autoconf needs to be run when patches modify configure.in

### DIFF
--- a/scripts/manage
+++ b/scripts/manage
@@ -193,7 +193,8 @@ __rvm_install_source()
   fi
 
   if [[ -z "${rvm_ruby_configure:-""}" \
-    && ! -s "${rvm_src_path}/$rvm_ruby_string/configure" ]] ; then
+    && (! -s "${rvm_src_path}/$rvm_ruby_string/configure" \
+        || "${rvm_src_path}/$rvm_ruby_string/configure.in" -nt "${rvm_src_path}/$rvm_ruby_string/configure") ]] ; then
 
     if command -v autoconf > /dev/null ; then
 


### PR DESCRIPTION
ruby source patches can modify configure.in. in this case, autoconf needs to be run after patching.

see https://github.com/skaes/rvm-patchsets
