### PR TITLE
not clear rvm_project_rvmrc_default user setting

### DIFF
--- a/scripts/rvm
+++ b/scripts/rvm
@@ -150,7 +150,7 @@ then
     printf "%b" "\n\$rvm_path ($rvm_path) does not exist."
   fi
   unset rvm_prefix_needs_trailing_slash rvm_gems_cache_path \
-    rvm_gems_path rvm_project_rvmrc_default rvm_gemset_separator rvm_reload_flag
+    rvm_gems_path rvm_gemset_separator rvm_reload_flag
 else
   source "${rvm_scripts_path:="$rvm_path/scripts"}/initialize"
   __rvm_setup


### PR DESCRIPTION
i'm set to .bashrc
export rvm_project_rvmrc_default=1

and expect when moving to next project without rvmrc, default ruby (not previous) setted

this is fix my expect.
