### PR TITLE
Verbose function declaration because ZSH on Debian Lenny complains

### DIFF
--- a/scripts/functions/checksum
+++ b/scripts/functions/checksum
@@ -74,9 +74,20 @@ __rvm_checksum_calculate_file()
   _checksum_sha512="$( __rvm_sha__calculate 512 "${1:-}" )"
 }
 
-__rvm_checksum_none() {[[ -z "${_checksum_md5:-}" && -z "${_checksum_sha512:-}" ]]}
-__rvm_checksum_any()  {[[ -n "${_checksum_md5:-}" || -n "${_checksum_sha512:-}" ]]}
-__rvm_checksum_all()  {[[ -n "${_checksum_md5:-}" && -n "${_checksum_sha512:-}" ]]}
+__rvm_checksum_none()
+{
+  [[ -z "${_checksum_md5:-}" && -z "${_checksum_sha512:-}" ]]
+}
+
+__rvm_checksum_any()
+{
+  [[ -n "${_checksum_md5:-}" || -n "${_checksum_sha512:-}" ]]
+}
+
+__rvm_checksum_all()
+{
+  [[ -n "${_checksum_md5:-}" && -n "${_checksum_sha512:-}" ]]
+}
 
 # __rvm_checksum_validate_file {file}
 # ENV in: _checksum_md5 _checksum_sha512


### PR DESCRIPTION
See this bug.

https://github.com/wayneeseguin/rvm/issues/1320

scripts/base sources this file using the default shell.

Defining these three functions without curly braces is equivalent in bash, but causes zsh to complain about an unexpected newline. I'm only able to reproduce on Debian Lenny with any version of zsh.
