### PR TITLE
Remove patchlevel related code, Rubinius doesn't use them

### DIFF
--- a/scripts/selector
+++ b/scripts/selector
@@ -80,12 +80,8 @@ __rvm_select()
       rvm_ruby_repo_url=${rvm_rbx_repo_url:-$(__rvm_db "rubinius_repo_url")}
       rbx_url=${rbx_url:-$(__rvm_db "rbx_url")}
       rvm_ruby_url="${rbx_url}"
+      rvm_ruby_patch_level=""
 
-      #
-      # rbx,rbx-head => master
-      # rbx-* => * is a remote branch, eg rbx-master, rbx-2.0pre
-      # rbx-t1.2.3 => tag 1.2.3 of master branch
-      #
       if [[ "${rvm_ruby_version}" == "2.0pre" ]]
       then
         rvm_ruby_repo_branch="hydra"
@@ -93,18 +89,9 @@ __rvm_select()
 
       if (( ${rvm_head_flag:=0} == 0 ))
       then
-        rvm_ruby_patch_level=${rvm_ruby_patch_level:-$(
-        __rvm_db "rbx_patch_level"
-        )}
-        rvm_ruby_string="${rvm_ruby_string/-prc/-rc}"
-        rvm_ruby_string="$(echo "$rvm_ruby_string" | \sed 's#-p*#-#')"
-        rvm_ruby_package_file="$(
-        echo "rubinius-${rvm_ruby_version}${rvm_ruby_patch_level:+-}${rvm_ruby_patch_level}.${rvm_archive_extension}" |
-        \sed 's#-p*#-#'
-        )"
+        rvm_ruby_package_file="rubinius-${rvm_ruby_version}.${rvm_archive_extension}"
         rvm_ruby_url="$rvm_ruby_url/$rvm_ruby_package_file"
       else
-        rvm_ruby_patch_level=""
         rvm_ruby_version="head"
       fi
 


### PR DESCRIPTION
I think this code was copy and pasted from when Rubinius was added. Rubinius will never release with patchlevels, so the code is unnecessary.
