### PR TITLE
rvm_user_install_flag is not set in initialize

### DIFF
--- a/scripts/initialize
+++ b/scripts/initialize
@@ -26,6 +26,17 @@ command -v __rvm_load_rvmrc >/dev/null 2>&1 || \
 # configurable by the end users for whatever their needs may be.
 # They should be set in /etc/rvmrc and then $HOME/.rvmrc
 #
+if [[ -z "${rvm_user_install_flag:-}" ]]
+then
+  if (( UID == 0 )) ||
+    [[ -n "${rvm_prefix:-}" && "${rvm_prefix:-}" != "${HOME}" ]]
+  then
+    rvm_user_install_flag=0
+  else
+    rvm_user_install_flag=1
+  fi
+fi
+
 if (( ${rvm_user_install_flag:=0} == 0 ))
 then
   true "${rvm_bin_path:="${rvm_prefix}/bin"}"


### PR DESCRIPTION
scripts/initialize did not set rvm_user_install_flag so because __rvm_teardown unset it the value would get lost after the first call to the rvm shell function.
This in turn caused rvm_bin_path to have an incorrect value.

I have simply copied the code to set rvm_user_install_flag over from scripts/rvm
