### PR TITLE
falcon patch: tune st_table packed size for 64bit

### DIFF
--- a/patches/ruby/1.9.3/p327/falcon-gc.diff
+++ b/patches/ruby/1.9.3/p327/falcon-gc.diff
@@ -4372,7 +4372,7 @@ index fda5784..20ec427 100644
 +#define ST_DEFAULT_MAX_DENSITY 2
  #define ST_DEFAULT_INIT_TABLE_SIZE 11
 +#define ST_DEFAULT_SECOND_TABLE_SIZE 19
-+#define ST_DEFAULT_PACKED_TABLE_SIZE 18
++#define ST_DEFAULT_PACKED_TABLE_SIZE 19
 +#define PACKED_UNIT (int)(sizeof(st_packed_entry) / sizeof(st_table_entry*))
 +#define MAX_PACKED_HASH (int)(ST_DEFAULT_PACKED_TABLE_SIZE * sizeof(st_table_entry*) / sizeof(st_packed_entry))
 +

--- a/patches/ruby/1.9.3/p327/falcon.diff
+++ b/patches/ruby/1.9.3/p327/falcon.diff
@@ -3298,7 +3298,7 @@ index fda5784..20ec427 100644
 +#define ST_DEFAULT_MAX_DENSITY 2
  #define ST_DEFAULT_INIT_TABLE_SIZE 11
 +#define ST_DEFAULT_SECOND_TABLE_SIZE 19
-+#define ST_DEFAULT_PACKED_TABLE_SIZE 18
++#define ST_DEFAULT_PACKED_TABLE_SIZE 19
 +#define PACKED_UNIT (int)(sizeof(st_packed_entry) / sizeof(st_table_entry*))
 +#define MAX_PACKED_HASH (int)(ST_DEFAULT_PACKED_TABLE_SIZE * sizeof(st_table_entry*) / sizeof(st_packed_entry))
 +


### PR DESCRIPTION
64bit tcmalloc/jemalloc preffers when packed size and secondary size are equal.

Strictly speaking, this optimization doesn't hurt development environment much,
but could be relatively significant in production.
