### PR TITLE
The rvm group needs to be created before use.

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -131,9 +131,9 @@ migrate_defaults
 
 correct_binary_permissions
 
-install_man_pages
-
 root_canal
+
+install_man_pages
 
 setup_rvmrc
 


### PR DESCRIPTION
The man pages are `chown` to `:rvm` in `install_man_pages` before the group is created in `root_canal`
