### PR TITLE
Fix skipping extract step for REE 

### DIFF
--- a/scripts/functions/manage/ree
+++ b/scripts/functions/manage/ree
@@ -12,7 +12,7 @@ ree_install()
 
     if (( rvm_force_flag == 0 )) &&
       [[ -d "${rvm_src_path}/$rvm_ruby_string" &&
-      ! -x "${rvm_src_path}/$rvm_ruby_string/installer" ]]
+         -x "${rvm_src_path}/$rvm_ruby_string/installer" ]]
   then
     rvm_log "It appears that the archive has already been extracted. Skipping extract (use --force to force re-download and extract)."
 


### PR DESCRIPTION
At least for ree-1.8.7-2011.03 the installer is executable. By making this change, you can now install REE with rvm on a system with glibc 2.14. I don't know how to fix the underlying issue, but to install you can:
1. Run `rvm install ree`
2. Wait for it to fail.
3. Fix the broken files with:
cd ~/.rvm/src/ree-1.8.7-2011.03/source/ext/dl
rm callback.func
touch callback.func
ruby mkcallback.rb >> callback.func
rm cbtable.func
touch cbtable.func
ruby mkcbtable.rb >> cbtable.func
4. Re-run `rvm install ree` and the REE files will not be re-extracted, so your changes to callback.func and cbtable.func will persist.
