### PR TITLE
Portability fix for running on Cygwin

### DIFF
--- a/scripts/functions/installer
+++ b/scripts/functions/installer
@@ -841,9 +841,11 @@ setup_etc_profile()
 # /etc/profile.d/rvm.sh # sh extension required for loading.
 #
 
+SHELL_BASENAME=\`basename \$SHELL\`
+
 if [ -n \"\${BASH_VERSION:-}\" -o -n \"\${ZSH_VERSION:-}\" ] &&
-  test \"\`ps -p \$\$ -o comm=\`\" != dash &&
-  test \"\`ps -p \$\$ -o comm=\`\" != sh
+  test \"\$SHELL_BASENAME\" != dash &&
+  test \"\$SHELL_BASENAME\" != sh
 then
 
   : rvm_stored_umask:\${rvm_stored_umask:=\$(umask)}


### PR DESCRIPTION
scripts/functions/installer was calling "ps -p $$ -o comm=", which does not work on Cygwin.  Another way to test the current shell name is by passing $SHELL to the basename command.  This change makes that modification.
