### PR TITLE
Sha256 trust

### DIFF
--- a/scripts/functions/rvmrc
+++ b/scripts/functions/rvmrc
@@ -18,8 +18,10 @@ __rvm_sha256_for()
 {
   if command -v sha256sum > /dev/null ; then
     echo "$1" | sha256sum | awk '{print $1}'
+  elif command -v shasum > /dev/null ; then
+    echo "$1" | shasum -a256 | awk '{print $1}'
   else
-    rvm_error "sha256 not found in the PATH"
+    rvm_error "Neither sha256sum nor shasum found in the PATH"
     return 1
   fi
 
@@ -47,8 +49,10 @@ __rvm_sha256_for_contents()
   if command -v sha256sum > /dev/null
   then
     echo "$1" | cat - "$1" | sha256sum | awk '{print $1}'
+  elif command -v shasum > /dev/null ; then
+    echo "$1" | cat - "$1" | shasum -a256 | awk '{print $1}'
   else
-    rvm_error "sha256sum not found in the PATH"
+    rvm_error "Neither sha256sum nor shasum found in the PATH"
     return 1
   fi
 


### PR DESCRIPTION
Hi Wayne,

I use rvm a lot at work btw. Thanks.

However, md5 has been repeatedly proven to be a weak alogorithm cryptographically. I can't find the paper at the moment, but a great example was the group who claimed to know who would win the next presidential election. Without wanting to specify who, they said they'd release the checksum now and the paper after the election. Clearly, they had multiple documents with the same md5 sum, but the gist of their research was proof of md5's insecurities.

By requiring the rvmrc's to pass both md5 and sha256 verification, the potential for collision becomes infinitessimally small, for a tiny performance hit, considering how often they are generally checked.

The test suite does not pass on my machine (either on master or my branch) but the same tests fail either way.

Let me know if there's anything you'd prefer implemented differently.

Cheers

richo
