### PR TITLE
Use 'rvm do gem' in gemset_rename.

### DIFF
--- a/scripts/gemsets
+++ b/scripts/gemsets
@@ -459,7 +459,7 @@ gemset_rename()
     return 1
   fi
 
-  source_path="$(rvm_silence_logging=1 rvm "@$source_name" gem env gemdir)"
+  source_path="$(rvm_silence_logging=1 rvm "@$source_name" do gem env gemdir)"
 
   if [[ -z "$source_path" || ! -d "$source_path" ]]
   then


### PR DESCRIPTION
`rvm gemset rename` is currently busted on master.  This is because `rvm @blah gem` emits a warning regarding switching to `rvm @blah do gem` in `gemset_rename()`.  This request switches the code to use `rvm do` to silence the offending warning.
