### PR TITLE
Update help for `rvm rubygems`

### DIFF
--- a/help/rubygems
+++ b/help/rubygems
@@ -1,11 +1,13 @@
-
 ∴ rvm rubygems [version]
 
 Installs a specific rubygems version in the current ruby. If
-current is specified, will install the most current rubygems
-as known by rvm.
+'current' is specified, the most current rubygems known to RVM
+will be installed.
 
-Please note that currently this is only compatible with ruby
-1.8.* and ruby enterprise edition. If your system isn't supported,
-running the command will generate an error message.
+Currently compatible with with MRI 1.8.*, 1.9.* and Ruby 
+Enterprise Edition. If your system isn't supported, running the
+command will generate an error message.
 
+MRI 1.9.* ships with a version of RubyGems. To revert to that version
+after installing a custom version via 'rvm rubygems' run 
+'rvm rubygems remove'.


### PR DESCRIPTION
`rvm rubygems` works with 1.9.\* as well. Also added the bit about `rvm rubygems remove` and 1.9.\*  from the rvm website.
