### PR TITLE
Minor FreeBSD fixes

### DIFF
--- a/scripts/functions/installer
+++ b/scripts/functions/installer
@@ -418,7 +418,7 @@ install_rvm_hooks()
         __rvm_rm_rf "$rvm_path/$entry"
       fi
       # Source is first level hook (after_use) and target is custom user hook, preserve it
-      if echo "$entry" | \grep -Eq '^hooks/[a-Z]+_[a-Z]+$' &&
+      if echo "$entry" | \grep -Eq '^hooks/[[:alpha:]]+_[[:alpha:]]+$' &&
         [[ -f "$rvm_path/$entry" ]] &&
         ! grep -q "$(basename ${entry})_\*" "$rvm_path/$entry"
       then


### PR DESCRIPTION
Tiny fix for "pw groupadd" syntax on FreeBSD - the "-q" must come after the group name, or the group doesn't get created.

Also, apparently, FreeBSD's grep doesn't like [a-Z] as a range.  Tested against Ubuntu and CentOS to verify that proposed fix doesn't break there.  It's unclear to me if you might want the regexp to be '^hooks/([[:alpha:]]+_)+[[:alpha:]]+$' instead, to match things like "hooks/after_use_jruby".

Thanks!
