### PR TITLE
Fix download problem.

### DIFF
--- a/binscripts/rvm-installer
+++ b/binscripts/rvm-installer
@@ -116,7 +116,7 @@ get_and_unpack()
   _file=$2
   _patern=$3
 
-  if curl -L ${_url} -o ${rvm_archives_path}/${_file}
+  if curl -kL ${_url} -o ${rvm_archives_path}/${_file}
   then
     true
   else


### PR DESCRIPTION
Detail:

curl: (60) SSL certificate problem, verify that the CA cert is OK. Details:
error:14090086:SSL routines:SSL3_GET_SERVER_CERTIFICATE:certificate verify failed
More details here: http://curl.haxx.se/docs/sslcerts.html

curl performs SSL certificate verification by default, using a "bundle"
 of Certificate Authority (CA) public keys (CA certs). The default
 bundle is named curl-ca-bundle.crt; you can specify an alternate file
 using the --cacert option.
If this HTTPS server uses a certificate signed by a CA represented in
 the bundle, the certificate verification probably failed due to a
 problem with the certificate (it might be expired, or the name might
 not match the domain name in the URL).
If you'd like to turn off curl's verification of the certificate, use
 the -k (or --insecure) option.

Could not download 'https://github.com/wayneeseguin/rvm/tarball/master'.
  Make sure your certificates are up to date as described above.
  To continue in insecure mode run 'echo insecure >> ~/.curlrc'.
