### PR TITLE
Don't override user's setops (zsh)

### DIFF
--- a/scripts/extras/rails
+++ b/scripts/extras/rails
@@ -26,6 +26,7 @@
 
 enable_extendglob() {
   if [[ -n "${ZSH_VERSION:-}" ]] ; then
+    emulate -L zsh
     setopt extendedglob
   else
     if [[ -n "${BASH_VERSION:-}" ]] ; then

--- a/scripts/functions/cleanup
+++ b/scripts/functions/cleanup
@@ -12,6 +12,7 @@ __rvm_rm_rf()
   #NOTE: RVM Requires extended globbing shell feature turned on.
   if [[ -n "${ZSH_VERSION:-}" ]]
   then
+    emulate -L zsh   # setopts should only be local
     setopt extendedglob
   else
     if [[ -n "${BASH_VERSION:-}" ]]

--- a/scripts/functions/environment
+++ b/scripts/functions/environment
@@ -251,7 +251,7 @@ __rvm_setup()
     then rvm_zsh_nomatch=0
     else rvm_zsh_nomatch=1
     fi
-    setopt no_nomatch
+    setopt no_nomatch # TODO: changing a user's options isn't polite.
   fi
 }
 
@@ -281,6 +281,7 @@ __rvm_teardown()
 
   if [[ -n "${ZSH_VERSION:-""}" ]]
   then
+    emulate -L zsh
     # If rvm_zsh_clobber is 0 then "setopt" contained "noclobber" before rvm performed "setopt clobber".
     (( rvm_zsh_clobber == 0 )) && setopt noclobber
     # If rvm_zsh_nomatch is 0 then "setopt" contained "nonomatch" before rvm performed "setopt nonomatch".

--- a/scripts/initialize
+++ b/scripts/initialize
@@ -28,6 +28,7 @@ then
   shopt -s extglob
 elif [[ -n "${ZSH_VERSION:-}" ]]
 then
+  emulate -L zsh
   setopt extendedglob
   setopt kshglob
   setopt no_glob_subst


### PR DESCRIPTION
In zsh, you can prevent overriding a user's setopts
by using `emulate -L zsh` before doing any setopts.

Specifically, it sets `setopt localoptions`.

We should probably make it a habit to set that in every function we do the ZSH/BASH detection.

Since I wrote the code originally, it's my fault. :-(

There is one place where I put a TODO since I'm not sure where `no_nomatch` is required; it's just set globally.
