### PR TITLE
Allow `rvm rvmrc create` to preserve the gemset.

### DIFF
--- a/scripts/functions/rvmrc
+++ b/scripts/functions/rvmrc
@@ -160,7 +160,7 @@ __rvm_rvmrc_tools()
   if
     [[ "${rvmrc_action}" == "create" ]]
   then
-    rvmrc_ruby="${1:-${MY_RUBY_HOME##*/}}"
+    rvmrc_ruby="${1:-${GEM_HOME##*/}}"
     rvmrc_path="$(builtin cd "$PWD" >/dev/null 2>&1; pwd)"
   elif
     [[ "${1:-}" == "all" ]]


### PR DESCRIPTION
Use `GEM_HOME` instead of `MY_RUBY_HOME` because it contains the full
ruby and gemset, e.g. `ruby@gemset`.

Closes #1100.
