### PR TITLE
switch to enable user-install flag

### DIFF
--- a/binscripts/rvm-installer
+++ b/binscripts/rvm-installer
@@ -219,6 +219,10 @@ while [[ $# -gt 0 ]] ; do
       fi
       ;;
 
+    --user-install)
+      rvm_user_install_flag=1
+      ;;
+
     --version)
       case "$1" in
         +([[:digit:]]).+([[:digit:]]).+([[:digit:]]))


### PR DESCRIPTION
support is in the script, but i always have to go looking for it in order to get rvm to install in root's home dir.
