### PR TITLE
don't download the same version that you already have

### DIFF
--- a/scripts/get
+++ b/scripts/get
@@ -14,23 +14,28 @@ get_help()
 
 get_latest()
 {
-  local version_url stable_version archive
+  local version_url stable_version archive current
 
   version_url="https://rvm.beginrescueend.com/releases/stable-version.txt"
 
   stable_version=$(curl -s -B $version_url)
 
+  current=${rvm_version}
+
   rvm_log "\nOriginal installed RVM version:"
   (__rvm_version)
 
-  [[ ! -d "$rvm_src_path" ]] && mkdir -p "$rvm_src_path/"
-  [[ ! -d "$rvm_archives_path" ]] && mkdir -p "$rvm_archives_path/"
+  if [ $stable_version != $current ]
+  then
 
-  # NOTE: This is the content as in binscripts/rvm-update-latest
+    [[ ! -d "$rvm_src_path" ]] && mkdir -p "$rvm_src_path/"
+    [[ ! -d "$rvm_archives_path" ]] && mkdir -p "$rvm_archives_path/"
 
-  stable_version=$(curl -B $version_url 2>/dev/null)
+    get_version $stable_version
 
-  get_version $stable_version
+  else
+    echo "You already have the latest version!"
+  fi
 }
 
 get_version()


### PR DESCRIPTION
Yo!

This is quite simple and just prevents the 'rvm get latest' command to download and install rvm again in case you already have the latest version.

I'm not quite sure if you'll like the way I did, but you get the idea.

Cheers.
