### PR TITLE
Update zlib package to version 1.2.7

### DIFF
--- a/scripts/functions/pkg
+++ b/scripts/functions/pkg
@@ -191,7 +191,7 @@ openssl()
 
 zlib()
 {
-  package="zlib" ; version="1.2.6" ; archive_format="tar.gz"
+  package="zlib" ; version="1.2.7" ; archive_format="tar.gz"
   install_package
 }
 


### PR DESCRIPTION
When trying to install the zlib package, the package_url (http://zlib.net/zlib-1.2.6.tar.gz) returns a 404 file not found error because zlib has updated to version 1.2.7.
