### PR TITLE
Xcode debugopt fix r34840

### DIFF
--- a/patches/ruby/1.9.3/p125/xcode-debugopt-fix-r34840.patch
+++ b/patches/ruby/1.9.3/p125/xcode-debugopt-fix-r34840.patch
@@ -1,0 +1,38 @@
+Shared library config fix for MacOS X to make Ruby 1.9.3-p125 with XCode 4.3.x
+happy.
+
+https://bugs.ruby-lang.org/issues/6080
+
+--- trunk/configure.in	2012/02/28 01:30:15	34839
++++ trunk/configure.in	2012/02/28 02:44:52	34840
+@@ -289,12 +289,10 @@
+ if test "$GCC" = yes; then
+     linker_flag=-Wl,
+     : ${optflags=-O3}
+-    AS_CASE(["$target_os"], [linux*|darwin*], [: ${debugflags=-ggdb}])
+     RUBY_APPEND_OPTIONS(XCFLAGS, ["-include ruby/config.h" "-include ruby/missing.h"])
+ else
+     linker_flag=
+ fi
+-test $ac_cv_prog_cc_g = yes && : ${debugflags=-g}
+ 
+ RUBY_PROG_GNU_LD
+ RUBY_CPPOUTFILE
+@@ -490,6 +488,9 @@
+     warnflags=
+ fi
+ if test "$GCC" = yes; then
++    test "${debugflags+set}" || {RUBY_TRY_CFLAGS(-ggdb, [debugflags=-ggdb])}
++    test "${debugflags+set}" || {RUBY_TRY_CFLAGS(-g3, [debugflags=-g3])}
++
+     # -D_FORTIFY_SOURCE
+     RUBY_TRY_CFLAGS(-D_FORTIFY_SOURCE=2, [RUBY_APPEND_OPTION(XCFLAGS, -D_FORTIFY_SOURCE=2)])
+ 
+@@ -513,6 +514,7 @@
+     # suppress annoying -Wstrict-overflow warnings
+     RUBY_TRY_CFLAGS(-fno-strict-overflow, [RUBY_APPEND_OPTION(XCFLAGS, -fno-strict-overflow)])
+ fi
++test $ac_cv_prog_cc_g = yes && : ${debugflags=-g}
+ 
+ if test "$GCC" = ""; then
+     AS_CASE(["$target_os"],[aix*],[warnflags="-qinfo=por"])


### PR DESCRIPTION
This patch, fixes Ruby 1.9.3's [Issue#6080](https://bugs.ruby-lang.org/issues/6080), which fix dynamic loading name resolution issue. 
This is a change set [r34840](http://svn.ruby-lang.org/cgi-bin/viewvc.cgi?revision=34840&view=revision) pulled from Ruby source repository

Please include this for convenience. This is a really annoy issue..
