### PR TITLE
Check if `make distclean` should be run before configuring packages such as libyaml.

### DIFF
--- a/scripts/functions/pkg
+++ b/scripts/functions/pkg
@@ -59,6 +59,11 @@ install_package()
         autoreconf "${rvm_autoconf_flags[@]}"
     fi
 
+    if [[ -f Makefile && -f config.status ]]; then
+       __rvm_log_command "$package/distclean" "Cleaning $package in $rvm_src_path/$package-$version." \
+            make distclean
+    fi
+
     [[ -n "${rvm_configure_env[*]}" ]] || rvm_configure_env=() # zsh can assume empty var => ( '' )
     (( ${#configure[@]} )) || configure=( ./configure )
     configure=(


### PR DESCRIPTION
Check if `make distclean` should be run before configuring packages such as libyaml.

[See issue #1437](https://github.com/wayneeseguin/rvm/issues/1437)
