### PR TITLE
__rvm_cd fix for rvm-installer

### DIFF
--- a/binscripts/rvm-installer
+++ b/binscripts/rvm-installer
@@ -121,6 +121,18 @@ install_head()
     ${_repo}-rvm-
 }
 
+# Drop in cd which _desotn't_ respect cdpath
+__rvm_cd()
+{
+    typeset old_cdpath ret
+    ret=0
+    old_cdpath="${CDPATH}"
+    CDPATH="."
+    chpwd_functions="" builtin cd "$@" || ret=$?
+    CDPATH="${old_cdpath}"
+    return $ret
+}
+
 get_and_unpack()
 {
   typeset _url _file _patern


### PR DESCRIPTION
Added the __rvm_cd function to the install script. Tested as working.

Resolves fatal crash caused by __rvm_cd by defining __rvm_cd in install script as well.
