### PR TITLE
Suppress Travis Markdown from CLI.

### DIFF
--- a/scripts/help
+++ b/scripts/help
@@ -28,8 +28,7 @@ if [[ -n "$_command" && -s "${rvm_help_path}/${_command}" ]] ; then
 
 else
 
-  __rvm_pager_or_cat_v "${rvm_path:-$HOME/.rvm}/README" | \
-    grep -v '<img src="https://secure.travis-ci.org'
+  __rvm_pager_or_cat_v "${rvm_path:-$HOME/.rvm}/README" | sed '1,2d'
 
   rvm_log "
 Commands available with 'rvm help':


### PR DESCRIPTION
(With a simple grep -v.)

Note that there is an unsightly blank line before the first output line of "rvm help", but I did not tackle that one.
