### PR TITLE
Add JRuby 1.6.1 to the list of known rubies

### DIFF
--- a/config/known
+++ b/config/known
@@ -17,7 +17,8 @@ goruby
 jruby-1.2.0
 jruby-1.3.1
 jruby-1.4.0
-jruby[-1.6.0]
+jruby-1.6.0
+jruby[-1.6.1]
 jruby-head
 
 # Rubinius
@@ -44,9 +45,9 @@ maglev[-25716]
 maglev-head
 
 # Mac OS X Snow Leopard Only
-macruby[-0.10] # the default macruby
+macruby[-0.10]
 macruby-nightly
-macruby-head      # Build from the macruby git repository
+macruby-head
 
 # IronRuby -- Not implemented yet.
 ironruby-0.9.3


### PR DESCRIPTION
This change seemed to be missing from 640cffdb771f8240bc00af6eac7cb0eab081a4a6.

I also removed some redundant comments from MacRuby.
