### PR TITLE
on FreeBSD, stat behaves as on OpenBSD.

### DIFF
--- a/scripts/functions/installer
+++ b/scripts/functions/installer
@@ -617,7 +617,7 @@ get_file_group()
 {
   case "$(uname)" in
     "Darwin") stat -f "%Sg" "$1" ;;
-    "OpenBSD") stat -f "%Sg" "$1" ;;
+    "OpenBSD" | "FreeBSD") stat -f "%Sg" "$1" ;;
     *)        stat -c "%G"  "$1" ;;
   esac
 }


### PR DESCRIPTION
When upgrading on FreeBSD I got :

```
$ curl -L https://get.rvm.io | sudo bash -s head
Downloading RVM from wayneeseguin branch master

Upgrading the RVM installation in /usr/local/rvm/
stat: illegal option -- c
usage: stat [-FLnq] [-f format | -l | -r | -s | -x] [-t timefmt] [file ...]
stat: illegal option -- c
usage: stat [-FLnq] [-f format | -l | -r | -s | -x] [-t timefmt] [file ...]
    RVM system user group 'rvm' exists, proceeding with installation.
    Installing rvm gem in 3 gemsets ............
```

easy fix.
