### PR TITLE
Fix error message for trouble-prone config in "gemrc"

### DIFF
--- a/scripts/initialize
+++ b/scripts/initialize
@@ -111,7 +111,7 @@ Error:
                   : double_check:${double_check:="${gemrc}"}
               fi
 
-              [[ -n "${double_check:-}" ]] && echo "Double check your ${double_check}. You could remove this warning by adding rvm_ignore_gemrc_issues=1 in your ${HOME}/.rvmrc" >&2
+              [[ -n "${double_check:-}" ]] && echo "Double check your ${double_check}. You could remove this warning by adding 'export rvm_ignore_gemrc_issues=1' to your ${HOME}/.rvmrc" >&2
           fi
       done
   fi


### PR DESCRIPTION
Hi!

I just noticed I forgot a commit in my previous PR.

Previous error message did not ensure rvm_ignore_gemrc_issues to be exported.

Sorry.
