### PR TITLE
Fix bash version detection when sort does not support "-g", fix #1158

### DIFF
--- a/binscripts/rvm-installer
+++ b/binscripts/rvm-installer
@@ -3,7 +3,7 @@
 BASH_MIN_VERSION="3.2.25"
 if
   [[ -n "${BASH_VERSION:-}" &&
-    "$(printf "%b" "${BASH_VERSION:-}\n${BASH_MIN_VERSION}\n" | sort -g -t"." | head -n1)" != "${BASH_MIN_VERSION}"
+    "$(printf "%b" "${BASH_VERSION:-}\n${BASH_MIN_VERSION}\n" | sort -n -t"." | head -n1)" != "${BASH_MIN_VERSION}"
   ]]
 then
   echo "BASH ${BASH_MIN_VERSION} required (you have $BASH_VERSION)"


### PR DESCRIPTION
I double checked the difference between -g and -n, since we use '-t "."', we won't need it.

Check #1158 for details.
