### PR TITLE
Allow rvmsudo to be compatible with command restrictions in sudoers, fix #1258.

### DIFF
--- a/binscripts/rvmsudo
+++ b/binscripts/rvmsudo
@@ -31,7 +31,7 @@ done
 
 if (( $# ))
 then
-  eval command sudo \"\${sudo_args[@]}\" /usr/bin/env $(
+  eval command sudo \"\${sudo_args[@]}\" $(
     /usr/bin/env |
       awk -F= 'BEGIN{v=0;}/^[a-zA-Z_][a-zA-Z0-9_]*=/{v=1;}v==1&&$2~/^['\''\$]/{v=2;} v==1&&$2~/^\(\) \{/{v=0;} v==1&&$2~/^\(/{v=3;}v==2&&/'\''$/&&!/'\'\''$/{v=1;}v==3&&/\)$/{v=1;}v{print;}v==1{v=0;}' |
       GREP_OPTIONS="" \grep -E '^rvm|^gemset|^http_|^PATH|^IRBRC|RUBY|GEM' |


### PR DESCRIPTION
sudo supports to be given directly a list of environments modifications. There
is no need to use /usr/bin/env.

This also provides support for command restrictions in the sudoers file. (The
user don't need to be allowed ALL commands or /usr/bin/env, which is the same,
anymore).

PS: Applied to fix #1258
