### PR TITLE
Fix: do not use "less" when rvm is being run non-interactively

### DIFF
--- a/scripts/cli
+++ b/scripts/cli
@@ -1068,13 +1068,21 @@ To reinstall use:
             rvm_is_a_shell_function no_warning
           then
             {
-              echo "Ruby (and needed base gems) for your selection will be installed shortly."
-              echo "Before it happens, please read and execute the instructions below."
-              echo "Please use a separate terminal to execute any additional commands."
-              echo "(use keyboard arrows to navigate)"
-              "$rvm_scripts_path"/requirements
-              echo "Press 'q' to continue."
-            } | less
+              if [[ -t 1 ]]
+              then
+                echo "Ruby (and needed base gems) for your selection will be installed shortly."
+                echo "Before it happens, please read and execute the instructions below."
+                echo "Please use a separate terminal to execute any additional commands."
+                echo "(use keyboard arrows to navigate)"
+                "$rvm_scripts_path"/requirements
+                echo "Press 'q' to continue."
+              else
+                echo "Ruby (and needed base gems) for your selection will now be installed."
+                echo "If you encounter any problems, please read and execute the instructions"
+                echo "below before trying again."
+                "$rvm_scripts_path"/requirements
+              fi
+            } | rvm_less
           fi
           __rvm_manage_wrapper install "${rvm_ruby_strings}"
         fi
@@ -1165,4 +1173,13 @@ To reinstall use:
   fi
 
   return ${result:-0}
+}
+
+# deal with things when we're not running interactively
+rvm_less() {
+  if [[ -t 1 ]] ; then
+    less
+  else
+    cat
+  fi
 }


### PR DESCRIPTION
scripts/cli pipes the output of scripts/requirements to the UNIX "less" pager. This stops rvm from successfully installing a ruby interpreter if rvm is NOT being run from a terminal (e.g., rvm is being run from a provisioning system such as chef or ansible).

This patch updates scripts/cli to only use "less" when rvm is being run from a terminal.
