### PR TITLE
Allow users to have their own logs in mixed-mode

### DIFF
--- a/scripts/tools
+++ b/scripts/tools
@@ -104,12 +104,13 @@ tools_user()
   for item in $@
   do
     case "$item" in
-      all)     selection+=( gemsets rubies hooks pkgs wrappers userdb ) ;;
+      all)     selection+=( gemsets rubies hooks pkgs wrappers userdb log ) ;;
       rubies)  selection+=( rubies  ) ;;
-      gemsets) selection+=( gemsets userdb ) ;;
+      gemsets) selection+=( gemsets userdb log ) ;;
       hooks)   selection+=( hooks   ) ;;
       pkgs)    selection+=( pkgs    ) ;;
       userdb)  selection+=( userdb  ) ;;
+      log)     selection+=( log  ) ;;
       --skel)  rvm_skel_flag=1        ;;
       *)
         tools_user_usage "Unrecognized option '$item'."
@@ -167,6 +168,9 @@ tools_user()
         ;;
       userdb)
         tools_user_setup "${target}" user
+        ;;
+      log)
+        tools_user_setup "${target}" log
         ;;
     esac
   done


### PR DESCRIPTION
If this is not the case, users can create but not delete their own gemsets:

```
  tee: /usr/local/rvm/log/ruby-1.9.2-p320/gemset.delete.log: Permission denied
  /usr/local/rvm/scripts/functions/utility: line 116: /usr/local/rvm/log/ruby-1.9.2-p320/gemset.delete.log: Permission denied
  Error running 'gemset_delete_task my-gemset ruby-1.9.2-p320@viptrainers-1.12.4 /home/user/.rvm/gems/ruby-1.9.2-p320@my-gemset', please read /usr/local/rvm/log/ruby-1.9.2-p320/gemset.delete.log
```

So this is also a (rather critical) fix.
