### PR TITLE
Set TERM to dumb when it's unknown

### DIFF
--- a/scripts/functions/logging
+++ b/scripts/functions/logging
@@ -2,6 +2,10 @@
 
 # Logging functions
 
+# ruby sets TERM to unknown when running commands from ``, so convert
+# that to dumb
+[[ "${TERM:-dumb}" == "unknown" ]] && TERM=dumb
+
 # check if user wants colors and if output goes to terminal
 # rvm_pretty_print_flag:
 # - 0|no    - disabled always


### PR DESCRIPTION
When running external system commands via `` in ruby, the TERM variable is set to unknown, which causes tput to complain:

```
tput: unknown terminal "unknown"
```
