### PR TITLE
escape the special characters

### DIFF
--- a/scripts/functions/rvmrc
+++ b/scripts/functions/rvmrc
@@ -480,7 +480,7 @@ fi
 # If you use bundler, this might be useful to you:
 # if [[ -s Gemfile ]] && ! command -v bundle >/dev/null
 # then
-#   printf "The rubygem 'bundler' is not installed. Installing it now.\n"
+#   printf \"The rubygem 'bundler' is not installed. Installing it now.\\\\n\"
 #   gem install bundler
 # fi
 # if [[ -s Gemfile ]] && command -v bundle


### PR DESCRIPTION
The generated rvmrc is truncated right now.
