### PR TITLE
Update scripts/rvm to ignore rvm_environments_path and always use instead rvm_path/environments.

### DIFF
--- a/scripts/rvm
+++ b/scripts/rvm
@@ -132,10 +132,7 @@ then
       builtin command -v ruby | GREP_OPTIONS="" \grep -v "${rvm_path}" >/dev/null ||
       builtin command -v ruby | GREP_OPTIONS="" \grep "${rvm_path}/bin/ruby$" >/dev/null
     then
-      if [[ -s "$rvm_environments_path/default" ]]
-      then
-        source "$rvm_environments_path/default"
-      elif [[ -s "$rvm_path/environments/default" ]]
+      if [[ -s "$rvm_path/environments/default" ]]
       then
         source "$rvm_path/environments/default"
       fi


### PR DESCRIPTION
This allows switch to work correctly and get's read of rvm_environments_path (which is documented in the History.txt as a removed variable although is used in the code quite profusely).
