### PR TITLE
Correct install issues when calling from script that uses "set -o nounset

### DIFF
--- a/scripts/functions/rvmrc
+++ b/scripts/functions/rvmrc
@@ -262,7 +262,7 @@ command cat -v "${_rvmrc}"
 __rvm_project_rvmrc()
 {
   local working_dir
-  if [[ -n "${rvm_scripts_path}" || -n "${rvm_path}" ]]
+  if [[ -n "${rvm_scripts_path:+x}" || -n "${rvm_path:+x}" ]]
   then
     # TODO: ... wtf was this for?
     source "${rvm_scripts_path:-"$rvm_path/scripts"}/initialize"

--- a/scripts/rvm
+++ b/scripts/rvm
@@ -125,7 +125,7 @@ then
     # Makes sure rvm_bin_path is in PATH atleast once.
     __rvm_conditionally_add_bin_path
 
-    if (( rvm_reload_flag == 1 ))
+    if (( ${rvm_reload_flag:=0} == 1 ))
     then
       printf 'RVM reloaded!\n'
     fi

--- a/scripts/selector
+++ b/scripts/selector
@@ -890,7 +890,7 @@ __rvm_ruby_string()
   fi
 
   # Head
-  if (( rvm_head_flag == 1 ))
+  if (( ${rvm_head_flag:=0} == 1 ))
   then
     rvm_ruby_string="${rvm_ruby_string}-head"
 


### PR DESCRIPTION
Hello Wayne,

I love rvm; it's awesome.

I've written minor changes to make the installer work when called from inside a script that does "set -o nounset".

This is my first git pull request; I've tried to follow best practices :)

Thanks,

Pat
