### PR TITLE
rvm get head: tmpfs defaults to noexec in /tmp

### DIFF
--- a/scripts/cli
+++ b/scripts/cli
@@ -835,7 +835,7 @@ rvm()
       fi
       tmpdir=${TMPDIR:-/tmp}
       \cp -f "$rvm_scripts_path/get" $tmpdir/$$
-      "$tmpdir/$$" $rvm_ruby_args
+      "$SHELL" "$tmpdir/$$" $rvm_ruby_args
       \rm -f $tmpdir/$$
       rvm_reload_flag=1
       ;;


### PR DESCRIPTION
I have a ramdisk (tmpfs) mounted as /tmp and it defaults to disallowing
execution of anything inside it.  This patch explictly uses the current
$SHELL to execute the temporary file rather than relying on the shebang
line of that file to bootstrap its execution.
