### PR TITLE
jruby head needs ant, which is in the apache-ant package on ArchLinux

### DIFF
--- a/scripts/requirements
+++ b/scripts/requirements
@@ -75,6 +75,8 @@ Additional Dependencies:
 
   # For JRuby, install the following:
   jruby: pacman -Sy --noconfirm jdk jre curl
+  jruby-head: pacman -Sy apache-ant
+
 
   # For IronRuby, install the following:
   ironruby: pacman -Sy --noconfirm mono


### PR DESCRIPTION
just a very minor change :)
