### PR TITLE
hooks/after_use now checks that after_use_* files are readable (-r) instead of executable (-x)

### DIFF
--- a/hooks/after_use
+++ b/hooks/after_use
@@ -6,7 +6,7 @@ after_use_hooks=($(
 
 for after_use_hook in "${after_use_hooks[@]}"
 do
-  if [[ -x "${after_use_hook}" ]]
+  if [[ -r "${after_use_hook}" ]]
   then
     __rvm_conditionally_do_with_env . "${after_use_hook}"
   fi


### PR DESCRIPTION
This fixes a bug related to using jruby with version 1.9.

The setup:
rvm get head
rvm install jruby
cd ~/workspace
mkdir -p ~/workspace/rvm-jruby
cd ~/workspace/rvm-jruby
rvm use jruby@rvm-jruby --create --rvmrc
ruby -pi -e 'gsub(/^# (PROJECT_JRUBY_OPTS)/, "\1")' .rvmrc
cd ..
cd rvm-jruby
# type 'y' to trust the .rvmrc file
# The symptoms:

$ echo $JRUBY_OPTS

$ jruby --version
jruby 1.6.5 (ruby-1.8.7-p330) (2011-10-25 9dcd388) (Java HotSpot(TM) 64-Bit Server VM 1.6.0_26) [darwin-x86_64-java]
# the fix:
# edit ~/.rvm/hooks/after_use to test -r instead of -x

$ echo $JRUBY_OPTS 
--ng --1.9
$ jruby --version
jruby 1.6.5 (ruby-1.9.2-p136) (2011-10-25 9dcd388) (Java HotSpot(TM) 64-Bit Server VM 1.6.0_26) [darwin-x86_64-java]

Eric
