### PR TITLE
Invalid archive on rvm maglev-head install.

### DIFF
--- a/scripts/functions/manage/maglev
+++ b/scripts/functions/manage/maglev
@@ -71,8 +71,8 @@ maglev_install()
     mkdir -p "${rvm_src_path}/${rvm_gemstone_package_file}"
   fi
 
-  __rvm_log_command "extract" "$rvm_ruby_string - #extracting $rvm_ruby_package_file to ${rvm_src_path}/$rvm_ruby_string" \
-    __rvm_package extract "${rvm_archives_path}/$rvm_ruby_package_file.$rvm_archive_extension" "${rvm_tmp_path:-/tmp}/rvm_src_$$" ||
+  __rvm_log_command "extract" "$rvm_ruby_string - #extracting $rvm_gemstone_package_file to ${rvm_src_path}/$rvm_ruby_string" \
+    __rvm_package extract "${rvm_archives_path}/$rvm_gemstone_package_file.$rvm_archive_extension" "${rvm_tmp_path:-/tmp}/rvm_src_$$" ||
   case $? in
     199)
       rvm_error "\nUnrecognized archive format '$archive_format'"


### PR DESCRIPTION
I believe that the wrong package variable is being used. It should be using the gemstone package and its using the unset ruby package instead. I see this error when installing before the change. 

Error running '__rvm_package extract /Users/barry/.rvm/archives/.tar.gz /Users/barry/.rvm/tmp/rvm_src_1858', please read /Users/barry/.rvm/log/maglev-head/extract.log
There has been an error while trying to extract the source. Halting the installation.
