### PR TITLE
fixed issue where Result#initialize would blow up if status was false

### DIFF
--- a/lib/rvm/shell/result.rb
+++ b/lib/rvm/shell/result.rb
@@ -11,7 +11,7 @@ module RVM
       def initialize(command, status, stdout, stderr)
         @command     = command.dup.freeze
         @raw_status  = status
-        @environment = @raw_status["environment"] || {}
+        @environment = (@raw_status ? (@raw_status["environment"] || {}) : {})
         @successful  = (exit_status == 0)
         @stdout      = stdout.freeze
         @stderr      = stderr.freeze


### PR DESCRIPTION
fixed issue where Result#initialize would blow up if status was false, giving (NoMethodError: undefined method '[]' for false:FalseClass) on result.rb:14

Used to get this error when using RVM.gemset_use! "gemset_name_here": http://pastie.org/2048327
Now the command still doesn't work, but at least the RVM Ruby API doesn't give me a stack trace:  http://pastie.org/2078395

As you can see, RVM.gemset_use! doesn't seem to be actually changing the current gemset. Any ideas? The RVM Ruby API is a central focus of a project I'm working on right now so any help would be greatly appreciated!
