### PR TITLE
Always fetch when running install maglev-head

### DIFF
--- a/scripts/functions/manage/maglev
+++ b/scripts/functions/manage/maglev
@@ -23,7 +23,7 @@ maglev_install()
   [ "${system}-${arch}" == "Darwin-x86_64" ] && arch="i386"
 
   true ${rvm_force_flag:=0}
-  if [[ ! -d "${rvm_src_path}/$rvm_ruby_string" ]] || (( rvm_force_flag == 1 ))
+  if [[ ! -d "${rvm_src_path}/$rvm_ruby_string" ]] || (( rvm_force_flag == 1 )) || (( ${rvm_head_flag:=0} == 1 ))
   then
     __rvm_rm_rf "${rvm_src_path}/$rvm_ruby_string/"
 


### PR DESCRIPTION
Right now, maglev-head is never updated on consecutive runs of rvm install maglev-head. This is different from the behaviour for the other impls "-heads".
