### PR TITLE
Fix call to free to check memory requirements, updates #1167, fix #1166

### DIFF
--- a/scripts/requirements
+++ b/scripts/requirements
@@ -40,7 +40,10 @@ Requirements for ${system} $release
   rvm_yum_binary="$(     builtin command -v yum     )"
   rvm_zypper_binary="$(  builtin command -v zypper  )"
   rvm_pkg_add_binary="$( builtin command -v pkg_add )"
-  rvm_free_ram_mb="$(    if ! which free >/dev/null 2>/dev/null ; then echo 0; else free -m | awk '{if (NR==3) print $4}' ; fi)"
+
+  rvm_free_ram="$(free -b 2>/dev/null | awk '{if (NR==3) print $4}')"
+  : rvm_free_ram: ${rvm_free_ram:="$(sysctl hw.physmem 2>/dev/null | cut -f 2 -d =)"}
+  : rvm_free_ram: ${rvm_free_ram:=0}
 
   printf "%b" "
 NOTE: 'ruby' represents Matz's Ruby Interpreter (MRI) (1.8.X, 1.9.X)
@@ -213,7 +216,7 @@ RVM requirements for unrecognised Solaris system.
  jruby: # The Oracle java runtime environment and development kit.
 "
   fi
-  if [[ $rvm_free_ram_mb -le 600 ]]
+  if [[ $rvm_free_ram -le 629145600 ]]
   then
     printf "
 For rbx (Rubinius) more than 600MB of free RAM required.


### PR DESCRIPTION
This call was introduced by @mpapis in aac1b34.
And the result use was lost while transfering requirements check from notes to
requirements in c6e79b3 (by @ddd).

In #1166, @shhhhh noticed that the check was giving an error message on OpenBSD
(and more generally, systems without `free` installed).

This commit reintroduce the lost check, as requested by @mpapis in #1167, and fix the error message.
