### PR TITLE
fixed zsh bug when glob_subst is set in user's ~/.zshrc

### DIFF
--- a/scripts/initialize
+++ b/scripts/initialize
@@ -9,6 +9,7 @@ elif [[ -n "${ZSH_VERSION:-}" ]]
 then
   setopt extendedglob
   setopt kshglob
+  setopt no_glob_subst
 else
   printf "%s\n" "What the heck kind of shell are you running here???"
 fi


### PR DESCRIPTION
Hi,

I was having trouble after updating from rvm 1.1.6 to the latest version (1.6.32). I even tried `implode`ing and reinstalling rvm and had the same problem:

```
/Users/meqif/.rvm/scripts/initialize:44: unknown sort specifier
```

when doing `rvm reload` or opening a new zsh instance.

After some debugging with `set -x`, I found out that the rvm_\* variables in `scripts/initialize` weren't being set, even when using `set` instead of `:` (as far as I could tell, they do the same thing).

Then, after commenting and uncommenting parts of ~/.zshrc, I discovered the cuplrit: `set glob_subst`. Commenting it made rvm behave correctly. That led me to this solution, in which glob_subst is disabled only in rvm's scripts. It works correctly here.
