### PR TITLE
fixes rvm get latest (broken since 1.6.10)

### DIFF
--- a/scripts/functions/installer
+++ b/scripts/functions/installer
@@ -643,7 +643,7 @@ install_man_pages()
   printf "\n    Copying manpages into place.\n"
 
   files=($(
-  cd "$install_source_path/man" ;
+  builtin cd "$install_source_path/man" ;
   find . -maxdepth 2 -mindepth 1 -type f -print
   ))
 


### PR DESCRIPTION
In commit 207ce89633ba53b67ba3c4986a22af2b93700d85 the builtin cd was accidentally replaced by the rvm version of cd which prompts for review of the .rvmrc in ~/.rvm/src/rvm-1.6.10 when upgrading an existing rvm to 1.6.10. This prompt isn't shown, the cd doesn't work and the installer copies all kind of crap into ~/.rvm/man and apparently hangs. This should be included quite fast, since it prevents previous users of rvm to upgrade to 1.6.10 (at least it prevented all users here in my office).
