### PR TITLE
Check for trouble-prone config in "gemrc"s, fix #855

### DIFF
--- a/scripts/initialize
+++ b/scripts/initialize
@@ -87,6 +87,35 @@ Error:
     fi
   fi
 
+  # Intends to fix #855 by checking for and warning about rubygem incompatible
+  # configs.
+  #  -- lemoinem 2012-09-25
+  if [[ -z "${rvm_ignore_gemrc_issues:-}" ]]
+  then
+      for gemrc in "/etc/gemrc" "${HOME}/.gemrc"
+      do
+          if [[ -r "${gemrc}" ]]
+          then
+              unset double_check
+              typeset double_check
+
+              if GREP_OPTIONS="" \grep '^gem:' "${gemrc}" | GREP_OPTIONS="" \grep ' -n/\?' >/dev/null 2>&1
+              then
+                  echo 'BEWARE! Forcing rubygems to use a constant path (-n option) to install gems is not recommended for RVM installations.' >&2
+                  : double_check:${double_check:="${gemrc}"}
+              fi
+              
+              if GREP_OPTIONS="" \grep '^gem\(_\(install\|update\)\)\?:' "${gemrc}" | GREP_OPTIONS="" \grep ' --user-install\( \|$\)' >/dev/null 2>&1
+              then
+                  echo 'BEWARE! rubygems "--user-install" option is not recommended for RVM installations.' >&2
+                  : double_check:${double_check:="${gemrc}"}
+              fi
+
+              [[ -n "${double_check:-}" ]] && echo "Double check your ${double_check}. You could remove this warning by adding rvm_ignore_gemrc_issues=1 in your ${HOME}/.rvmrc" >&2
+          fi
+      done
+  fi
+
   true ${rvm_scripts_path:="$rvm_path/scripts"}
 
   #


### PR DESCRIPTION
Here is a first try to fix #855.

Since I'm don't know the implementation details of the installation/update process, I prefer to do the check each time RVM is loaded.

Since this could be tiring of people very quickly, I added an RVM configuration: `export rvm_ignore_gemrc_issues=1` to cancel the check.

I didn't relied on the output of `gem env` because it doesn't seem to take into account the sub-command configurations (such as `gem_install: [...]`.
