### PR TITLE
Fixed typo in "gemsets" script

### DIFF
--- a/scripts/gemsets
+++ b/scripts/gemsets
@@ -259,7 +259,7 @@ gemset_delete()
       rvm_log "$gemdir already does not exist."
     fi
   else
-    rvm_error "A gemset name must be specified in order to delete a gems."
+    rvm_error "A gemset name must be specified in order to delete a gemset."
     return 1
   fi
   return 0


### PR DESCRIPTION
My humble contribution to RVM: Instead of "A gemset name must be specified in order to delete a gems" it should read "A gemset name must be specified in order to delete a gemset".

I leave it up to a native speaker to drop the initial gemset (or not).
