### PR TITLE
Fix missing escape

### DIFF
--- a/scripts/functions/installer
+++ b/scripts/functions/installer
@@ -769,7 +769,7 @@ if [ -n \"\${BASH_VERSION:-}\" -o -n \"\${ZSH_VERSION:-}\" ] ; then
     fi
   fi
 
-  # Add \$rvm_bin_path to \$PATH in necessary
+  # Add \$rvm_bin_path to \$PATH if necessary
   if [[ \"\${rvm_bin_path}\" != \"\${rvm_path}/bin\" ]] ; then
     regex=\"^([^:]*:)*\${rvm_bin_path}(:[^:]*)*\$\"
     if [[ ! \"\${PATH}\" =~ \$regex ]] ; then


### PR DESCRIPTION
Hi Wayne, this patch fixes a missing dollar escape in the generated `/etc/profile.d/rvm.sh`.

--Holger
