### PR TITLE
Add Mac users to the rvm group, so they don't have to use sudo to modify rvm settings.

### DIFF
--- a/scripts/functions/installer
+++ b/scripts/functions/installer
@@ -940,13 +940,20 @@ add_user_to_rvm_group()
 
 setup_rvm_group_users()
 {
-  # TODO: implement this.  For now we'll use a naieve approach based on homes.
-  user_homes=$(find /home/ -mindepth 1 -maxdepth 1 -type d)
-  for user_home in ${user_homes[@]}
+  case "$(uname)" in
+    "Darwin")
+      usernames=$(dscl . -search /Users PrimaryGroupID 20 | grep PrimaryGroupID | cut -f 1)
+      ;;
+    *)
+      # TODO: implement this.  For now we'll use a naieve approach based on homes.
+      usernames=$(find /home -mindepth 1 -maxdepth 1 -type d | cut -d '/' -f 3)
+      ;;
+  esac
+
+  for user in ${usernames[@]}
   do
     # TODO: Check if user is a login user.
     # TODO: Skip if user is already in the RVM group.
-    user="${user_home//*\/}"
     printf "Ensuring '$user' is in group '$rvm_group_name'\n"
     add_user_to_rvm_group $user
   done


### PR DESCRIPTION
This fixes the bug where system-installed RVM on Mac doesn't properly add the users to the rvm group.
To properly add Mac users to the rvm group, list all users that are in the "staff" group, which seems to mean can login.
