### PR TITLE
Update a docstring in config/known

### DIFF
--- a/config/known
+++ b/config/known
@@ -51,7 +51,7 @@ kiji
 maglev[-head]
 maglev-1.0.0
 
-# Mac OS X Snow Leopard Only
+# Mac OS X Snow Leopard Or Newer
 macruby[-0.10]
 macruby-nightly
 macruby-head


### PR DESCRIPTION
MacRuby is Snow Leopard Or Newer, since Lion was released since that string was originally written
