### PR TITLE
Fix rvm gemset list in mixed-mode.

### DIFF
--- a/scripts/selector
+++ b/scripts/selector
@@ -662,7 +662,7 @@ __rvm_ruby_string()
 
   if (( ${#strings[@]} == 0 ))
   then
-    if echo "${GEM_HOME:-}" | GREP_OPTIONS="" \grep "${rvm_path}" >/dev/null 2>&1
+    if echo "${GEM_HOME:-}" | GREP_OPTIONS="" \grep "${rvm_gems_path}" >/dev/null 2>&1
     then
       # Current Ruby
       strings="${GEM_HOME##*\/}"


### PR DESCRIPTION
Hi!

Since in Mixed-mode the gemsets are not under rvm_path, the selector was not able to have the right variables.
I modified it to compare GEM_HOME to rvm_gems_path instead of rvm_path.

Tell me if you think this could break something, but I fail to see how it could be.

Mathieu.
