### PR TITLE
Fix for issue #724.

### DIFF
--- a/scripts/functions/utility
+++ b/scripts/functions/utility
@@ -308,8 +308,15 @@ __rvm_version_compare()
   else dots=$v2d
   fi
 
+  if [[ "$MACHTYPE" == *darwin* ]]
+  then
+    sequencer="jot - $dots 0 -1"
+  else
+    sequencer="seq $dots -1 0"
+  fi
+
   counter=1
-  for x in $( seq $dots -1 0 )
+  for x in $( $sequencer )
   do
     transformer+=( "$(( 256 ** x ))*\$${counter}" )
     : $(( counter+=1 ))


### PR DESCRIPTION
Seq is not installed on Mac OS X by default. Jot can be used instead.
