### PR TITLE
Fixed a bug wherein "rvm get" throws an error if user is at the latest version.

### DIFF
--- a/scripts/get
+++ b/scripts/get
@@ -30,7 +30,6 @@ case "$1" in
 
   (*)
     get_usage
-    false
     ;;
 esac
 


### PR DESCRIPTION
The error thrown was "Could not update RVM, get some help at #rvm IRC channel at freenode servers."

It now instead says "RVM reloaded!"
