### PR TITLE
Slashes in gemset names?

### DIFF
--- a/scripts/functions/environment
+++ b/scripts/functions/environment
@@ -7,7 +7,7 @@ __rvm_environment_identifier()
   path="${GEM_HOME:-""}"
 
   string="${path//*gems\//}"
-  string="${string//\/*/}"
+  string="${string//\/*$/}"
 
   printf "${string:-system}"
 


### PR DESCRIPTION
Not sure if this is legit or not. Tried posting to the mailing list but my post seems to be stuck in moderation. 

gemset names with slashes are improperly truncated in __rvm_environment_identifier
