### PR TITLE
Fix for Arch Linux typo

### DIFF
--- a/contrib/bootstrap_rails_environment
+++ b/contrib/bootstrap_rails_environment
@@ -39,7 +39,7 @@ else
       sudo apt-get install build-essential bison openssl libreadline6 libreadline6-dev curl git-core zlib1g zlib1g-dev libssl-dev libyaml-dev libsqlite3-0 libsqlite3-dev sqlite3 libxml2-dev libxslt-dev autoconf libc6-dev
     elif command -v pacman
     then
-      sudo pacman -S --noconfirm gcc patch curl bison zlib readline libxml2 libxslt git autoconf diffutils patch bison make
+      sudo pacman -S --noconfirm gcc patch curl bison zlib readline libxml2 libxslt git autoconf diffutils patch make
     elif command -v yum
     then
       sudo yum install -y gcc-c++ patch readline readline-devel zlib zlib-devel libyaml-devel libffi-devel openssl-devel

--- a/scripts/notes
+++ b/scripts/notes
@@ -83,7 +83,7 @@ dependencies:
   rvm: bash curl git
 
   # For Ruby (MRI & Ree) you should install the following OS dependencies:
-  ruby: pacman -Sy --noconfirm gcc patch curl bison zlib readline libxml2 libxslt git autoconf diffutils bison make
+  ruby: pacman -Sy --noconfirm gcc patch curl bison zlib readline libxml2 libxslt git autoconf diffutils make
   ruby-head: pacman -Sy --noconfirm subversion
 
   # For JRuby (if you wish to use it) you will need:


### PR DESCRIPTION
When installing on arch linux, when looking at the required dependencies, notice there are two times bison is listed. This is also true in the "bootstrap" script touched in this commit. 

(This is my first pull request ever, apologies if I'm forgetting something).
