### PR TITLE
Fix minor documentation/comment snafu

### DIFF
--- a/scripts/functions/rvmrc
+++ b/scripts/functions/rvmrc
@@ -466,7 +466,7 @@ then
     then
       printf "%b" "  if [[ \$- == *i* ]] # check for interactive shells
   then echo \"Using: \$(tput setaf 2)\$GEM_HOME\$(tput sgr0)\" # show the user the ruby and gemset they are using in green
-  else echo \"Using: \$GEM_HOME\" # don't use colors in interactive shells
+  else echo \"Using: \$GEM_HOME\" # don't use colors in non-interactive shells
   fi
 " >> .rvmrc
     fi


### PR DESCRIPTION
It now says:

```
# don't use colors in non-interactive shells
```

instead of:

```
# don't use colors in interactive shells
```
