### PR TITLE
Minor tweak to help text of 'rvm upgrade'.  Nicer for users!

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -17,6 +17,8 @@ usage()
     given destination ruby version. Will migrate gemsets, wrappers, aliases
     and environment files.
 
+    To upgrade rvm itself you want 'rvm get'.
+
   Examples:
 
     $ rvm upgrade 1.9.2-p136 1.9.2-p180


### PR DESCRIPTION
Added help message to 'rvm upgrade' directing to how to upgrade rvm itself. This always is difficult to find and requires me to lookup the webstie.
