### PR TITLE
Copy maglev shipped gems

### DIFF
--- a/scripts/functions/manage/maglev
+++ b/scripts/functions/manage/maglev
@@ -126,6 +126,13 @@ maglev_install()
   rvm_log "Generating smalltalk FFI."
   "$rvm_wrappers_path/$compatible_ruby/rake" stwrappers >/dev/null 2>&1
 
+  # maglev ships with some built in gems, copy them in to place.
+  if [[ -d "$rvm_ruby_home/lib/maglev/gems/1.8" ]]
+  then
+    rvm_log "Copying across included gems"
+    cp -R "$rvm_ruby_home/lib/maglev/gems/1.8/" "$rvm_ruby_gem_home/"
+  fi
+
   unset compatible_ruby
 
   # MagLev comes with RubyGems preinstalled -- don't try to install it


### PR DESCRIPTION
maglev (like jruby) ships with some gems, so copy those across when installing
