### PR TITLE
Source the rvm function in ~/.profile if it exists

### DIFF
--- a/scripts/functions/installer
+++ b/scripts/functions/installer
@@ -961,8 +961,10 @@ setup_user_profile()
   target_rc=( ~/.bashrc )
   [[ -f ~/.zshenv ]] &&
     target_rc+=( ~/.zshenv ) || target_rc+=( ~/.zshrc )
-  [[ -f ~/.bash_profile ]] &&
-    target_login+=( ~/.bash_profile ) || target_login+=( ~/.bash_login )
+  [[ -f ~/.bash_profile ]] && 
+    target_login+=( ~/.bash_profile ) || 
+      [[ -f ~/.profile ]] && 
+        target_login+=( ~/.profile ) || target_login+=( ~/.bash_login )
   [[ -f ~/.zprofile ]] &&
     target_login+=( ~/.zprofile ) || target_login+=( ~/.zlogin )
 


### PR DESCRIPTION
Sourcing ~/.rvm/scripts/rvm in ~/.bash_login when ~/.profile exists avoids to loading ~/.profile, so RVM is not loaded.

I was creating some VMs in Vagrant with the Lucid32 (Ubuntu) box and it turns out that it comes with ~/.profile which loads ~/.bashrc so when one installs RVM it isn't loaded as function.
