### PR TITLE
move changeset from Changelog to Changelog.backport_gc

### DIFF
--- a/patches/ruby/1.9.3/p125/falcon.patch
+++ b/patches/ruby/1.9.3/p125/falcon.patch
@@ -1,23 +1,14 @@
-diff --git a/ChangeLog b/ChangeLog
-index 12edc3e..6f4ca39 100644
---- a/ChangeLog
-+++ b/ChangeLog
-@@ -875,6 +875,11 @@ Tue Jan 17 17:18:41 2012  Nobuyoshi Nakada  <nobu@ruby-lang.org>
- 
- 	* missing/setproctitle.c (ruby_init_setproctitle): changed prefix.
- 
+diff --git a/Changelog.backport_gc b/Changelog.backport_gc
+new file mode 100644
+index 0000000..b617fc8
+--- /dev/null
++++ b/Changelog.backport_gc
+@@ -0,0 +1,128 @@
 +Tue Jan 17 12:32:46 2012  Nobuyoshi Nakada  <nobu@ruby-lang.org>
 +
 +	* gc.c (aligned_malloc, aligned_free): covered missing defined
 +	  operators and fixes for cygwin.
 +
- Mon Jan 16 16:41:53 2012  Nobuyoshi Nakada  <nobu@ruby-lang.org>
- 
- 	* lib/optparse.rb (Regexp): fix incorrect options when casting to
-@@ -902,12 +907,135 @@ Thu Jan 12 01:40:33 2012  NAKAMURA Usaku  <usa@ruby-lang.org>
- 	* test/ruby/test_io.rb (TestIO#test_autoclose): Tempfile.new doesn't
- 	  accept the block argument.
- 
 +Wed Jan 11 22:52:51 2012  CHIKANAGA Tomoyuki  <nagachika00@gmail.com>
 +
 +	* gc.c (ruby_mimmalloc): don't set allocated size to header.
@@ -125,12 +116,6 @@ index 12edc3e..6f4ca39 100644
 +	  _POSIX_C_SOURCE and _XOPEN_SOURCE because they can't be used
 +	  to check availability at least on FreeBSD.
 +
- Sat Jan  7 22:46:36 2012  Kouhei Sutou  <kou@cozmixng.org>
- 
- 	* lib/rexml/parsers/baseparser.rb: use private instead of _xxx
- 	  method name. This is Ruby code not Python code.
- 	  refs #5696
- 
 +Sat Jan  7 22:25:50 2012  Narihiro Nakamura  <authornari@gmail.com>
 +
 +	* gc.c: use Bitmap Marking algorithm to avoid copy-on-write of
@@ -147,9 +132,6 @@ index 12edc3e..6f4ca39 100644
 +
 +	* class.c (rb_singleton_class_clone): ditto.
 +
- Tue Jan 03 23:57:37 2012  Ayumu AIZAWA  <ayumu.aizawa@gmail.com>
- 
- 	* lib/rexml/parsers/baseparser.rb: rexml BaseParser uses
 diff --git a/class.c b/class.c
 index df19812..56a6f6f 100644
 --- a/class.c


### PR DESCRIPTION
modifying Changelog forces to rewrite of revision.h, so than RUBY_REVISION
is set to 0, cause no svn or git repository in source tree
it breaks building of ruby-debug19
