### PR TITLE
Fix broken symlink introduced by 9d3929f

### DIFF
--- a/patches/ree/fix-irb-completion.diff
+++ b/patches/ree/fix-irb-completion.diff
@@ -1,1 +1,13 @@
-../ruby/fix-irb-completion.diff
+diff --git a/lib/irb/completion.rb b/lib/irb/completion.rb
+index 000658e..609dca3 100644
+--- a/lib/irb/completion.rb
++++ b/lib/irb/completion.rb
+@@ -157,7 +157,7 @@ module IRB
+ 	    end
+ 	    next if name != "IRB::Context" and 
+ 	      /^(IRB|SLex|RubyLex|RubyToken)/ =~ name
+-	    candidates.concat m.instance_methods(false)
++	    candidates.concat m.instance_methods(false).map { |m| m.to_s }
+ 	  }
+ 	  candidates.sort!
+ 	  candidates.uniq!


### PR DESCRIPTION
patches/ree/fix-irb-completion.diff was a symlink to
patches/ruby/fix-irb-completion.diff. 9d3929f copied the patch into the
various 1.8.x sub-directories leaving the symlink broken. This commit
replaces the symlink with another copy of the patch.
