### PR TITLE
Escape grep while checking for function definition.

### DIFF
--- a/scripts/rvm
+++ b/scripts/rvm
@@ -72,7 +72,7 @@ fi
 
 if [[ -n "${BASH_VERSION:-}" ]]
 then
-  if type rvm 2>&1 | grep 'function' >/dev/null
+  if type rvm 2>&1 | \grep 'function' >/dev/null
   then
     rvm_loaded_flag=1
   else
@@ -80,7 +80,7 @@ then
   fi
 elif [[ -n "${ZSH_VERSION:-}" ]]
 then
-  if type rvm 2>&1 | grep 'function' >/dev/null
+  if type rvm 2>&1 | \grep 'function' >/dev/null
   then
     rvm_loaded_flag=1
   else


### PR DESCRIPTION
Some people have ack-grep aliased to grep which has different exit
codes. This will mess up the detection and not produce the desired
results.

This has already been done in a few places. These two were not and they messed up my setup. 
