### PR TITLE
Improve the error message when a checksum can't be found for a given ruby.

### DIFF
--- a/scripts/fetch
+++ b/scripts/fetch
@@ -41,7 +41,10 @@ __rvm_checksum_read "$url" "$archive"
 
 __rvm_checksum_any || (( ${rvm_verify_downloads_flag:-0} > 0 )) ||
   rvm_fail "There is no checksum for '$url' or '$archive', it's not possible to validate it.
-If you wish to continue with unverified download add '--verify-downloads 1' after the command.
+This could be because your RVM install's list of versions is out of date. You may want to
+update your list of rubies by running 'rvm get stable' and try again.
+If that does not resolve the issue and you wish to continue with unverified download
+add '--verify-downloads 1' after the command.
 "
 
 if


### PR DESCRIPTION
This could be becuase the user hasn't updated their list of rubies so I
add a line to show how to update your list of rubies.
