### PR TITLE
patch to prevent ruby from not compiling on archlinux systems (& other systems using glibc-2.14)

### DIFF
--- a/patches/ruby/1.8.7/stdout-rouge-fix.patch
+++ b/patches/ruby/1.8.7/stdout-rouge-fix.patch
@@ -1,0 +1,35 @@
+diff --git a/lib/mkmf.rb b/lib/mkmf.rb
+index c9e738a..7a8004d 100644
+--- a/lib/mkmf.rb
++++ b/lib/mkmf.rb
+@@ -201,20 +201,26 @@ end
+ module Logging
+   @log = nil
+   @logfile = 'mkmf.log'
+-  @orgerr = $stderr.dup
+-  @orgout = $stdout.dup
+   @postpone = 0
+   @quiet = $extmk
+ 
+   def self::open
+     @log ||= File::open(@logfile, 'w')
+     @log.sync = true
++    orgerr = $stderr.dup
++    orgout = $stdout.dup
+     $stderr.reopen(@log)
+     $stdout.reopen(@log)
+     yield
+   ensure
+-    $stderr.reopen(@orgerr)
+-    $stdout.reopen(@orgout)
++    if orgerr
++      $stderr.reopen(orgerr)
++      orgerr.close
++    end
++    if orgout
++      $stdout.reopen(orgout)
++      orgout.close
++    end
+   end
+ 
+   def self::message(*s)


### PR DESCRIPTION
added "stdout-rouge-fix.patch" to fix this problem in 1.8.7: http://redmine.ruby-lang.org/issues/5108 (i did not write the patch, i am simply providing it so others don't have to find the patch for themselves)
