### PR TITLE
Possible --clang bug fix.

### DIFF
--- a/scripts/manage
+++ b/scripts/manage
@@ -19,7 +19,7 @@ unset RUBYLIB RUBYOPT # Sanity check.
 
 __rvm_check_for_clang()
 {
-  if [[ -n "${rvm_clang_flag:-""}" ]] && ! command -v clang >/dev/null ; then
+  if [[ ${rvm_clang_flag}" ]] && ! command -v clang >/dev/null ; then
     rvm_error "\nYou passed the --clang option and clang is not in your path. \nPlease try again or do not use --clang.\n"
     return 1
   fi


### PR DESCRIPTION
telemachus + brainlag + me looked at the bug on IRC and sort of concluded this might be it.

My rvm seems to work regardless on my machine, even if I have 1.6.3 and not clang it seems to work installing.

On my ubuntu 10.10 server however it's not so happy. Just decided to throw this out there and see if you guys agree. And perhaps someone can test it :-)
