### PR TITLE
A tiny git SHA1 commit number parsing optimization

### DIFF
--- a/contrib/ps1_functions
+++ b/contrib/ps1_functions
@@ -58,8 +58,7 @@ ps1_git()
   branch=${branch##refs/heads/}
 
   # Now we display the branch.
-  sha1=($(git log --no-color -1 2>/dev/null))
-  sha1=${sha1[1]}
+  sha1=($(git rev-parse HEAD 2>/dev/null))
   sha1=${sha1:0:7}
 
   case "${branch:-"(no branch)"}" in


### PR DESCRIPTION
Using `git rev-parse` instead of `git log --no-color -1` to get the last sha1 commit on current branch so we can remove some treatment.
