### PR TITLE
Add a check to FQ rvm_path

### DIFF
--- a/binscripts/rvm-installer
+++ b/binscripts/rvm-installer
@@ -312,6 +312,11 @@ done
 
 true "${version:=head}"
 
+if [[ "$rvm_path" != /* ]]
+then
+  fail "The rvm install path must be fully qualified. Tried $rvm_path"
+fi
+
 rvm_src_path="$rvm_path/src"
 rvm_archives_path="$rvm_path/archives"
 rvm_releases_url="https://rvm.beginrescueend.com/releases"


### PR DESCRIPTION
The installer script will fail with a moderately cryptic error if
the rvm_path is not fully qualified. This is becuase the various
"cd" commands do not take their relative position into account.

A better fix would likely be to fix the "cd" calls, but this is good
enough.
