### PR TITLE
Update unicode symbols of 'rvm-prompt u'

### DIFF
--- a/binscripts/rvm-prompt
+++ b/binscripts/rvm-prompt
@@ -159,7 +159,7 @@ if [[ -n "$ruby" && -n "$(echo "$ruby" | awk '/rvm/{print}')" ]] ; then
 
       jruby)    unicode="☯" ;;
 
-      rbx)      unicode="☃" ;;
+      rbx)      unicode="❖" ;;
 
       ree)      unicode="✈" ;;
 
@@ -177,25 +177,29 @@ if [[ -n "$ruby" && -n "$(echo "$ruby" | awk '/rvm/{print}')" ]] ; then
 
         case ${version:-""} in
 
-          1.8.6)  unicode="❻"  ;;
+          1.8.6)  unicode="➇❻"  ;;
 
-          1.8.7)  unicode="❼"  ;;
+          1.8.7)  unicode="➇❼"  ;;
 
-          1.9.1)  unicode="❶"  ;;
+          1.8*)   unicode="➇"  ;;
 
-          1.9.2)  unicode="❷"  ;;
+          1.9.1)  unicode="➈❶"  ;;
 
-          *)      unicode="♢"  ;;
+          1.9.2)  unicode="➈❷"  ;;
+
+          1.9.3)  unicode="➈❸"  ;;
+
+          *)      unicode="⦿"  ;;
 
         esac ;;
 
-      *) unicode="♢" ;;
+      *) unicode="⦿" ;;
 
     esac
 
     if echo "$ruby_string" | GREP_OPTIONS="" \grep '-head' >/dev/null 2>&1 ; then
 
-      unicode="${unicode}〠"
+      unicode="${unicode}⚡"
 
     fi
 


### PR DESCRIPTION
- Add support for 1.9.3
- Add 8 to all 1.8.\* and 9 to all 1.9.*
- Avoid large unicodes as they break some terminals
- Blocky char for rbx to resemble its logo
