### PR TITLE
Remove unneeded call to `free` in scripts/requirements, fix #1166

### DIFF
--- a/scripts/requirements
+++ b/scripts/requirements
@@ -40,7 +40,6 @@ Requirements for ${system} $release
   rvm_yum_binary="$(     builtin command -v yum     )"
   rvm_zypper_binary="$(  builtin command -v zypper  )"
   rvm_pkg_add_binary="$( builtin command -v pkg_add )"
-  rvm_free_ram_mb="$(free -m | awk '{if (NR==3) print $4}')"
 
   printf "%b" "
 NOTE: 'ruby' represents Matz's Ruby Interpreter (MRI) (1.8.X, 1.9.X)


### PR DESCRIPTION
This call was introduced by mpapis in aac1b343d3eb64bf3c7c74723cb7f77aa053f530
And the result use was lost while transfering requirements check from notes to requirements in c6e79b3c093e4da4eabdfb221743dea322fb0b0a (by @ddd).

If the check is still needed, I will reintroduce it in another PR and change the call to free so there is no error message.
