### PR TITLE
Ignore certificates for https curl download.

### DIFF
--- a/scripts/fetch
+++ b/scripts/fetch
@@ -53,11 +53,11 @@ if ! command -v curl > /dev/null ; then
 
 elif [[ ! -z ${rvm_proxy} ]] ; then
 
-  fetch_command="curl -x${rvm_proxy} -f -L --create-dirs -C - " # -s for silent
+  fetch_command="curl -k -x${rvm_proxy} -f -L --create-dirs -C - " # -s for silent
 
 else
 
-  fetch_command="curl -f -L --create-dirs -C - " # -s for silent
+  fetch_command="curl -k -f -L --create-dirs -C - " # -s for silent
 
 fi
 

--- a/scripts/functions/developer
+++ b/scripts/functions/developer
@@ -26,7 +26,7 @@ rvmselect()
 
   if [[ ! -d "${rvm_path}.${name}" ]]
   then
-    bash < <(curl -s https://rvm.beginrescueend.com/install/rvm)
+    bash < <(curl -k -s https://rvm.beginrescueend.com/install/rvm)
     mv "${rvm_path}" "${rvm_path}.${name}"
   fi
 

--- a/scripts/get
+++ b/scripts/get
@@ -18,7 +18,7 @@ get_latest()
 
   version_url="https://rvm.beginrescueend.com/releases/stable-version.txt"
 
-  stable_version=$(curl -s -B $version_url)
+  stable_version=$(curl -k -s -B $version_url)
 
   rvm_log "\nOriginal installed RVM version:"
   (__rvm_version)
@@ -28,7 +28,7 @@ get_latest()
 
   # NOTE: This is the content as in binscripts/rvm-update-latest
 
-  stable_version=$(curl -B $version_url 2>/dev/null)
+  stable_version=$(curl -k -B $version_url 2>/dev/null)
 
   get_version $stable_version
 }
@@ -37,13 +37,13 @@ get_version()
 {
   version="$1"
 
-  md5=$(curl -s -B https://rvm.beginrescueend.com/releases/rvm-${version}.tar.gz.md5 2>/dev/null)
+  md5=$(curl -k -s -B https://rvm.beginrescueend.com/releases/rvm-${version}.tar.gz.md5 2>/dev/null)
 
   echo "rvm-${version}"
 
   archive="$rvm_archives_path/rvm-${version}.tar.gz"
 
-  curl -L "https://rvm.beginrescueend.com/releases/rvm-${version}.tar.gz" \
+  curl -k -L "https://rvm.beginrescueend.com/releases/rvm-${version}.tar.gz" \
     -o "$archive"
   case "$(uname)" in
     Darwin|FreeBSD)

--- a/scripts/rubygems
+++ b/scripts/rubygems
@@ -65,7 +65,7 @@ rubygems_setup()
   rvm_gem_package_name="rubygems-${rvm_rubygems_version}"
   rvm_rubygems_url=$(__rvm_db "rubygems_url")
   rvm_gem_url="${rvm_rubygems_url}/${rvm_gem_package_name}.tgz"
-  # awk '/download.php/ && /tgz/' < <(curl -s http://rubyforge.org/frs/?group_id=126&release_id=45995 ) | sed -e 's#^.*href="#http://rubyforge.org#;s#">.*$##'
+  # awk '/download.php/ && /tgz/' < <(curl -k -s http://rubyforge.org/frs/?group_id=126&release_id=45995 ) | sed -e 's#^.*href="#http://rubyforge.org#;s#">.*$##'
 
   # Sanity check... If setup.rb is missing from the rubygems source path,
   # something went wrong. Cleanup, aisle 3!

--- a/scripts/selector
+++ b/scripts/selector
@@ -157,7 +157,7 @@ __rvm_select()
         rvm_ruby_repo_url="${rvm_ruby_repo_url:-$(__rvm_db "maglev_repo_url")}"
         rvm_ruby_url="${rvm_ruby_repo_url:-$(__rvm_db "maglev_repo_url")}"
         rvm_gemstone_version=$(
-            command curl -s https://raw.github.com/MagLev/maglev/master/version.txt |
+            command curl -k -s https://raw.github.com/MagLev/maglev/master/version.txt |
             grep ^GEMSTONE | cut -f2 -d-
          )
         rvm_gemstone_package_file="GemStone-${rvm_gemstone_version}.${system}-${arch}"


### PR DESCRIPTION
Hello :)

I recently got this bug. I will send you quick solution.
Better solution will be to insert certificate within the project and add it to each curl run using --crlfile.

Another solution can be informing users on site about ~/.curlrc with "insecure".
But i think that will introduce complexity for new users which you do not want at all.

Cheers,
Marcin Nowicki
