### PR TITLE
Ensure aptitude is installed. 

### DIFF
--- a/contrib/bootstrap_rails_environment
+++ b/contrib/bootstrap_rails_environment
@@ -39,6 +39,7 @@ else
 
     if command -v aptitude || command -v apt-get ; then
 
+      sudo apt-get install aptitude
       sudo aptitude install build-essential bison openssl libreadline6 libreadline6-dev curl git-core zlib1g zlib1g-dev libssl-dev libyaml-dev libsqlite3-0 libsqlite3-dev sqlite3 libxml2-dev libxslt-dev autoconf libc6-dev
 
     elif command -v pacman ; then


### PR DESCRIPTION
Ubuntu 11 desktop doesn't ship with it, but does ship with apt-get. If apt-get is a reasonable install path, maybe we should remove the aptitude dependency.
