### PR TITLE
Update help/mount

### DIFF
--- a/help/mount
+++ b/help/mount
@@ -1,4 +1,3 @@
-
 Usage:
 
     rvm automount
@@ -31,10 +30,6 @@ distinguish externally compiled rubies.
 RVM also supports downloading compiled rubies.
 
 You can specify full url to the binaries:
-
-    rvm mount -r https://rvm.io/binaries/ubuntu/12.04/x86_64/ruby-1.9.3-p194.tar.bz2
-
-Or just give ruby version to download from default location:
 
     rvm mount -r https://rvm.io/binaries/ubuntu/12.04/x86_64/ruby-1.9.3-p194.tar.bz2
 


### PR DESCRIPTION
There seems to be a duplication in the help for `rvm mount`.
