### PR TITLE
Added __rvm_setup to scripts/rvm

### DIFF
--- a/scripts/rvm
+++ b/scripts/rvm
@@ -107,6 +107,7 @@ then
         RVM will likely not work as expected.\n"
       fi
     done
+    __rvm_setup
 
     rvm_version="$(cat "$rvm_path/VERSION")"
 
@@ -139,6 +140,8 @@ then
   fi
   unset rvm_prefix_needs_trailing_slash rvm_rc_files rvm_gems_cache_path \
     rvm_gems_path rvm_project_rvmrc_default rvm_gemset_separator
+else
+  __rvm_setup
 fi
 
 if [[ -t 0 ]] && (( ${rvm_project_rvmrc:-1} > 0 )) && command -v __rvm_project_rvmrc >/dev/null  2>&1


### PR DESCRIPTION
`__rvm_setup` and `__rvm_teardown` are two great methods, but they kinda need each other to work properly.

I added a `__rvm_setup` call to `scripts/rvm`, since it was missing. 
