### PR TITLE
changed each option sequence. unexpected error will not occur to run 'package install zlib' on Mac OS X.

### DIFF
--- a/scripts/functions/build
+++ b/scripts/functions/build
@@ -15,7 +15,7 @@ __rvm_setup_compile_environment()
     rvm_configure_env+=("CXXFLAGS='$architectures -g -Os -pipe'")
     rvm_configure_env+=("LDFLAGS='$architectures -bind_at_load'")
     rvm_configure_env+=(
-    "LDSHARED='$architectures cc -dynamiclib -undefined suppress -flat_namespace'"
+    "LDSHARED='cc $architectures -dynamiclib -undefined suppress -flat_namespace'"
     )
   fi
   rvm_configure_env="${rvm_configure_env[*]}"


### PR DESCRIPTION
changed each option sequence. unexpected error won't occur to run 'package install zlib' on Mac OS X 10.6.
"ERROR: Error running '/_/make install', please read /_/make.install.log"
