### PR TITLE
Allow wrapping multiple commands in one script

### DIFF
--- a/scripts/wrapper
+++ b/scripts/wrapper
@@ -76,8 +76,10 @@ symlink_binary()
   if
     wrap_binary && [[ -f "$file_name" ]]
   then
+    file_link="$rvm_bin_path/${prefix}_${binary_name##*\/}"
+    file_link=${file_link// /_}
     rm -f "$rvm_bin_path/${prefix}_${binary_name##*\/}"
-    ln -fs "$file_name" "$rvm_bin_path/${prefix}_${binary_name##*\/}"
+    ln -fs "$file_name" "$file_link"
   fi
 }
 
@@ -149,6 +151,7 @@ environment_identifier="$(__rvm_env_string)"
 for binary_name in "${binaries[@]}"
 do
   file_name="$rvm_wrappers_path/${environment_identifier}/${binary_name##*\/}"
+  file_name=${file_name// /_}
   if
     [[ -z "${prefix:-}" ]]
   then


### PR DESCRIPTION
`rvm wrapper 1.9.2@me me "bundle exec unicorn_rails"` Creates 3 wrappers me_(bundle, exec, unicorn_rails)

`rvm wrapper 1.9.2@me me "bundle exec unicorn_rail"` Now creates me_bundle_exec_unicorn_rails

My bash string manipulation is a little rusty, so I had to break out the string replacement into its own line.
