### PR TITLE
Use https:// with curl.

### DIFF
--- a/README
+++ b/README
@@ -13,7 +13,7 @@ It manages Ruby application environments and enables switching between them.
 
 == Installation
 
-  curl -L get.rvm.io | bash -s stable [--ruby] [--rails] [--trace]
+  curl -L https://get.rvm.io | bash -s stable [--ruby] [--rails] [--trace]
 
 stable  :: Install stable RVM, good for servers.
 --ruby  :: Additionally install latest ruby version (MRI).

--- a/scripts/functions/developer
+++ b/scripts/functions/developer
@@ -27,7 +27,7 @@ rvmselect()
 
   if [[ ! -d "${rvm_path}.${name}" ]]
   then
-    curl -L get.rvm.io | bash
+    curl -L https://get.rvm.io | bash
     mv "${rvm_path}" "${rvm_path}.${name}"
   fi
 

--- a/scripts/get
+++ b/scripts/get
@@ -9,7 +9,7 @@ get_usage()
 
 get_via_installer()
 {
-  curl -L get.rvm.io | bash -s -- $@ || return $?
+  curl -L https://get.rvm.io | bash -s -- $@ || return $?
 
   typeset -x rvm_hook
   rvm_hook="after_update"

--- a/scripts/notes
+++ b/scripts/notes
@@ -104,7 +104,7 @@ $notes_type Notes:
 
     install RVM:
 
-      curl -L get.rvm.io | bash -s stable
+      curl -L https://get.rvm.io | bash -s stable
 
     for details check:
 


### PR DESCRIPTION
Fixed `curl` commands that were not using `https://` for `get.rvm.io`.
