### PR TITLE
Remove extraneous messages

### DIFF
--- a/scripts/functions/installer
+++ b/scripts/functions/installer
@@ -115,9 +115,6 @@ upgrade_notes()
 
 Upgrade Notes
 
-  * Set rvm_project_rvmrc=1 to enable project switching on cd, note that this
-    will override cd with a function (bash) and/or hook into it (zsh)
-
   * rvm_trust_rvmrcs has been changed to rvm_trust_rvmrcs_flag for consistency
 
   * Project rvmrc files are now checked for trust whenever they change, as
@@ -136,9 +133,6 @@ Upgrade Notes
     the custom hooks can be easily turned on/off by:
       chmod +x $rvm_path/hooks/after_use_[hook_name]
       chmod -x $rvm_path/hooks/after_use_[hook_name]
-
-  * Set rvm_project_rvmrc=1 to enable project switching on cd, note that this
-    will override cd with a function (bash) and/or hook into it (zsh)
 "
 }
 


### PR DESCRIPTION
At the moment the post install message still mentions that you need to  Set rvm_project_rvmrc=1 to enable project switching on cd

Which isn't the case in 1.8

I didn't make a topic branch because it's a very linear change without functional changes.
