### PR TITLE
use TMPDIR value or /tmp by default

### DIFF
--- a/scripts/cli
+++ b/scripts/cli
@@ -831,9 +831,10 @@ rvm()
       then
         shift
       fi
-      \cp -f "$rvm_scripts_path/get" /tmp/$$
-      "/tmp/$$" $rvm_ruby_args
-      \rm -f /tmp/$$
+      tmpdir=${TMPDIR:-/tmp}
+      \cp -f "$rvm_scripts_path/get" $tmpdir/$$
+      "$tmpdir/$$" $rvm_ruby_args
+      \rm -f $tmpdir/$$
       ;;
 
     help|rtfm|env|current|info|list|gemdir|gemhome|gempath|monitor|notes|package)


### PR DESCRIPTION
use TMPDIR value or /tmp by default. This will allow to update rvm when /tmp is mounted with noexec flag
