### PR TITLE
Use the correct url, the old one points you to the new one

### DIFF
--- a/README
+++ b/README
@@ -147,7 +147,7 @@ See http://rvm.beginrescueend.com/rvm/install/
 
 or just use:
 
-    bash < <(curl -s https://rvm.beginrescueend.com/install/rvm)
+    bash -s stable < <(curl -s https://raw.github.com/wayneeseguin/rvm/master/binscripts/rvm-installer)
 
 == LICENSE:
 


### PR DESCRIPTION
The present README sends you to a url that just gives you a new one- cut out the middle man
