### PR TITLE
Update Install requirements for JRuby in ArchLinux

### DIFF
--- a/scripts/requirements
+++ b/scripts/requirements
@@ -93,7 +93,7 @@ Additional Dependencies:
   ruby: pacman -Sy --noconfirm gcc patch curl zlib readline libxml2 libxslt git autoconf automake diffutils make libtool bison subversion
 
 # For JRuby, install the following:
-  jruby: pacman -Sy --noconfirm jdk jre curl
+  jruby: pacman -Sy --noconfirm jdk7-openjdk jre7-openjdk curl
   jruby-head: pacman -Sy apache-ant
 
 # For IronRuby, install the following:


### PR DESCRIPTION
`jre` and `jdk` packages do not exist in ArchLinux anymore & would throw an error. 
 Instead, following packages are suggested:
- [jre7-openjdk](https://www.archlinux.org/packages/?name=jre7-openjdk)
- [jdk7-openjdk](https://www.archlinux.org/packages/?name=jdk7-openjdk)

This patch updates the package names which fixes the error
