### PR TITLE
Rm `unset rvm_configure_env` for libyaml.

### DIFF
--- a/scripts/functions/pkg
+++ b/scripts/functions/pkg
@@ -255,10 +255,6 @@ libxslt()
 libyaml()
 {
   package="yaml" ; version="0.1.4" ; archive_format="tar.gz"
-  if [[ "Darwin" == "$(uname)" ]]
-  then
-    unset rvm_configure_env
-  fi
   install_package
 }
 


### PR DESCRIPTION
mpapis asked me to remove this because it was
unsetting CFLAGS & LDFLAGS, which I set in my
~/.rvmrc. This is for installing Ruby with new
Xcode without installing Command Line Tools.
