### PR TITLE
Installer does not enforce world-readable permissions: Forgot /etc/rvmrc last time in first fix

### DIFF
--- a/scripts/functions/installer
+++ b/scripts/functions/installer
@@ -988,6 +988,7 @@ setup_rvmrc()
       [[ -s $rvmrc_file ]]
     then
       chown $USER:${rvm_group_name:-$USER} $rvmrc_file
+      chmod a+r $rvmrc_file
     fi
   else
     rvmrc_file="$HOME/.rvmrc"


### PR DESCRIPTION
Forgot /etc/rvmrc last time in first fix, sorry :P 

fix cdd25cf, updates #1213, fix #1124
