### PR TITLE
rvm notes: show warning if ~/.profile exists

### DIFF
--- a/scripts/notes
+++ b/scripts/notes
@@ -117,6 +117,17 @@ $notes_type Notes:
 
 "
   fi
+
+  if [[ -f ~/.profile ]]
+  then
+    printf "%b" "
+  * WARNING: You're using ~/.profile, make sure you load it,
+    add the following line to ~/.bash_profile if it exists
+    otherwise add it to ~/.bash_login:
+
+      source ~/.profile
+"
+  fi
 } | new_notes | "${PAGER:-cat}"
 
 printf "%b" \


### PR DESCRIPTION
This pull request was based on what was discussed in this thread:

Here's the @mpapis' comment:

[https://github.com/wayneeseguin/rvm/pull/890#issuecomment-5010045](https://github.com/wayneeseguin/rvm/pull/890#issuecomment-5010045)
