### PR TITLE
Correct and clarify resetting of zsh options.

### DIFF
--- a/scripts/functions/environment
+++ b/scripts/functions/environment
@@ -237,8 +237,10 @@ __rvm_teardown()
 
   if [[ -n "${ZSH_VERSION:-""}" ]]
   then
-    (( rvm_zsh_clobber > 0 )) || setopt noclobber
-    (( rvm_zsh_nomatch > 0 )) || setopt nomatch
+    # If rvm_zsh_clobber is 0 then "setopt" contained "noclobber" before rvm performed "setopt clobber".
+    (( rvm_zsh_clobber == 0 )) && setopt noclobber
+    # If rvm_zsh_nomatch is 0 then "setopt" contained "nonomatch" before rvm performed "setopt nonomatch".
+    (( rvm_zsh_nomatch == 0 )) || setopt nomatch
 
     unset rvm_zsh_clobber rvm_zsh_nomatch
   else


### PR DESCRIPTION
Hi Wayne,

There's a slight mistake in the horrible negated-negatives-ful boolean logic when rvm tries to restore zsh options to default. This patch fixes that.

Conrad

---

Unfortunately this will have the side effect that the people who have "setopt nomatch" will now see that RVM sometimes changes it to nonomatch. This is because of other bugs:

When running under zsh, with "setopt nomatch" and cd-ing into a directory that contains a ".rvmrc" which contains "rvm use 1.9.2@foo":

The chpwd hook will run __rvm_project_rvmrc which sources script/initialize which sets rvm_zsh_nomatch to 1 and runs setopt nonomatch. Later, the rvm function will be called (as rvm use 1.9.2@foo) which will initialize the script again. This time, rvm_zsh_nomatch will be set to 0 as rvm just ran setopt nonomatch (oops!). Thus when __rvm_teardown is called as rvm() exits, the nonomatch setting will not be restored.

When running under zsh, with "setopt nomatch" and cd-ing into a directory that does not contain a ".rvmrc":

The chpwd hook will run __rvm_project_rvmrc and setopt nonomatch as before. Unfortunately __rvm_teardown is not called, and so rvm's settings prevail.

The solution to these problems seems harder to come by — I imagine the thing to do will be to move the setopt stuff out of the initialize script and into another script/function that will only be called inside rvm(), not inside the chpwd hook (as I don't think it's needed there). (I really don't understand the codebase though, so it probably needs your judgement call of when the best time is to do the initializing). The alternative would be to ensure that ./script/initialize is always paired with __rvm_teardown, and that the options setting is properly re-entrant — that seems a bit of a tall ask though.

Conrad

P.S. I was going to add these to pivotal but it said I needed to join the project.
