### PR TITLE
Adjust scripts/functions/bundler to allow for shortened Bundler syntax

### DIFF
--- a/scripts/functions/bundler
+++ b/scripts/functions/bundler
@@ -18,7 +18,7 @@ bundle()
 
   if (unset bundle ; command -v bundle >/dev/null 2>&1)
   then
-    if [[ "$*" =~ 'install' && ! "$*" =~ '--help' ]]
+    if [[ ("$*" =~ 'install' && ! "$*" =~ '--help') || -z "$1" ]]
     then
       printf "Bundling your gems. This may take a few minutes on first run.\n"
       command bundle "$@" --binstubs=$GEM_HOME/bin


### PR DESCRIPTION
Running "bundle" by itself is the same thing as running "bundle install".
