### PR TITLE
project .rvmrc trust based on file contents, as well as path

### DIFF
--- a/scripts/functions/installer
+++ b/scripts/functions/installer
@@ -176,6 +176,9 @@ Upgrade Notes
 
   * rvm_trust_rvmrcs has been changed to rvm_trust_rvmrcs_flag for consistency
 
+  * Project rvmrc files are now checked for trust whenever they change, as promised by
+    the note displayed during the review process
+
   * Ruby package dependency list for your OS is given by:
     rvm notes
 
@@ -421,6 +424,11 @@ setup_configuration_files()
       touch user/rvmrcs
     fi
   fi
+
+  # Prune old (keyed-by-hash) trust entries
+  grep '^_' user/rvmrcs > user/rvmrcs.new
+  mv user/rvmrcs.new user/rvmrcs
+
   popd >/dev/null
 }
 

--- a/scripts/functions/rvmrc
+++ b/scripts/functions/rvmrc
@@ -30,12 +30,7 @@ __rvm_md5_for_contents()
 
 __rvm_rvmrc_key()
 {
-  if [[ ${rvm_always_trust_rvmrc_flag:-0} -eq 1 ]]; then
-    printf "$1"
-  else
-    __rvm_md5_for "$1"
-  fi
-
+  printf "$1" | tr '[#/.=]' _
   return $?
 }
 


### PR DESCRIPTION
This change changes the project rvmrc logic:
1. "Trust" is determined based on file contents, as well as path.
2. A new trust state ("contains unreviewed changes") is now discernible by "rvm rvmrc trusted"

As discussed in the Google Group, http://z.pist0s.ca/wPt 

Note that this will force all users to re-approve their existing approvals. Existing approvals will be described as "unreviewed changes" in "rvm rvmrc trusted". The prompt associated with the automated trust verification already claims it will reprompt "if file contents change," which is not actually true in the current release, but becomes true with these changes.

A large Release Notes comment therefore seems in order.
