### PR TITLE
Improve speed of rvm install jruby by only building the necessary jars

### DIFF
--- a/scripts/functions/manage/jruby
+++ b/scripts/functions/manage/jruby
@@ -39,7 +39,7 @@ jruby_install()
   then
     __rvm_apply_patches
 
-    __rvm_run "ant.dist" "ant dist" "$rvm_ruby_string - #ant dist"
+    __rvm_run "ant.jar" "ant jar" "$rvm_ruby_string - #ant jar"
   fi
 
   mkdir -p "$rvm_ruby_home/bin/"


### PR DESCRIPTION
We dont need to depend ant dist to build jruby, ant jar is enough and a lot faster.
Also until https://jira.codehaus.org/browse/JRUBY-5968 is merged into jruby-head, jruby-head install with _ant dist_ on Mac OS X is broken.

From my initial tests everything seams to be working properly with just ant jar.
Don't know if you guys had any reason to go with dist in the past that invalidates this patch.
