### PR TITLE
Update config/known

### DIFF
--- a/config/known
+++ b/config/known
@@ -6,7 +6,7 @@
 [ruby-]1.9.3-p125
 [ruby-]1.9.3-p194
 [ruby-]1.9.3-p286
-[ruby-]1.9.3-[p327]
+[ruby-]1.9.3[-p327]
 [ruby-]1.9.3-head
 [ruby-]2.0.0-preview2
 ruby-head


### PR DESCRIPTION
Typo on MRI ruby-1.9.3-p327, it can be installed with simply "install 1.9.3" instead of the implied "install 1.9.3-".
