### PR TITLE
Add option to rvmrc to not touch dotfiles

### DIFF
--- a/scripts/functions/installer
+++ b/scripts/functions/installer
@@ -941,6 +941,7 @@ setup_rvmrc()
 setup_user_profile()
 {
   (( UID > 0 )) || return 0
+  [ "${rvm_ignore_dotfiles:-no}" == "no" ] || return 0
 
   export user_profile_file
   export -a user_login_files user_rc_files


### PR DESCRIPTION
After seeing significant discussion in #774 surrounding this issue, it seems that consensus is to not try to be too clever, and just short circuit the dotfile code if we shouldn't be touching anything.
