### PR TITLE
improve README formatting

### DIFF
--- a/README
+++ b/README
@@ -128,7 +128,7 @@ notes       :: Display notes, with operating system specifics.
 
 export      :: Temporarily set an environment variable in the current shell.
 unexport    :: Undo changes made to the environment by 'rvm export'.
-requirements  :: Shows additional OS specific dependencies/requirementes for building various rubies.
+requirements  :: Shows additional OS specific dependencies/requirements for building various rubies.
 
 == Implementation
 


### PR DESCRIPTION
This patch series is in line with @deryldoucette comment in #800 to

> convert the existing readme TO rdoc format internally

Also one spelling fix.

Take a look at the results at https://github.com/rctay/rvm/tree/rc/doc.

I'm a bit iffy at using table/lists for the command options. What do you guys think?
