### PR TITLE
Fix CLI help

### DIFF
--- a/docs/rvm.txt
+++ b/docs/rvm.txt
@@ -202,7 +202,7 @@ ACTIONS
     Show currently installed rubies, interactive output.
     http://rvm.beginrescueend.com/rubies/list/
 
-*package*::
+*pkg*::
     Install a dependency package {readline,iconv,zlib,openssl}.
     http://rvm.beginrescueend.com/packages/
 


### PR DESCRIPTION
Noted that the CLI help referred to rvm package, which appears to no longer work. Since it's now rvm pkg, updated the CLI help to reflect that.
