### PR TITLE
Use correct archive extension for rubies older than 1.8.4.

### DIFF
--- a/scripts/selector
+++ b/scripts/selector
@@ -295,14 +295,12 @@ __rvm_select()
         rvm_ruby_repo_url="${rvm_ruby_repo_url:-"$(__rvm_db "ruby_repo_url")"}"
         if (( ${rvm_head_flag:=0} == 0 ))
         then
-          case "${rvm_ruby_version}" in
-            (1.8.4)
-              rvm_archive_extension="tar.gz"
-              ;;
-            (*)
-              rvm_archive_extension="tar.bz2"
-              ;;
-          esac
+          if __rvm_version_compare "${rvm_ruby_version}" -lt "1.8.5"
+          then
+            rvm_archive_extension="tar.gz"
+          else
+            rvm_archive_extension="tar.bz2"
+          fi
         else rvm_disable_binary_flag=1
         fi
       fi


### PR DESCRIPTION
RVM is hard coded to use `tar.gz` for Ruby 1.8.4, and `tar.bz2` for all other Rubies.

This patch changes the behaviour so `tar.gz` is used for Ruby 1.8.4 and older.
