### PR TITLE
Fix typo in example .rvmrc

### DIFF
--- a/examples/rvmrc
+++ b/examples/rvmrc
@@ -60,5 +60,5 @@
 # Specify RBXOPT enviroment settings that should always be set when calling
 # Rubinius scripts. For example, to always run the agent when running from
 # an Rubinius environment, set the value to '-Xagent'
-# export rvm_rbx_opts
+# export rvm_rbx_opt
 


### PR DESCRIPTION
I was really confused when I went to set my RBXOPT. This should clear it up for anyone else who comes along.
