### PR TITLE
Tiny doc fix.

### DIFF
--- a/scripts/functions/installer
+++ b/scripts/functions/installer
@@ -119,7 +119,7 @@ fork the project and issue a pull request.
 If you wish to disable the project .rvmrc file functionality, set
 rvm_project_rvmrc=0 in either /etc/rvmrc or ~/.rvmrc.
 
-NOTE: To Multi-User installers, please do NOT forget to add your users to the 'rvm'.
+NOTE: To Multi-User installers, please do NOT forget to add your users to the 'rvm' group.
   The installer no longer auto-adds root or users to the rvm group. Admins must do this.
   Also, please note that group memberships are ONLY evaluated at login time.
   This means that users must log out then back in before group membership takes effect!


### PR DESCRIPTION
I found a tiny error in a documentation/note string in scripts/functions/installer and fixed it.

You might also wanna sync the paragraphs in scripts/functions/installer with scripts/requirements since they seem really similar. Use this to find the similar-but-not-same paragraphs:
$ git grep "forget to add your users to"

And by the way THANKS for making rvm awesome!
