### PR TITLE
Avoid after_cd_bundler hook spurious output

### DIFF
--- a/hooks/after_cd_bundler
+++ b/hooks/after_cd_bundler
@@ -3,7 +3,7 @@
 BUNDLER_BIN_PATH=""
 
 # see BUNDLE_BIN is set in the current directories .bundle/config
-if grep BUNDLE_BIN .bundle/config 2>/dev/null
+if grep BUNDLE_BIN .bundle/config >/dev/null 2>/dev/null
   then
   BUNDLER_BIN_PATH=$(grep BUNDLE_BIN .bundle/config | cut -d ' ' -f 2 -)
   # Expand the bundler stub path


### PR DESCRIPTION
Before the patch used to output `BUNDLE_BIN: bin` every time the hook is run inside projects with configured Bundler's binstubs
