### PR TITLE
Quick fix for the __rvm_cd installation crash

### DIFF
--- a/binscripts/rvm-installer
+++ b/binscripts/rvm-installer
@@ -153,11 +153,16 @@ Could not download '${_url}'.
   fi
 
   [[ -d "${rvm_src_path}/rvm" ]] || \mkdir -p "${rvm_src_path}/rvm"
-  if ! __rvm_cd "${rvm_src_path}/rvm"
+  typeset old_cdpath
+  old_cdpath="${CDPATH}"
+  CDPATH="."
+  if ! chpwd_functions="" builtin cd "$@" "${rvm_src_path}/rvm"
   then
+    CDPATH="${old_cdpath}"
     log "Could not change directory '${rvm_src_path}/rvm'."
     return 2
   fi
+  CDPATH="${old_cdpath}"
 
   rm -rf ${rvm_src_path}/rvm/*
   if ! $rvm_tar_command xzf ${rvm_archives_path}/${_file} ${rvm_tar_options:-}


### PR DESCRIPTION
Hopefully, this will solve the issue. I'll see about a workaround in the meantime.

__rvm_cd is not defined in the rvm-installer script. As such, it was causing a fatal crash on installation.
