### PR TITLE
split bunzip into 2 lines, the one-liner fails in RHEL4 for some reason. 

### DIFF
--- a/scripts/manage
+++ b/scripts/manage
@@ -1354,7 +1354,8 @@ __rvm_fetch_ruby()
           fi
           ;;
         tar.bz2)
-          __rvm_run "extract" "bunzip2 < '${rvm_archives_path}/$rvm_ruby_package_file.$rvm_archive_extension' | tar xf - -C ${rvm_tmp_path:-/tmp}/rvm_src_$$" "$rvm_ruby_string - #extracting $rvm_ruby_package_file to ${rvm_src_path}/$rvm_ruby_string"
+          __rvm_run "extract" "bunzip2 '${rvm_archives_path}/$rvm_ruby_package_file.$rvm_archive_extension'"
+          __rvm_run "extract" "tar xf ${rvm_archives_path}/$rvm_ruby_package_file.tar -C ${rvm_tmp_path:-/tmp}/rvm_src_$$" "$rvm_ruby_string - #extracting $rvm_ruby_package_file to ${rvm_src_path}/$rvm_ruby_string"
           result=$?
 
           if (( result > 0 ))


### PR DESCRIPTION
split bunzip into 2 lines, the one-liner fails in RHEL4 for some reason. 2 lines works for RHEL4, RHEL5, Ubuntu, and MacOS, have not tested anything else
