### PR TITLE
falcon.diff: fix method signature

### DIFF
--- a/patches/ruby/1.9.3/p327/falcon-gc.diff
+++ b/patches/ruby/1.9.3/p327/falcon-gc.diff
@@ -652,7 +652,7 @@ index df19812..db6b3e5 100644
  
  static int
 -method_entry_i(st_data_t key, st_data_t value, st_data_t data)
-+method_entry_i(st_index_t key, st_data_t value, st_data_t data)
++method_entry_i(sa_index_t key, st_data_t value, st_data_t data)
  {
      const rb_method_entry_t *me = (const rb_method_entry_t *)value;
 -    st_table *list = (st_table *)data;

--- a/patches/ruby/1.9.3/p327/falcon.diff
+++ b/patches/ruby/1.9.3/p327/falcon.diff
@@ -652,7 +652,7 @@ index df19812..db6b3e5 100644
  
  static int
 -method_entry_i(st_data_t key, st_data_t value, st_data_t data)
-+method_entry_i(st_index_t key, st_data_t value, st_data_t data)
++method_entry_i(sa_index_t key, st_data_t value, st_data_t data)
  {
      const rb_method_entry_t *me = (const rb_method_entry_t *)value;
 -    st_table *list = (st_table *)data;


### PR DESCRIPTION
fix method signature. It happens that compiller didn't inform me for this issue.
