### PR TITLE
Fix user db overrides to use $rvm_user_path/db consistently.

### DIFF
--- a/scripts/functions/db
+++ b/scripts/functions/db
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Query the rvm key-value database for a specific key
-# Allow overrides from user specifications in $rvm_config_path/user
+# Allow overrides from user specifications in $rvm_user_path/db
 __rvm_db()
 {
   local value key variable
@@ -9,7 +9,7 @@ __rvm_db()
   key=${1:-""}
   variable=${2:-""}
 
-  if [[ -f "$rvm_config_path/user" ]] ; then
+  if [[ -f "$rvm_user_path/db" ]] ; then
     value="$("$rvm_scripts_path/db" "$rvm_user_path/db" "$key")"
   fi
 

--- a/scripts/functions/gemset
+++ b/scripts/functions/gemset
@@ -17,7 +17,7 @@ __rvm_current_gemset()
 
 __rvm_using_gemset_globalcache()
 {
-  "$rvm_scripts_path/db" "$rvm_config_path/user" \
+  "$rvm_scripts_path/db" "$rvm_user_path/db" \
     "use_gemset_globalcache" | \grep '^true$' >/dev/null 2>&1
   return $?
 }

--- a/scripts/functions/installer
+++ b/scripts/functions/installer
@@ -333,16 +333,14 @@ install_rvm_files()
 setup_configuration_files()
 {
   (
-    if [[ ! -s "$rvm_config_path/user" ]] ; then
-      echo '# User settings, overrides db settings and persists across installs.' \
-        >> "$rvm_config_path/user"
-    fi
-
     cd "$rvm_path"
 
     [[ ! -f config/user ]] && mv config/user user/db
 
-    [[ ! -f user/db ]] && touch user/db
+    if [[ ! -s user/db ]] ; then
+      echo '# User settings, overrides db settings and persists across installs.' \
+        >> user/db
+    fi
 
     if [[ -s config/rvmrcs ]] ; then
       mv config/rvmrcs user/rvmrcs

--- a/scripts/functions/reset
+++ b/scripts/functions/reset
@@ -47,7 +47,7 @@ __rvm_reset()
 
   for system_config in "${configs[@]}" ; do
 
-    "$rvm_scripts_path/db" "$rvm_config_path/user" "$system_config" "delete"
+    "$rvm_scripts_path/db" "$rvm_user_path/db" "$system_config" "delete"
 
   done
 

--- a/scripts/gemsets
+++ b/scripts/gemsets
@@ -94,7 +94,7 @@ gemset_globalcache()
       fi
     done
 
-    "$rvm_scripts_path/db" "$rvm_config_path/user" \
+    "$rvm_scripts_path/db" "$rvm_user_path/db" \
       "use_gemset_globalcache" "delete"
 
   elif [[ "$1" == "enable" ]]; then
@@ -128,7 +128,7 @@ gemset_globalcache()
 
     done
 
-    "$rvm_scripts_path/db" "$rvm_config_path/user" \
+    "$rvm_scripts_path/db" "$rvm_user_path/db" \
       "use_gemset_globalcache" "true"
 
   else

--- a/scripts/snapshot
+++ b/scripts/snapshot
@@ -54,7 +54,7 @@ snapshot_save()
   cp "$rvm_config_path/alias" "$snapshot_temp_path/"
 
   rvm_log "Backing up your user preferences"
-  cp "$rvm_config_path/user" "$snapshot_temp_path/"
+  cp "$rvm_user_path/db" "$snapshot_temp_path/"
 
   rvm_log "Backing up your installed packages"
   sed -e 's/-//' -e 's/^lib//' < "$rvm_config_path/packages" | awk -F= '{print $1}' | sort | uniq > "$snapshot_temp_path/packages"
@@ -178,7 +178,7 @@ snapshot_load()
   )
 
   rvm_log "Restoring user settings"
-  \cp -f "$snapshot_temp_path/user" "$rvm_config_path/user"
+  \cp -f "$snapshot_temp_path/db" "$rvm_user_path/db"
 
   rvm_log "Installing rvm-managed packages"
   for snapshot_package in $(cat "$snapshot_temp_path/packages"); do


### PR DESCRIPTION
Cleanup some of the places that still reference the old user db override location.
