### PR TITLE
don't reinstall libyaml over and over again on OS X

### DIFF
--- a/scripts/functions/pkg
+++ b/scripts/functions/pkg
@@ -247,11 +247,18 @@ libyaml()
   fi
   install_package
 }
+
 libyaml_installed()
 {
   typeset path
   path="${prefix_path:-${rvm_usr_path:-${rvm_path}/usr}}"
-  [[ -f "${path}/include/yaml.h" ]] && \find "${path}" -name libyaml.so | GREP_OPTIONS="" \grep '.*' >/dev/null
+  if [[ "Darwin" == "$(uname)" ]]
+  then
+    extension="dylib"
+  else
+    extension="so"
+  fi
+  [[ -f "${path}/include/yaml.h" ]] && \find "${path}" -name "libyaml.${extension}" | GREP_OPTIONS="" \grep '.*' >/dev/null
 }
 
 glib()


### PR DESCRIPTION
improved check for existence of libyaml on rvm_usr_path
