### PR TITLE
Make 'gemset use' show completions when called without rvm

### DIFF
--- a/scripts/completion
+++ b/scripts/completion
@@ -120,6 +120,8 @@ _rvm_gemset ()
   if [[ -z "$subcommand" ]]; then
     __rvm_comp "$subcommands"
     return
+  elif [[ "$subcommand" = "use" ]]; then
+    _rvm_use
   fi
 }
 


### PR DESCRIPTION
I call `rvm gemset` so much, I end up putting this in my .bashrc:

```
alias gemset='rvm gemset'
complete -o default -o nospace -F _rvm_gemset gemset
```

This way I can just type 'gemset use rails31'.  Awesome.

Problem is, gemset completions don't work without this patch.  Now gemset completions match 'rvm gemset' completions, and 'rvm gemset' completions work exactly like before.
