### PR TITLE
add libxslt to notes for yum-based 

### DIFF
--- a/scripts/notes
+++ b/scripts/notes
@@ -98,7 +98,7 @@ dependencies:
     printf "
 dependencies:
   # For RVM
-  rvm: yum install -y bash curl git # NOTE: For git you need the EPEL repository enabled
+  rvm: yum install -y bash curl git libxslt # NOTE: For git you need the EPEL repository enabled
 
   # For Ruby (MRI & Ree) you should install the following OS dependencies:
   ruby: yum install -y gcc-c++ patch readline readline-devel zlib zlib-devel libyaml-devel libffi-devel openssl-devel ;


### PR DESCRIPTION
libxslt needed (at least) in CentOS 5.6.  No effect if already installed.
