### PR TITLE
fix cmd completion

### DIFF
--- a/scripts/zsh/Completion/_rvm
+++ b/scripts/zsh/Completion/_rvm
@@ -38,7 +38,7 @@ case $state in
 
   cmds)
 
-    cmds=( ${(f)"$(_call_program commands rvm help 2> /dev/null | sed -e '/^== Action/,/^== Implementation/!d; / - /!d; s/^[ *]*\([^ ]*\) *\- *\(.*\)/\1:\2/')"} )
+    cmds=( ${(f)"$(_call_program commands rvm help 2> /dev/null | sed -e '/^== Action/,/^== Implementation/!d; / :: /!d; s/^[ *]*\([^ ]*\) *:: *\(.*\)/\1:\2/')"} )
     cmds+=( $(rvm list strings) )
     _describe -t commands 'rvm command' cmds && ret=0
     ;;


### PR DESCRIPTION
Hi,
zsh 4.3.17 doesn't complete rvm 1.11.3 commands (install,cleanup,...)
'-' must have changed to '::' in the help at some stage. Or did something go wrong during my rvm install ?
