### PR TITLE
after_install hook not having ruby_options exposed properly

### DIFF
--- a/scripts/functions/manage/base
+++ b/scripts/functions/manage/base
@@ -325,7 +325,7 @@ Continuing with compilation. Please read 'rvm mount' to get more information on 
 __rvm_install_ruby()
 {
   true ${rvm_head_flag:=0} ${rvm_ruby_selected_flag:=0}
-  typeset binary __rvm_ruby_name ruby_options ruby_install_type
+  typeset binary __rvm_ruby_name ruby_install_type
 
   if
     (( rvm_ruby_selected_flag == 0 ))


### PR DESCRIPTION
This fixes an issue that I worked with Michael Papis on regarding an after_install hook not having ruby_options properly exposed.
