### PR TITLE
Small addition to the project .rvmrc template so it displays the gem path they are using after it runs. Helpful reminder for those of us who switch between projects frequently.

### DIFF
--- a/scripts/functions/rvmrc
+++ b/scripts/functions/rvmrc
@@ -473,6 +473,12 @@ fi
 #   bundle install
 # fi
 
+if [[ \$- == *i* ]] # check for interactive shells
+then
+    echo \"Using: \$(tput setaf 2)\$GEM_HOME\$(tput sgr0)\" # show the user the ruby and gemset they are using in green
+else 
+	echo \"Using: \$GEM_HOME\" # don't use colors in interactive shells
+fi
 
 " >> .rvmrc
 


### PR DESCRIPTION
...and gemset they are using by displaying the gem path. Displays in green for non-interactive shells.
