### PR TITLE
Fixes paths to mirrorservice.org in scripts/tools

### DIFF
--- a/scripts/tools
+++ b/scripts/tools
@@ -184,12 +184,12 @@ tools_mirror()
     then
       if (( ${rvm_force_flag:-0} == 1 ))
       then
-        __rvm_sed_i "${file}" -e "s/^ruby_${n}_url=.*$/ruby_${n}_url=http:\/\/www.mirrorservice.org\/sites\/ftp.ruby-lang.org\/pub\/ruby\/${n}/"
+        __rvm_sed_i "${file}" -e "s/^ruby_${n}_url=.*$/ruby_${n}_url=http:\/\/old-www.mirrorservice.org\/sites\/ftp.ruby-lang.org\/pub\/ruby\/${n}/"
       else
         warn=1
       fi
     else
-      printf "ruby_${n}_url=http://www.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/${n}
+      printf "ruby_${n}_url=http://old-www.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/${n}
 " >> "$file"
     fi
   done


### PR DESCRIPTION
Mirrorservice have brought in a new system and its not mirroring ruby-lang.org yet.
I have changed the script to point at the old system, which is still running.
