### PR TITLE
Use cp -f and rm -f when dealing with /tmp/$$

### DIFF
--- a/scripts/cli
+++ b/scripts/cli
@@ -817,9 +817,9 @@ rvm()
       then
         shift
       fi
-      cp "$rvm_scripts_path/get" /tmp/$$
+      \cp -f "$rvm_scripts_path/get" /tmp/$$
       "/tmp/$$" $rvm_ruby_args
-      rm /tmp/$$
+      \rm -f /tmp/$$
       ;;
 
     help|rtfm|env|current|info|list|gemdir|gemhome|gempath|monitor|notes|package)


### PR DESCRIPTION
This removes the need for the user to indicate that yes, they do want to delete /tmp/$$ after each "rvm get head".
