### PR TITLE
Fix for the wrapper command

### DIFF
--- a/scripts/wrapper
+++ b/scripts/wrapper
@@ -89,8 +89,8 @@ symlink_binary()
   # we then symlink it into place.
   if wrap_binary && [[ -f "$file_name" ]]
   then
-    rm -f "$rvm_bin_path/${prefix}_${binary_name}"
-    ln -fs "$file_name" "$rvm_bin_path/${prefix}_${binary_name}"
+    rm -f "$rvm_bin_path/${prefix}_${binary_name##*\/}"
+    ln -fs "$file_name" "$rvm_bin_path/${prefix}_${binary_name##*\/}"
   fi
 }
 


### PR DESCRIPTION
Hello,

Short: I have the need to wrap a command with an absolute path.
This happens when you want to wrap a command that is not in $PATH.

It looked like the wrapper script handled this usecase in most of the code but the symlink code. So I copied the previous paradigm across.

I tested with an absolute path, and a path that is in a gem.

Please let me know if I missed a test case or if you would like this solved in a different way.
Also point me to any test cases I need to write. I couldn't find any.

Thanks for the great product,
Keenan
