### PR TITLE
rvm install rbx-head causes file_exists_at_url warning

### DIFF
--- a/scripts/functions/manage/rubinius
+++ b/scripts/functions/manage/rubinius
@@ -75,8 +75,16 @@ rubinius_install()
 
   __rvm_compatibility_flag_configuration --default-version=
 
-  if ( [[ -n "${rvm_ruby_package_file}" ]] && [[ -s "${rvm_archives_path}/${rvm_ruby_package_file}" ]] ) ||
-    ( [[ -n "${rvm_ruby_url:-}" ]] && file_exists_at_url "${rvm_ruby_url}" )
+  if
+    {
+      [[ -n "${rvm_ruby_package_file:-}" &&
+         -f "${rvm_archives_path}/${rvm_ruby_package_file}" &&
+         -s "${rvm_archives_path}/${rvm_ruby_package_file}" ]]
+    } ||
+    {
+      [[ -n "${rvm_ruby_url:-}" ]] &&
+      file_exists_at_url "${rvm_ruby_url}"
+    }
   then
     rvm_head_flag=0
   else


### PR DESCRIPTION
When attempting to install rbx-head via rvm the following warning appears:

```
Warning: URL was not passed to file_exists_at_url
```

A quick trace:

```
++ 1359174537.799319528 /scripts/functions/manage/rubinius : rubinius_install()  -1096 > [[ -s /home/cwgem/.rvm/archives/ ]]
++ 1359174537.801610602 /scripts/functions/manage/rubinius : rubinius_install()  79 > file_exists_at_url ''
++ 1359174537.804529338 /scripts/functions/utility : file_exists_at_url()  16 > [[ -n '' ]]
++ 1359174537.807018620 /scripts/functions/utility : file_exists_at_url()  721 > rvm_log 'Warning: URL was not passed to file_exists_at_url'
++ 1359174537.809535140 /scripts/functions/logging : rvm_log()  105 > rvm_pretty_print stdout
++ 1359174537.812035388 /scripts/functions/logging : rvm_pretty_print()  17 > case "${rvm_pretty_print_flag:=auto}" in
++ 1359174537.814322691 /scripts/functions/logging : rvm_pretty_print()  22 > case "${TERM:-dumb}" in
++ 1359174537.816705605 /scripts/functions/logging : rvm_pretty_print()  25 > case "$1" in
++ 1359174537.818998283 /scripts/functions/logging : rvm_pretty_print()  10 > [[ -t 1 ]]
++ 1359174537.821350048 /scripts/functions/logging : rvm_pretty_print()  32 > return 0
++ 1359174537.823813281 /scripts/functions/logging : rvm_log()  106 > printf %b 'Warning: URL was not passed to file_exists_at_url\n'
Warning: URL was not passed to file_exists_at_url
```

lead me to this piece of code:

```
  if [[ -s "${rvm_archives_path}/${rvm_ruby_package_file}" ]] ||
    [[ -n "${rvm_ruby_url:-}" ]] && file_exists_at_url "${rvm_ruby_url}"
  then
    rvm_head_flag=0
  else
    rvm_head_flag=1
```

What's happening is that first `-s` check needs both `${rvm_archives_path}` and `${rvm_ruby_package_file}` to be set, but if `${rvm_ruby_package_file}` is empty and `${rvm_archives_path}` is set to a valid location, this will become a false positive. 

This also causes the && conditional to be hit unexpectedly so I also added some parens around as a safeguard in the future. 
