### PR TITLE
README refers to `rvm get stable` (instead of `rvm get latest`)

### DIFF
--- a/README
+++ b/README
@@ -56,7 +56,8 @@ It manages Ruby application environments and switching between them.
                This means everything in $rvm_path (~/.rvm || /usr/local/rvm).
                This does not touch your profiles. However, this means that you
 	       must manually clean up your profiles and remove the lines which source RVM.
-  get        - {head,latest} upgrades rvm to latest head or release version.
+  get        - {head,stable} upgrades rvm to latest head or stable version.
+               Check 'rvm help get' for more details.
                (If you experience bugs try this first with head version, then
                 ask for help in #rvm on irc.freenode.net and hang around)
   reset      - remove current and stored default & system settings.


### PR DESCRIPTION
As discussed in issue #702 I suggest to refer to 'stable' and 'head'
branches in the main README. I also refered to the more detailed
`rvm help get` command.
