### PR TITLE
fixed duplicate dependency in installation notes

### DIFF
--- a/scripts/notes
+++ b/scripts/notes
@@ -83,7 +83,7 @@ dependencies:
   rvm: bash curl git
 
   # For Ruby (MRI & Ree) you should install the following OS dependencies:
-  ruby: pacman -Sy --noconfirm gcc patch curl bison zlib readline libxml2 libxslt git autoconf diffutils patch bison make
+  ruby: pacman -Sy --noconfirm gcc patch curl bison zlib readline libxml2 libxslt git autoconf diffutils bison make
   ruby-head: pacman -Sy --noconfirm subversion
 
   # For JRuby (if you wish to use it) you will need:


### PR DESCRIPTION
When running rvm notes, it gave a duplicate dependency for 'patch'. This commit removes the duplicate dependency.
