### PR TITLE
Update known list to reflect that JRuby 1.6.2 is the new default

### DIFF
--- a/config/known
+++ b/config/known
@@ -18,7 +18,7 @@ jruby-1.2.0
 jruby-1.3.1
 jruby-1.4.0
 jruby-1.6.0
-jruby[-1.6.1]
+jruby[-1.6.2]
 jruby-head
 
 # Rubinius


### PR DESCRIPTION
We really need to automate generation of the known list so it doesn't need to be manually updated.
