### PR TITLE
Fixed rvm.sh setting path for global installs.

### DIFF
--- a/scripts/functions/installer
+++ b/scripts/functions/installer
@@ -928,7 +928,7 @@ if [ -n \"\${BASH_VERSION:-}\" -o -n \"\${ZSH_VERSION:-}\" ] ; then
     source \"\$HOME/.rvm/scripts/rvm\"
 
   elif [[ -s \"/usr/local/rvm/scripts/rvm\" ]] ; then
-    true \${rvm_path:=\"/usr/local/rvm/scripts/rvm\"}
+    true \${rvm_path:=\"/usr/local/rvm\"}
     source \"/usr/local/rvm/scripts/rvm\"
   fi
 


### PR DESCRIPTION
Before this patch, when opening a new shell I would get the following error:

$rvm_path (/usr/local/rvm/scripts/rvm) does not exist.
