### PR TITLE
Added strings option to gemset listings. Ex: rvm gemset list strings

### DIFF
--- a/scripts/gemsets
+++ b/scripts/gemsets
@@ -186,7 +186,10 @@ gemset_list()
     __rvm_select
   fi
 
-  rvm_log "\ngemsets for $rvm_ruby_string (found in ${rvm_gems_path:-"$rvm_path/gems"}/$rvm_ruby_string)"
+  if [[ "${args[0]:-""}" != "strings" ]]
+  then
+    rvm_log "\ngemsets for $rvm_ruby_string (found in ${rvm_gems_path:-"$rvm_path/gems"}/$rvm_ruby_string)"
+  fi
 
   if [[ -d "${rvm_gems_path:-"$rvm_path/gems"}" ]]
   then
@@ -200,9 +203,19 @@ gemset_list()
         gemset="${gemset##*${rvm_gemset_separator:-@}}"
         if [[ "${gemset}" = "${current_gemset}" ]]
         then
-          echo "=> ${gemset}"
+		    if [[ "${args[0]:-""}" != "strings" ]]
+			  then
+             echo "=> ${gemset}"
+          else
+		       echo "${gemset} (default)"
+			 fi
         else
-          echo "   ${gemset}"
+	       if [[ "${args[0]:-""}" != "strings" ]]
+			  then
+             echo "   ${gemset}"
+			  else
+				echo $gemset
+			  fi
         fi
       done
     else


### PR DESCRIPTION
Needed a way to not have the gemset heading and indentation on gemset listings per ruby for JewelryBox integration. Added strings option to gemset list and conditionalized formatting accordingly.
