### PR TITLE
Fix error message to be more clear

### DIFF
--- a/scripts/gemsets
+++ b/scripts/gemsets
@@ -145,6 +145,12 @@ gemset_create()
   gemsets=(${args[@]})
   for gemset in "${gemsets[@]}"
   do
+    if [[ "$(__rvm_environment_identifier)" == "system" ]]
+    then
+      rvm_error "Can not create gemset before using a ruby.  Try 'rvm use <some ruby>'."
+      return 1
+    fi
+
     if [[ "$gemset" == *"${rvm_gemset_separator:-"@"}"* ]]
     then
       rvm_error "Can not create gemset '$gemset', it contains a \"${rvm_gemset_separator:-"@"}\"."


### PR DESCRIPTION
- Previously, if you did 'gemset create foo' before having done 'use
  ruby', you would see a permission denied error followed by an incorrect
  success message.  Now rvm properly bails with a helpful error saying
  what to do.
