### PR TITLE
Update install logic for maglev-head

### DIFF
--- a/scripts/functions/manage/maglev
+++ b/scripts/functions/manage/maglev
@@ -114,7 +114,7 @@ maglev_install()
     ln -fs maglev.demo.key-${system}-${arch} etc/maglev.demo.key
 
     rvm_log "Bootstrapping a new image"
-    "$rvm_wrappers_path/$compatible_ruby/rake" "build:image"
+    "$rvm_wrappers_path/$compatible_ruby/rake" "build:maglev"
   fi
 
   if [[ ! -e ${rvm_ruby_home}/etc/conf.d/maglev.conf ]]


### PR DESCRIPTION
Adds a bootstrapping step. New maglev releases need to run this to create a fresh ruby image with the most current smalltalk code.
