### PR TITLE
Adding support for project-specific RBXOPT (related to #1354)

### DIFF
--- a/hooks/after_use_rbx_opts
+++ b/hooks/after_use_rbx_opts
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+. "${rvm_path}/scripts/functions/hooks/rbx"
+
+if [[ "${rvm_ruby_string}" =~ "rbx" ]]
+then
+  rbx_options_append "${PROJECT_RBXOPT[@]}"
+else 
+  rbx_options_remove "${PROJECT_RBXOPT[@]}"
+  rbx_clean_project_options
+fi

--- a/scripts/functions/hooks/rbx
+++ b/scripts/functions/hooks/rbx
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+export RBXOPT
+
+rbx_options_trim()
+{
+  RBXOPT="${RBXOPT## }"
+  RBXOPT="${RBXOPT%% }"
+}
+
+rbx_options_append()
+{
+  for param in "$@"
+  do
+    if ! [[ " ${RBXOPT} " =~ " $param " ]]
+    then
+      RBXOPT="${RBXOPT} $param"
+    fi
+  done
+  rbx_options_trim
+}
+
+rbx_options_remove()
+{
+  RBXOPT=" ${RBXOPT} "
+  for param in "$@"
+  do
+    if [[ "${RBXOPT}" =~ " $param " ]]
+    then
+      RBXOPT="${RBXOPT// $param / }"
+    fi
+  done
+  rbx_options_trim
+}
+
+rbx_clean_project_options()
+{
+  if [[ -n "${PROJECT_RBXOPT}" ]]
+  then
+    unset PROJECT_RBXOPT
+  fi
+}


### PR DESCRIPTION
This modification adds support to a project-specific RBXOPT exactly
same way how project-specific JRUBY_OPTS are working.

The example usage is:

``` bash
PROJECT_RBXOPT=( "-X18" "-Xagent" )
```
