### PR TITLE
rvm applies patches with -p1 so set the prefix in the gcdata.patch to mat

### DIFF
--- a/patches/ruby/1.9.2/p290/gcdata.patch
+++ b/patches/ruby/1.9.2/p290/gcdata.patch
@@ -1,7 +1,7 @@
 Index: gc.c
 ===================================================================
---- gc.c	(revision 32826)
-+++ gc.c	(working copy)
+--- a/gc.c	(revision 32826)
++++ b/gc.c	(working copy)
 @@ -291,16 +291,12 @@
      struct gc_list *next;
  };


### PR DESCRIPTION
patch wasn't applying cleanly, this fixes it
