### PR TITLE
Fix setup_rvm_group_users for the case when there are no additional users

### DIFF
--- a/scripts/functions/installer
+++ b/scripts/functions/installer
@@ -832,7 +832,7 @@ setup_rvm_group_users()
 {
   # TODO: implement this.  For now we'll use a naieve approach based on homes.
   user_homes=$(find /home/ -mindepth 1 -maxdepth 1 -type d)
-  for user_home in "${user_homes[@]}" ; do
+  for user_home in ${user_homes[@]} ; do
     # TODO: Check if user is a login user.
     # TODO: Skip if user is already in the RVM group.
     user="${user_home//*\/}"


### PR DESCRIPTION
Fix setup_rvm_group_users for the case when there are no additional users.

The erroneous behavior was the output of
Ensuring '' is in group 'rvm'
Adding user '' to group 'rvm'
usermod: user '' does not exist
