### PR TITLE
use Zsh "whence" to avoid matching functions

### DIFF
--- a/scripts/functions/support
+++ b/scripts/functions/support
@@ -135,9 +135,9 @@ __rvm_which()
   then command whence -p "$@"
   elif command which which >/dev/null 2>&1
   then command which "$@"
-  elif [[ -n "${ZSH_VERSION:-}" ]]
-  then return 1 #TODO: zsh detects functions, it is very bad!
-  else which "$@"
+  elif which which >/dev/null 2>&1
+  then which "$@"
+  else return 1
   fi
 }
 


### PR DESCRIPTION
```
__rvm_where rvm
```

matches 'rvm()' function, causing a flood of eval() parse errors (during ruby install).

The patch: use "whence -p" when available (Zsh).
