### PR TITLE
Do not download rubygems tgz if it exists in the archives directory 

### DIFF
--- a/scripts/rubygems
+++ b/scripts/rubygems
@@ -137,15 +137,19 @@ rubygems_setup()
 
   if [[ ! -d "${rvm_src_path}/${rvm_gem_package_name}" ]]
   then
-    rvm_log "Retrieving $rvm_gem_package_name"
-
-    "$rvm_scripts_path/fetch" "$rvm_gem_url" "${rvm_gem_package_name}.tgz"
-    result=$?
-
-    if (( result > 0 ))
+    # Download tar file if it does not exist
+    if [[ ! -f "${rvm_archives_path}/${rvm_gem_package_name}.tgz" ]]
     then
-      rvm_error "There has been an error while trying to fetch the source. \nHalting the installation."
-      return $result
+      rvm_log "Retrieving $rvm_gem_package_name"
+
+      "$rvm_scripts_path/fetch" "$rvm_gem_url" "${rvm_gem_package_name}.tgz"
+      result=$?
+
+      if (( result > 0 ))
+      then
+        rvm_error "There has been an error while trying to fetch the source. \nHalting the installation."
+        return $result
+      fi
     fi
 
     if [[ ! -d "${rvm_src_path}/$rvm_gem_package_name" ]]


### PR DESCRIPTION
I was the guy commenting and asking questions in [this Stackoverflow thread](http://stackoverflow.com/questions/9459149/install-rvm-offline-completely), but when I tried things out, the rubygems tgz was being downloaded even if it existed in the archives directory.  This pull request fixes that - it downloads the tgz only if it does not exist in the archives dir.
