### PR TITLE
OpenIndiana/OpenSolaris Support

### DIFF
--- a/scripts/functions/installer
+++ b/scripts/functions/installer
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+#Handle Solaris Hosts
+if [ "`uname -sr`" = "SunOS 5.11" ]; 
+	then export PATH="/usr/gnu/bin:$PATH";
+fi;
+
+
 install_setup()
 {
   set -o errtrace

--- a/scripts/install
+++ b/scripts/install
@@ -5,6 +5,11 @@ set -o errtrace
 PATH="/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:/usr/local/sbin:$PATH"
 export PS4 PATH
 
+#Handle Solaris Hosts
+if [ "`uname -sr`" = "SunOS 5.11" ]; 
+	then export PATH="/usr/gnu/bin:$PATH";
+fi;
+
 if [[ "$*" =~ --trace ]] || (( ${rvm_trace_flag:-0} > 0 ))
 then # Tracing, if asked for.
   set -o xtrace


### PR DESCRIPTION
Added a conditional check for solaris hosts and appended the corrent path

Hey guys, Im not a bash scripting guru, but I added a conditional check for solaris 5.11, so rvm can be used when the proper gnu-packages are installed. Please let me know what you think? maybe even simplify this. I would just like to see this working on solaris hosts. This was only testing on OpenIndiana build 151. worked fine.

Thanks

these are the needed packages from OpenIndiana.

pkg install gnu-coreutils
pkg install gcc-3
pkg install gawk
pkg install gnu-grep
pkg install gnu-findutils
pkg install gnu-patch
pkg install autoconf
pkg install gnu-tar
