### PR TITLE
scripts/functions/env fails under sh

### DIFF
--- a/scripts/functions/env
+++ b/scripts/functions/env
@@ -106,7 +106,7 @@ __rvm_export()
 __rvm_unset_exports()
 {
   typeset wrap_name name value
-  while IFS== read -d "" wrap_name value
+  printenv_null | while IFS== read -d "" wrap_name value
   do
     case "$wrap_name" in
       rvm_old_*)
@@ -118,7 +118,7 @@ __rvm_unset_exports()
         unset $wrap_name
         ;;
     esac
-  done < <(printenv_null)
+  done
 }
 
 # Clean all *duplicate* items out of the path. (keep first occurrence of each)


### PR DESCRIPTION
If scripts/functions/env is called from sh (not bash - even if sh is in fact bash) then following error is raised:

/usr/local/rvm/scripts/functions/env: line 121: syntax error near unexpected token `<'
/usr/local/rvm/scripts/functions/env: line 121:`  done < <(printenv_null)'

This patch should also help with https://github.com/wayneeseguin/rvm/issues/835 
