### PR TITLE
Fix for syntax error near unexpected token `<'

### DIFF
--- a/scripts/functions/env
+++ b/scripts/functions/env
@@ -118,7 +118,7 @@ __rvm_unset_exports()
         unset $wrap_name
         ;;
     esac
-  done < <(printenv_null)
+  done < $(printenv_null)
 }
 
 # Clean all *duplicate* items out of the path. (keep first occurrence of each)


### PR DESCRIPTION
Was getting the following error while building a script that `sources` rvm.

Error message:

```
rvm/scripts/functions/env: line 121: syntax error near unexpected token `<'
```
