### PR TITLE
FIX: build readline on mac os x lion

### DIFF
--- a/patches/readline-6.2/patch-shobj-conf.diff
+++ b/patches/readline-6.2/patch-shobj-conf.diff
@@ -1,0 +1,41 @@
+--- support/shobj-conf.orig	2009-10-29 00:20:21.000000000 +1100
++++ support/shobj-conf	2011-03-24 13:43:03.000000000 +1100
+@@ -157,19 +157,19 @@
+ 	;;
+ 
+ # Darwin/MacOS X
+-darwin[89]*|darwin10*)
++darwin[89]*|darwin1[0-9]*)
+ 	SHOBJ_STATUS=supported
+ 	SHLIB_STATUS=supported
+ 	
+ 	SHOBJ_CFLAGS='-fno-common'
+ 
+-	SHOBJ_LD='MACOSX_DEPLOYMENT_TARGET=10.3 ${CC}'
++	SHOBJ_LD='${CC}'
+ 
+ 	SHLIB_LIBVERSION='$(SHLIB_MAJOR)$(SHLIB_MINOR).$(SHLIB_LIBSUFF)'
+ 	SHLIB_LIBSUFF='dylib'
+ 
+-	SHOBJ_LDFLAGS='-dynamiclib -dynamic -undefined dynamic_lookup -arch_only `/usr/bin/arch`'
+-	SHLIB_XLDFLAGS='-dynamiclib -arch_only `/usr/bin/arch` -install_name $(libdir)/$@ -current_version $(SHLIB_MAJOR)$(SHLIB_MINOR) -compatibility_version $(SHLIB_MAJOR) -v'
++	SHOBJ_LDFLAGS='-dynamiclib -dynamic -undefined dynamic_lookup'
++	SHLIB_XLDFLAGS='-dynamiclib -install_name $(libdir)/$@ -current_version $(SHLIB_MAJOR)$(SHLIB_MINOR) -compatibility_version $(SHLIB_MAJOR) -v'
+ 
+ 	SHLIB_LIBS='-lncurses'	# see if -lcurses works on MacOS X 10.1 
+ 	;;
+@@ -186,11 +186,11 @@
+ 	SHLIB_LIBSUFF='dylib'
+ 
+ 	case "${host_os}" in
+-	darwin[789]*|darwin10*)	SHOBJ_LDFLAGS=''
+-			SHLIB_XLDFLAGS='-dynamiclib -arch_only `/usr/bin/arch` -install_name $(libdir)/$@ -current_version $(SHLIB_MAJOR)$(SHLIB_MINOR) -compatibility_version $(SHLIB_MAJOR) -v'
++	darwin[789]*|darwin1[0-9]*)	SHOBJ_LDFLAGS=''
++			SHLIB_XLDFLAGS='-dynamiclib -install_name $(libdir)/$@ -current_version $(SHLIB_MAJOR)$(SHLIB_MINOR) -compatibility_version $(SHLIB_MAJOR) -v'
+ 			;;
+ 	*)		SHOBJ_LDFLAGS='-dynamic'
+-			SHLIB_XLDFLAGS='-arch_only `/usr/bin/arch` -install_name $(libdir)/$@ -current_version $(SHLIB_MAJOR)$(SHLIB_MINOR) -compatibility_version $(SHLIB_MAJOR) -v'
++			SHLIB_XLDFLAGS='-install_name $(libdir)/$@ -current_version $(SHLIB_MAJOR)$(SHLIB_MINOR) -compatibility_version $(SHLIB_MAJOR) -v'
+ 			;;
+ 	esac
+ 

--- a/scripts/functions/pkg
+++ b/scripts/functions/pkg
@@ -105,8 +105,8 @@ readline()
   patches="$rvm_patches_path/$package-$version/shobj-conf.patch"
   install_package
 
-  version="6.0"
-  patches=""
+  version="6.2"
+  patches="$rvm_patches_path/$package-$version/patch-shobj-conf.diff"
   install_package
 }
 


### PR DESCRIPTION
This fixes building readline under Lion using `rvm pkg`.  Also bumped readline to v.6.2.

Both Homebrew and MacPorts had patches for this.  I went with the latter as it was more "accurate."  

https://trac.macports.org/browser/trunk/dports/devel/readline/files/patch-shobj-conf.diff
