### PR TITLE
Add warning before nuking $rvm_path/gemsets directory

### DIFF
--- a/scripts/functions/installer
+++ b/scripts/functions/installer
@@ -426,10 +426,13 @@ install_gemsets()
   then
     # warn the user if you're nuking this. Even so, relying on an env var
     # to have this behavior determined/set is pretty bad...tsk, tsk...
-    echo "WARNING: Environment variable rvm_keep_gemset_defaults_flag is either not set or is 0"
-    echo "If you want to keep your gemsets, run this from your shell"
-    echo "export rvm_keep_gemset_defaults_flag=1"
-    echo "Nuking $rvm_path/gemsets..."
+    printf "%b" "
+    WARNING: Environment variable rvm_keep_gemset_defaults_flag is either not set or is 0
+    If you want to keep your gemsets, run this from your shell
+    export rvm_keep_gemset_defaults_flag=1
+
+    Nuking $rvm_path/gemsets...
+    "
     rm -rf "$rvm_path/gemsets"
   fi
 


### PR DESCRIPTION
I'd like to propose a change whereby a user is prompted with a message informing them that the gemsets directory in their rvm path is going to be removed. I think it's better that way, as opposed to just silently dropping that directory. 

In the future, maybe consider making rvm prompt the user for confirmation before doing "destructive" things like that?

Thanks
