### PR TITLE
Fix --verify-download typo in help files

### DIFF
--- a/help/fetch
+++ b/help/fetch
@@ -4,9 +4,9 @@ Performs an archive / src fetch of the current selected ruby.
 
 ## Usage
 
-    ∴ rvm fetch [--verify-download {0,1,2}]
+    ∴ rvm fetch [--verify-downloads {0,1,2}]
 
-Where `--verify-download {0,1,2}` specifies verification level:
+Where `--verify-downloads {0,1,2}` specifies verification level:
 
 - `0` - only verified allowed - the default,
 - `1` - allow missing checksum,

--- a/help/install
+++ b/help/install
@@ -1,6 +1,6 @@
 ## Usage
 
-    rvm install {ruby-string} [--verify-download {0,1,2}] [--binary|--disable-binary|--movable]
+    rvm install {ruby-string} [--verify-downloads {0,1,2}] [--binary|--disable-binary|--movable]
 
 
 For a partial list of valid ruby strings please run
@@ -49,7 +49,7 @@ More details about managing binary builds can be found in `rvm help mount`.
 
 ## Verification
 
-`--verify-download {0,1,2}` specifies verification level:
+`--verify-downloads {0,1,2}` specifies verification level:
 
 - `0` - only verified allowed,
 - `1` - allow missing checksum,


### PR DESCRIPTION
As per #1477 (`rvm help install` misspells --verify-downloads)
