### PR TITLE
Add a note/warning about gcc vs llvm on Lion

### DIFF
--- a/scripts/notes
+++ b/scripts/notes
@@ -153,6 +153,11 @@ then
 
   printf "
   Notes for ${system} $release
+    For Lion, Rubies should be built using gcc rather than llvm-gcc. Since
+    /usr/bin/gcc is now linked to /usr/bin/llvm-gcc-4.2, add the following to
+    your shell's start-up file: export CC=gcc-4.2
+    (The situation with LLVM and Ruby may improve. This is as of 07-23-2011.)
+
     For Snow Leopard be sure to have Xcode Tools Version 3.2.1 (1613) or later
     You should download the latest Xcode tools from developer.apple.com.
       (This is since the dvd install for Snow Leopard contained bugs).


### PR DESCRIPTION
This is pretty brief, but we can hope people pay attention (for their own sake). Maybe also something on the website?
