### PR TITLE
Requirement clarification for Xcode 4.[23].x on MacOS X

### DIFF
--- a/scripts/requirements
+++ b/scripts/requirements
@@ -238,31 +238,19 @@ ${rvm_error_clr:-}Xcode 4.2${rvm_reset_clr:-}:
   if __rvm_version_compare $xcode_version -ge 4.3
   then
     printf "%b" "
-${rvm_error_clr:-}Xcode 4.3${rvm_reset_clr:-}+ users
-- please be warned
+${rvm_error_clr:-}Xcode 4.3.x${rvm_reset_clr:-}+ users - please be warned
 - only ruby-1.9.3-p125+ is partially supported
+  (verfied to work on Xcode 4.3.1 and 4.3.2)
 - in case of any compilation issues:
- * downgrade to ${rvm_notify_clr:-}Xcode 4.1${rvm_error_clr:-}
- * uninstall Xcode and install ${rvm_notify_clr:-}osx-gcc-installer${rvm_reset_clr:-}
-and reinstall your rubies.
-"
-  elif __rvm_version_compare $xcode_version -ge 4.2.1
-  then
-    printf "%b" "
-${rvm_error_clr:-}Xcode 4.2.1${rvm_reset_clr:-}+ users - please be warned -
-in case of any compilation issues
- * downgrade to ${rvm_notify_clr:-}Xcode 4.1${rvm_error_clr:-}
- * uninstall Xcode and install ${rvm_notify_clr:-}osx-gcc-installer${rvm_reset_clr:-}
-and reinstall your rubies.
+ * downgrade to ${rvm_notify_clr:-}Xcode 4.1${rvm_reset_clr:-} and reinstall your rubies.
 "
   elif __rvm_version_compare $xcode_version -ge 4.2
   then
     printf "%b" "
-${rvm_error_clr:-}Xcode 4.2${rvm_reset_clr:-} users - please be warned -
-in case of any compilation issues
- * downgrade to ${rvm_notify_clr:-}Xcode 4.1${rvm_reset_clr:-}
- * or install ${rvm_notify_clr:-}osx-gcc-installer${rvm_reset_clr:-}
-and reinstall your rubies.
+${rvm_error_clr:-}Xcode 4.2.x${rvm_reset_clr:-} users
+- only ruby-1.9.3-p125+ is partially supported
+- in case of any compilation issues:
+ * downgrade to ${rvm_notify_clr:-}Xcode 4.1${rvm_reset_clr:-} and reinstall your rubies.
 "
   fi
 


### PR DESCRIPTION
Clean-up of requirements for Xcode 4.3, 4.3.1, 4.3.2, 4.2 and 4.2.1
