### PR TITLE
binscripts/rvm-installer: bash version detection fails depending on the given input

### DIFF
--- a/binscripts/rvm-installer
+++ b/binscripts/rvm-installer
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
 
-# echo "65536 * 3 + 256 * 2 + 25" | bc
-if [[ -n "${BASH_VERSION:-}" ]] &&
-  (( 65536 * ${BASH_VERSINFO[0]} + 256 * ${BASH_VERSINFO[1]} + ${BASH_VERSINFO[2]} < 197145 ))
+BASH_MIN_VERSION="3.2.25"
+if [[ -n "${BASH_VERSION:-}" ]] && [[ "$(echo -e "${BASH_VERSION:-}\n${BASH_MIN_VERSION}" | sort -g -t"." | head -n1)" != "${BASH_MIN_VERSION}" ]] 
 then
-  echo "BASH 3.2.25 required (you have $BASH_VERSION)"
+  echo "BASH ${BASH_MIN_VERSION} required (you have $BASH_VERSION)"
   exit 1
 fi
 


### PR DESCRIPTION
See [1]

regards,
Patrick

[1] - https://github.com/wayneeseguin/rvm/issues/1127
