### PR TITLE
Bump up openssl version to use from 0.9.8n to 0.9.8t

### DIFF
--- a/scripts/functions/pkg
+++ b/scripts/functions/pkg
@@ -140,7 +140,7 @@ curl()
 
 openssl()
 {
-  package="openssl" ; version="0.9.8n" ; archive_format="tar.gz"
+  package="openssl" ; version="0.9.8t" ; archive_format="tar.gz"
   if [[ "Darwin" == "$(uname)" ]] ; then
 
     if [[ -n "$rvm_architectures" ]]; then


### PR DESCRIPTION
As subject read.

Tested on: MacOS X 10.6 (Xcode 4.2) and 10.7 (Xcode 4.3.1), Ubuntu 11.10.
Test environment: a rails app (based on 3.2.1), test with rspec, database on PostgreSQL 8.4.
(Actually, openssl only affect till gem bundle)

OpenSSL 0.9.8t selected because 1.0 series has some API change which may cause problem.
