### PR TITLE
Verify that a ruby is installed before installing rvm to its global gemset

### DIFF
--- a/scripts/functions/installer
+++ b/scripts/functions/installer
@@ -444,7 +444,7 @@ install_gemsets()
 
 update_gemsets_install_rvm()
 {
-  typeset paths path found missing
+  typeset paths path installed found missing
   typeset -a missing
 
   if [[ ${rvm_keep_gemset_defaults_flag:-0} == 0 ]]
@@ -456,6 +456,12 @@ update_gemsets_install_rvm()
 
     for path in "${paths[@]}"
     do
+      # skip unless this ruby is installed
+      installed="${path%@global}"
+      installed="${installed/\/gems\//\/rubies\//}/bin/ruby"
+      installed=${installed//\\/}
+      [[ -x "$installed" ]] || continue
+
       # rvm /gems @global /gems
       found=($(
         find "${path%%+(\/)}/gems" -maxdepth 1 "${name_opt}" 'rvm-*' | sed 's/^\.\///'


### PR DESCRIPTION
The recent RVM feature of automatically installing the rvm gem to global gemsets currently attempts installation for all existing global gemset directories. I have scenarios where the ruby is no longer installed, but the global gemset directory still exists. This causes error messages to be displayed every time that <code>rvm get head</code> is called.

With some help from @mpapis, this patch attempts to verify that a given ruby is installed before adding its global gemset path to the rvm gem installation queue.
