### PR TITLE
removing requirement of "--with-gcc=clang" from requirements

### DIFF
--- a/scripts/requirements
+++ b/scripts/requirements
@@ -213,7 +213,7 @@ To use an RVM installed Ruby as default, instead of the system ruby:
 And reopen your terminal windows.
 
 ${rvm_error_clr:-}Xcode 4.2${rvm_reset_clr:-}:
- * is only supported by ruby 1.9.3+ using command line flag: --with-gcc=clang
+ * is only supported by ruby 1.9.3+
  * it breaks gems with native extensions, especially DB drivers.
 "
 


### PR DESCRIPTION
since it's detected automatically now.
