### PR TITLE
Add slash after using rvm_prefix

### DIFF
--- a/scripts/initialize
+++ b/scripts/initialize
@@ -28,8 +28,8 @@ command -v __rvm_load_rvmrc >/dev/null 2>&1 || \
 #
 if (( ${rvm_user_install_flag:=0} == 0 ))
 then
-  true "${rvm_bin_path:="${rvm_prefix}bin"}"
-  true "${rvm_man_path:="${rvm_prefix}share/man"}"
+  true "${rvm_bin_path:="${rvm_prefix}/bin"}"
+  true "${rvm_man_path:="${rvm_prefix}/share/man"}"
   true "${rvm_rc_files:="/etc/profile /etc/zshenv"}"
 else
   true "${rvm_bin_path:="$rvm_path/bin"}"


### PR DESCRIPTION
On my install, $rvm_prefix is same as $HOME:  /Users/dan
No trailing slash..

ruby-1.9.2-p180 @~ [21:16:09] :) $ env | grep man
rvm_man_path=/Users/danshare/man
ruby-1.9.2-p180 @~ [21:16:18] :) $ env $PATH
env: /Users/danbin:/Users/dan/.rvm/gems/ruby-1.9.2-p180/bin: .....
