### PR TITLE
rvm fix for OpenBSD stat command

### DIFF
--- a/scripts/functions/installer
+++ b/scripts/functions/installer
@@ -619,6 +619,7 @@ get_file_group()
 {
   case "$(uname)" in
     "Darwin") stat -f "%Sg" "$1" ;;
+    "OpenBSD") stat -f "%Sg" "$1" ;;
     *)        stat -c "%G"  "$1" ;;
   esac
 }


### PR DESCRIPTION
The _stat_ command that determines what group the file is owned by for Darwin and everything else which is essentially Linux. The OpenBSD syntax is the same as the one needed for Darwin so I added a case for OpenBSD.
