### PR TITLE
Add 'cancel' support for trusting RVMRC files

### DIFF
--- a/scripts/functions/rvmrc
+++ b/scripts/functions/rvmrc
@@ -253,7 +253,7 @@ __rvm_ask_to_trust()
   while (( ! trusted ))
   do
     printf "Do you wish to trust this .rvmrc file? (%s)\n" "${_rvmrc}"
-    printf "%s" 'y[es], n[o], v[iew]> '
+    printf "%s" 'y[es], n[o], v[iew], c[ancel]> '
 
     read response
 
@@ -268,6 +268,9 @@ __rvm_ask_to_trust()
       ;;
       n|no)
         break
+      ;;
+      c|cancel)
+        return 0
       ;;
     esac
   done


### PR DESCRIPTION
Sometimes I'm indecisive and end up closing the Terminal window rather than making a damn decision - e.g. temporary directories I don't want cluttering the list of trusted/untrusted files, .rvmrc files I know are wrong and may cause issues, etc. All it does if you choose (c|cancel) is return 0 from __rvm_ask_to_trust.
