### PR TITLE
Allow irb switches to set the prompt mode

### DIFF
--- a/scripts/irbrc.rb
+++ b/scripts/irbrc.rb
@@ -50,7 +50,7 @@ rvm_ruby_string = ENV["rvm_ruby_string"] || `rvm tools identifier`.strip.split("
 }
 IRB.conf[:PROMPT] ||= {}
 IRB.conf[:PROMPT][:RVM] = @prompt
-IRB.conf[:PROMPT_MODE] = :RVM
+IRB.conf[:PROMPT_MODE] = :RVM if IRB.conf[:PROMPT_MODE] == :DEFAULT
 
 # Load the user's irbrc file, if possible.
 # Report any errors that occur.


### PR DESCRIPTION
Emacs uses irb --inf-ruby-mode to, among other things, set a specific
prompt mode.  However, RVM's irbrc.rb was unconditionally overriding the
prompt mode.  The user could still set the prompt mode in ~/.irbrc, but
I didn't see any easy way to check if irb was called with
--inf-ruby-mode or --prompt[-mode] from irbrc, so I'd just be swapping
out one unconditional prompt mode override (:RVM) for another (e.g.
:INF_RUBY) which isn't what I wanted--I should get the nice RVM prompt
when I run irb from a shell but Emacs should also be able to get the
prompt mode it wants.

Hence this change, which only changes PROMPT_MODE if it's set to
:DEFAULT, which should be the case unless the user supplied a prompt
mode on the command line.
