### PR TITLE
Duplicate invocation of `after_install` hook?

### DIFF
--- a/scripts/functions/manage/base
+++ b/scripts/functions/manage/base
@@ -1188,9 +1188,6 @@ __rvm_manage_rubies()
       unset current_ruby_string
 
       __rvm_unset_ruby_variables
-
-      rvm_hook="after_install"
-      source "$rvm_scripts_path/hook"
     done
   else # all
     if [[ "$action" != "install" && "$action" != "remove" &&


### PR DESCRIPTION
The `after_install` hook runs twice for me. After some Git history reconnaissance I discovered the first invocation was added in 9d8055d480ea28f12e8a27b21960c0289bb02de0 (actually 01b8a6d0be6c4aacf6a20431e43c31d69d8594d6), and the second one was added in 70c2d90e357d9797fb69f911c62caf96dd5f5123 alongside a `before_install` hook. The implementations appear independent.

I don't have a lot of context but this suggests to me that the duplicate dispatch is an accident. Operating under that assumption, I submit this patch which removes one of the two invocations. The newer of the two invocations lacks several environment variables (including `$rvm_ruby_home`, which I care about very much), so I chose that one to delete.

Of course, I could be way off the mark here, in which case feel free to put me in my place. :)
