### PR TITLE
Backported Syck Patch for 1.8.6 to Guard Against Buffer Overflows

### DIFF
--- a/patches/ruby/1.8.6/syck.patch
+++ b/patches/ruby/1.8.6/syck.patch
@@ -1,0 +1,20 @@
+diff --git a/ext/syck/rubyext.c b/ext/syck/rubyext.c
+index 078de4f..8c4027f 100644
+--- a/ext/syck/rubyext.c
++++ b/ext/syck/rubyext.c
+@@ -268,9 +268,13 @@ rb_syck_mktime(str, len)
+     {
+         char padded[] = "000000";
+         char *end = ptr + 1;
++        char *p = end;
+         while ( isdigit( *end ) ) end++;
+-        MEMCPY(padded, ptr + 1, char, end - (ptr + 1));
+-        usec = strtol(padded, NULL, 10);
++        if (end - p < sizeof(padded)) {
++            MEMCPY(padded, ptr + 1, char, end - (ptr + 1));
++            p = padded;
++        }
++        usec = strtol(p, NULL, 10);
+     }
+     else
+     {

--- a/patchsets/ruby/1.8.6/default
+++ b/patchsets/ruby/1.8.6/default
@@ -1,3 +1,4 @@
 openssl-1.0
 stdout-rouge-fix
 no_sslv2
+syck


### PR DESCRIPTION
This commit introduces a Ruby patch for 1.8.6 backported from 1.8.7, which fixes a buffer overflow caused by the YAML library syck:

```
Tue Apr 15 23:40:39 2008  Akinori MUSHA  <knu@iDaemons.org>
    * ext/syck/rubyext.c (rb_syck_mktime): Avoid buffer overflow.
```

As gem installations have embedded metadata.gz files, which are compressed YAML files, when config files are formed in a way to trigger the buffer overflow, ruby (and thus gem installations) crash hard.

As an isolated example, with a stock 1.8.6-p420 installation with rvm:

```
$ tar xfv /usr/local/rvm/gems/ruby-1.8.6-p420/cache/json-1.6.4.gem
data.tar.gz
tar: data.tar.gz: implausibly old time stamp 1970-01-01 00:00:00
metadata.gz
tar: metadata.gz: implausibly old time stamp 1970-01-01 00:00:00
$ gunzip metadata.gz 
$ irb
1.8.6-p420 :001 > require 'yaml'
 => true 
1.8.6-p420 :002 > YAML::load_file 'metadata'
*** buffer overflow detected ***: irb terminated
======= Backtrace: =========
/lib/x86_64-linux-gnu/libc.so.6(__fortify_fail+0x37)[0x7fefb17b61d7]
/lib/x86_64-linux-gnu/libc.so.6(+0xfd0f0)[0x7fefb17b50f0]
/usr/local/rvm/rubies/ruby-1.8.6-p420/lib/ruby/1.8/x86_64-linux/syck.so(rb_syck_mktime+0x4b1)[0x7fefb09fe031]
<snip>
```

Related literature:
- http://code.google.com/p/rubyenterpriseedition/issues/detail?id=66
- http://bugs.ruby-lang.org/issues/4493

Thanks!
