### PR TITLE
Lookup shell from running binary on systems with a /proc fs

### DIFF
--- a/scripts/functions/installer
+++ b/scripts/functions/installer
@@ -841,9 +841,16 @@ setup_etc_profile()
 # /etc/profile.d/rvm.sh # sh extension required for loading.
 #
 
+
+if test -d /proc
+then
+    shell=\$(basename \$(readlink -f /proc/\$\$/exe))
+else
+    shell=\"\`ps -p \$\$ -o comm=\`\"
+fi
 if [ -n \"\${BASH_VERSION:-}\" -o -n \"\${ZSH_VERSION:-}\" ] &&
-  test \"\`ps -p \$\$ -o comm=\`\" != dash &&
-  test \"\`ps -p \$\$ -o comm=\`\" != sh
+  test \"\$shell\" != dash &&
+  test \"\$shell\" != sh
 then
 
   : rvm_stored_umask:\${rvm_stored_umask:=\$(umask)}


### PR DESCRIPTION
Any reason not to do this?
