### PR TITLE
Enable OpenSSL ASM Optimizations

### DIFF
--- a/scripts/functions/pkg
+++ b/scripts/functions/pkg
@@ -183,6 +183,7 @@ install_openssl()
         [[ $hw_cpu64bit == 1 ]]
       then
         openssl_os="darwin64-x86_64-cc"
+        openssl_use_asm=1
       else
         openssl_os="darwin-i386-cc"
       fi
@@ -193,8 +194,13 @@ install_openssl()
   else
     configure_command="./config"
   fi
+  if
+    [[ "$openssl_use_asm" != "1" ]]
+  then
+    openssl_no_asm="no-asm"
+  fi
   configure=(
-    $configure_command $openssl_os -I$rvm_usr_path/include -L$rvm_usr_path/lib zlib no-asm no-krb5
+    $configure_command $openssl_os -I$rvm_usr_path/include -L$rvm_usr_path/lib zlib $openssl_no_asm no-krb5
   )
   install_package
   __rvm_log_command openssl.certs "Updating openssl certificates" update_openssl_certs


### PR DESCRIPTION
This patch removes the no-asm flag from the OpenSSL config directives if the build target is darwin64-x86_64-cc.

The openssl config scripts appear to properly determine whether or not no-asm should be used, so rather than accepting this pull request it's probably better to decide whether the no-asm flag should be entirely removed (maybe it is there for reasons I'm unaware of?).

The advantage to removing the flag is that it allows OpenSSL 1.0.1+ to utilize the AES-NI accelerated paths on Intel processors that support the extension. This results in a ~4-6x performance improvement in AES encryption throughput. There are also several optimized hash implementations that are significantly faster.

I've tested removing no-asm and compiling using clang (Apple/clang-421.11.66) on OS X 10.8.2 as well as gcc 4.7.2 on a Fedora 17 VM so far.
