### PR TITLE
Fixed typo in notes

### DIFF
--- a/scripts/notes
+++ b/scripts/notes
@@ -181,7 +181,7 @@ then
      You have installed RVM as root. You need to add users to the rvm group.
        Run the following commands as a user to make this happen
 
-     user$ sudo dscl localhost -append /Local/Default/Groups/rvm GroupMemip "$USER"\n
+     user$ sudo dscl localhost -append /Local/Default/Groups/rvm GroupMembership "\$USER"\n
      "
   fi
 fi


### PR DESCRIPTION
The instructions for Mac Users on how to add the rvm group to their account was wrong because of two typos.

first GroupMembership was missing bership

second "$USER" should have been escaped "\$USER"
