### PR TITLE
falcon patch: please macos compiler with data types

### DIFF
--- a/patches/ruby/1.9.3/p327/falcon-gc.diff
+++ b/patches/ruby/1.9.3/p327/falcon-gc.diff
@@ -6160,7 +6160,7 @@ index 3da500e..385d4af 100644
          iv_index_tbl = ROBJECT_IV_INDEX_TBL(obj);
          if (!iv_index_tbl) break;
 -        if (!st_lookup(iv_index_tbl, (st_data_t)id, &index)) break;
-+        if (!sa_lookup(iv_index_tbl, (st_data_t)id, &index)) break;
++        if (!sa_lookup(iv_index_tbl, (sa_index_t)id, &index)) break;
          if (len <= (long)index) break;
          val = ptr[index];
          if (val != Qundef)
@@ -6428,7 +6428,7 @@ index 3da500e..385d4af 100644
      rb_const_set(mod, id, Qundef);
      tbl = RCLASS_IV_TBL(mod);
 -    if (tbl && st_lookup(tbl, (st_data_t)autoload, &av)) {
-+    if (sa_lookup(tbl, (st_data_t)autoload, &av)) {
++    if (sa_lookup(tbl, (sa_index_t)autoload, &av)) {
  	tbl = check_autoload_table((VALUE)av);
      }
      else {

--- a/patches/ruby/1.9.3/p327/falcon.diff
+++ b/patches/ruby/1.9.3/p327/falcon.diff
@@ -5086,7 +5086,7 @@ index 3da500e..385d4af 100644
          iv_index_tbl = ROBJECT_IV_INDEX_TBL(obj);
          if (!iv_index_tbl) break;
 -        if (!st_lookup(iv_index_tbl, (st_data_t)id, &index)) break;
-+        if (!sa_lookup(iv_index_tbl, (st_data_t)id, &index)) break;
++        if (!sa_lookup(iv_index_tbl, (sa_index_t)id, &index)) break;
          if (len <= (long)index) break;
          val = ptr[index];
          if (val != Qundef)
@@ -5354,7 +5354,7 @@ index 3da500e..385d4af 100644
      rb_const_set(mod, id, Qundef);
      tbl = RCLASS_IV_TBL(mod);
 -    if (tbl && st_lookup(tbl, (st_data_t)autoload, &av)) {
-+    if (sa_lookup(tbl, (st_data_t)autoload, &av)) {
++    if (sa_lookup(tbl, (sa_index_t)autoload, &av)) {
  	tbl = check_autoload_table((VALUE)av);
      }
      else {


### PR DESCRIPTION
Mac OS users report about problem with 64-to-32-bit conversion.
Hope this last to errors, but there could be other some.

It seems that linux's GCC is more forgiving for such conversion.
