### PR TITLE
scripts/md5 on Cygwin

### DIFF
--- a/scripts/md5
+++ b/scripts/md5
@@ -11,12 +11,11 @@ file="${args[0]}"
 md5="${args[1]}"
 args="$(echo ${args[@]:2}) " # Strip trailing / leading / extra spacing.
 
-if [[ "$MACHTYPE" =~ linux ]]
-then
-  command="md5sum"
-elif [[ "$MACHTYPE" =~ darwin ]]
+if [[ "$MACHTYPE" =~ darwin ]]
 then
   command="/sbin/md5 -q"
+else
+  command="md5sum"
 fi
 
 file_md5=$($command "$file" | awk '{print $1}')


### PR DESCRIPTION
Making md5sum the default executable, to fix an issue on Cygwin, which doesn't have a correctly formatted MACHTYPE.
