### PR TITLE
Requirements scripts functions need to match os name

### DIFF
--- a/scripts/functions/requirements/openbsd
+++ b/scripts/functions/requirements/openbsd
@@ -2,7 +2,7 @@
 
 set -e
 
-function requirements_gentoo()
+function requirements_openbsd()
 {
   typeset -a command_to_run __ctr_sudo
   typeset __ctr_echo
@@ -70,4 +70,4 @@ function requirements_gentoo()
   done
 }
 
-requirements_gentoo "$@"
+requirements_openbsd "$@"

--- a/scripts/functions/requirements/openindiana
+++ b/scripts/functions/requirements/openindiana
@@ -2,7 +2,7 @@
 
 set -e
 
-function requirements_gentoo()
+function requirements_openindiana()
 {
   typeset -a command_to_run command_flags
   command_to_run=()
@@ -57,4 +57,4 @@ function requirements_gentoo()
   done
 }
 
-requirements_gentoo "$@"
+requirements_openindiana "$@"

--- a/scripts/functions/requirements/smartos
+++ b/scripts/functions/requirements/smartos
@@ -2,7 +2,7 @@
 
 set -e
 
-function requirements_gentoo()
+function requirements_smartos()
 {
   typeset -a command_to_run command_flags
   command_to_run=()
@@ -57,4 +57,4 @@ function requirements_gentoo()
   done
 }
 
-requirements_gentoo "$@"
+requirements_smartos "$@"

--- a/scripts/functions/requirements/solaris
+++ b/scripts/functions/requirements/solaris
@@ -2,7 +2,7 @@
 
 set -e
 
-function requirements_gentoo()
+function requirements_solaris()
 {
   typeset -a command_to_run command_flags
   command_to_run=()
@@ -57,4 +57,4 @@ function requirements_gentoo()
   done
 }
 
-requirements_gentoo "$@"
+requirements_solaris "$@"


### PR DESCRIPTION
Noticed that a few of the scripts in `scripts/functions/requirements` had their functions named `_gentoo` so this matches their OS names instead. 
