### PR TITLE
Add missing "then" to scripts/rubygems

### DIFF
--- a/scripts/rubygems
+++ b/scripts/rubygems
@@ -85,6 +85,7 @@ rubygems_setup()
     result=$?
 
     if (( result > 0 ))
+    then
       rvm_error "There has been an error while trying to fetch the source. \nHalting the installation."
       return $result
     fi


### PR DESCRIPTION
An "if" statement introduced in wayneeseguin/rvm@d3ae27f7b9fa2a57428db086044350dd8581783a was missing a corresponding "then".
