### PR TITLE
rvm user userdb did not include sha512, which prooved problematic when t...

### DIFF
--- a/scripts/tools
+++ b/scripts/tools
@@ -87,7 +87,7 @@ tools_user_setup()
     # create empty db files for rvm_user_path
     if [[ "$eval_target" == "user" ]]
     then
-      for file in db md5 rvmrcs
+      for file in db md5 rvmrcs sha512
       do
         [[ -f "${_user_path}/${file}" ]] || touch "${_user_path}/${file}"
       done


### PR DESCRIPTION
...rying to install a new ruby

The point of this fix is to get rid of the

```
mlemoine@server:~/maxihard$ rvmsudo rvm install ruby-1.9.3-p286
[sudo] password for mlemoine: 
No binary rubies available for: ubuntu/12.04/x86_64/ruby-1.9.3-p286.
Continuing with compilation. Please read 'rvm mount' to get more information on binary rubies.
Installing Ruby from source to: /usr/local/rvm/rubies/ruby-1.9.3-p286, this may take a while depending on your cpu(s)...
ruby-1.9.3-p286 - #downloading ruby-1.9.3-p286, this may take a while depending on your connection...
Error running '/usr/local/rvm/scripts/fetch http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p286.tar.bz2', please read /usr/local/rvm/log/ruby-1.9.3-p286/fetch.log
There has been an error fetching the ruby interpreter. Halting the installation.
mlemoine@deployment-test:~/maxihard$ cat /usr/local/rvm/log/ruby-1.9.3-p286/fetch.log


Database file /home/mlemoine/.rvm/user/sha512 does not exist.



Database file /home/mlemoine/.rvm/user/sha512 does not exist.

There is no checksum for 'http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p286.tar.bz2' or 'ruby-1.9.3-p286.tar.bz2', it's not possible to validate it.
If you wish to continue with unverified download add '--verify-downloads 1' after the command.
```
