### PR TITLE
install_package(): added tar -m option. 

### DIFF
--- a/scripts/functions/pkg
+++ b/scripts/functions/pkg
@@ -20,7 +20,7 @@ install_package()
           || (result=$? && return $result)
 
         __rvm_run "$package/extract" \
-          "tar zxf $rvm_archives_path/$package-$version.$archive_format -C $rvm_src_path --no-same-owner" \
+          "tar mzxf $rvm_archives_path/$package-$version.$archive_format -C $rvm_src_path --no-same-owner" \
           "Extracting $package-$version.$archive_format to $rvm_src_path"
         ;;
 
@@ -31,7 +31,7 @@ install_package()
           || (result=$? && return $result)
 
         __rvm_run "$package/extract" \
-          "tar jxf $rvm_archives_path/$package-$version.$archive_format -C $rvm_src_path --no-same-owner "\
+          "tar mjxf $rvm_archives_path/$package-$version.$archive_format -C $rvm_src_path --no-same-owner "\
           "Extracting $package-$version.$archive_format to $rvm_src_path"
 
         ;;


### PR DESCRIPTION
Hello guys,

This request include fix for error "**Can't update time for yaml-0.1.4**" on OS X 10.7.2.

$ cat /usr/local/rvm/log/ruby-1.9.3-p0/yaml/extract.log

``` console
tar zxf /usr/local/rvm/archives/yaml-0.1.4.tar.gz -C /usr/local/rvm/src --no-same-owner

yaml-0.1.4/: Can't update time for yaml-0.1.4
yaml-0.1.4/tests/: Can't update time for yaml-0.1.4/tests
yaml-0.1.4/include/: Can't update time for yaml-0.1.4/include
yaml-0.1.4/config/: Can't update time for yaml-0.1.4/config
yaml-0.1.4/doc/: Can't update time for yaml-0.1.4/doc
yaml-0.1.4/doc/html/: Can't update time for yaml-0.1.4/doc/html
yaml-0.1.4/src/: Can't update time for yaml-0.1.4/src
yaml-0.1.4/win32/: Can't update time for yaml-0.1.4/win32
yaml-0.1.4/win32/vs2003/: Can't update time for yaml-0.1.4/win32/vs2003
yaml-0.1.4/win32/vc6/: Can't update time for yaml-0.1.4/win32/vc6
yaml-0.1.4/win32/vs2008/: Can't update time for yaml-0.1.4/win32/vs2008
tar: Error exit delayed from previous errors.
```

**-m** (x mode only) Do not extract modification time.  By default, the modification time is set to the time stored in the archive.

Cheers
