### PR TITLE
Support Gnome3 in "rvm docs open"

### DIFF
--- a/scripts/docs
+++ b/scripts/docs
@@ -46,15 +46,15 @@ open_docs()
 
       gnome-open "${rvm_docs_path:-"$rvm_path/docs"}/$rvm_docs_ruby_string/$rvm_docs_type/index.html" &>/dev/null
 
+    elif [[ -n "${XDG_SESSION_COOKIE}" ]] && builtin command -v xdg-open >/dev/null
+    then
+
+      xdg-open "${rvm_docs_path:-"$rvm_path/docs"}/$rvm_docs_ruby_string/$rvm_docs_type/index.html" &>/dev/null
+
     elif builtin command -v open >/dev/null
     then
 
       open "${rvm_docs_path:-"$rvm_path/docs"}/$rvm_docs_ruby_string/$rvm_docs_type/index.html"
-
-    elif builtin command -v xdg-open >/dev/null
-    then
-
-      xdg-open "${rvm_docs_path:-"$rvm_path/docs"}/$rvm_docs_ruby_string/$rvm_docs_type/index.html"
 
     else
 


### PR DESCRIPTION
On Fedora 16, /usr/bin/open is not what you want; it's a symlink to /usr/bin/openvt. But if you're in a GNOME session and gnome-open exists, all is well. Patch attached.
