### PR TITLE
Update README

### DIFF
--- a/README
+++ b/README
@@ -109,7 +109,7 @@ environments and switching between them.
   fetch      - Performs an archive / src fetch only of the selected ruby.
   list       - show currently installed rubies, interactive output.
                http://rvm.beginrescueend.com/rubies/list/
-  package    - Install a dependency package {readline,iconv,zlib,openssl}
+  pkg        - Install a dependency package {readline,iconv,zlib,openssl}
                http://rvm.beginrescueend.com/packages/
   notes      - Display notes, with operating system specifics.
 


### PR DESCRIPTION
I've had problems when use following command.

``` bash
rvm package install readline
```

This command returns:

```
ERROR: Unrecognized command line argument: 'package' ( see: 'rvm usage' )
```

I use pkg instead of package on README.

Thanks.
