### PR TITLE
For colorized logging detect interactive shell by looking at STDOUT

### DIFF
--- a/scripts/functions/logging
+++ b/scripts/functions/logging
@@ -2,8 +2,8 @@
 
 # Logging functions
 
-# Detect wheter or not the shell is interactive.
-if [[ -t 0 ]]
+# Detect wheter or not the shell is interactive by asking if stdout is a terminal
+if [[ -t 1 ]]
 then
   eval "rvm_log()   { printf \"\$(tput setaf 2)\$*\$(tput sgr0)\n\" ; }"
   eval "rvm_debug() { printf \"\$(tput setaf 5)DEBUG: \$*\$(tput sgr0)\n\" ; }"


### PR DESCRIPTION
Shouldn't STDOUT instead of STDIN be tested for "interactivity" for output? This way

```
rvm install 1.9.2 > output.txt
```

won't have colorization.
