### PR TITLE
Fix list of rvmrc files looked for by /etc/profile script.

### DIFF
--- a/scripts/functions/installer
+++ b/scripts/functions/installer
@@ -842,7 +842,7 @@ then
 
   : rvm_stored_umask:\${rvm_stored_umask:=\$(umask)}
   # Load user rvmrc configurations, if exist
-  for file in \"/etc/rvmrc\" \"$HOME/.rvmrc\" ; do
+  for file in \"/etc/rvmrc\" \"\$HOME/.rvmrc\" ; do
     [[ -s \"\$file\" ]] && source \$file
   done
   if [[ -n \"\${rvm_prefix:-}\" ]] && ! [[ \"\$HOME/.rvmrc\" -ef \"\${rvm_prefix}/.rvmrc\" ]] && [[ -s \"\${rvm_prefix}/.rvmrc\" ]]


### PR DESCRIPTION
Add escape character to prevent premature expansion of $HOME when writing out /etc/profile script.
