### PR TITLE
Fix "backported-ossl-fixes" to work correctly with the Ruby 1.8.5

### DIFF
--- a/patches/ruby/1.8.5/backported-ossl-fixes.diff
+++ b/patches/ruby/1.8.5/backported-ossl-fixes.diff
@@ -219,15 +219,6 @@ diff -r -u ruby-1.8.5-p231/ext/openssl/ossl_hmac.c ruby-1.8.5-p231-fixed/ext/ope
  static VALUE
  ossl_hmac_initialize(VALUE self, VALUE key, VALUE digest)
  {
-@@ -64,7 +70,7 @@
- 
-     StringValue(key);
-     GetHMAC(self, ctx);
--    HMAC_Init_ex(ctx, RSTRING(key)->ptr, RSTRING(key)->len,
-+    HMAC_Init_ex(ctx, RSTRING_PTR(key), RSTRING_LEN(key),
- 		 GetDigestPtr(digest), NULL);
- 
-     return self;
 @@ -81,12 +87,15 @@
      GetHMAC(self, ctx1);
      SafeGetHMAC(other, ctx2);
@@ -247,15 +238,6 @@ diff -r -u ruby-1.8.5-p231/ext/openssl/ossl_hmac.c ruby-1.8.5-p231-fixed/ext/ope
  static VALUE
  ossl_hmac_update(VALUE self, VALUE data)
  {
-@@ -94,7 +103,7 @@
- 
-     StringValue(data);
-     GetHMAC(self, ctx);
--    HMAC_Update(ctx, RSTRING(data)->ptr, RSTRING(data)->len);
-+    HMAC_Update(ctx, RSTRING_PTR(data), RSTRING_LEN(data));
- 
-     return self;
- }
 @@ -104,9 +113,7 @@
  {
      HMAC_CTX final;
@@ -319,37 +301,6 @@ diff -r -u ruby-1.8.5-p231/ext/openssl/ossl_hmac.c ruby-1.8.5-p231-fixed/ext/ope
  static VALUE
  ossl_hmac_s_digest(VALUE klass, VALUE digest, VALUE key, VALUE data)
  {
-@@ -159,12 +197,17 @@
- 	
-     StringValue(key);
-     StringValue(data);
--    buf = HMAC(GetDigestPtr(digest), RSTRING(key)->ptr, RSTRING(key)->len,
--	       RSTRING(data)->ptr, RSTRING(data)->len, NULL, &buf_len);
-+    buf = HMAC(GetDigestPtr(digest), RSTRING_PTR(key), RSTRING_LEN(key),
-+	       RSTRING_PTR(data), RSTRING_LEN(data), NULL, &buf_len);
- 
-     return rb_str_new(buf, buf_len);
- }
- 
-+/*
-+ *  call-seq:
-+ *     HMAC.digest(digest, key, data) -> aString
-+ *
-+ */
- static VALUE
- ossl_hmac_s_hexdigest(VALUE klass, VALUE digest, VALUE key, VALUE data)
- {
-@@ -175,8 +218,8 @@
-     StringValue(key);
-     StringValue(data);
- 	
--    buf = HMAC(GetDigestPtr(digest), RSTRING(key)->ptr, RSTRING(key)->len,
--	       RSTRING(data)->ptr, RSTRING(data)->len, NULL, &buf_len);
-+    buf = HMAC(GetDigestPtr(digest), RSTRING_PTR(key), RSTRING_LEN(key),
-+	       RSTRING_PTR(data), RSTRING_LEN(data), NULL, &buf_len);
-     if (string2hex(buf, buf_len, &hexbuf, NULL) != 2 * buf_len) {
- 	ossl_raise(eHMACError, "Cannot convert buf to hexbuf");
-     }
 @@ -191,6 +234,10 @@
  void
  Init_ossl_hmac()


### PR DESCRIPTION
RSTRING_{LEN,PTR} are from newer versions of Ruby, and are not defined for this ancient version, leading to missing symbols when trying to load the OpenSSL extension.  The specific modifications can simple be dropped.
