### PR TITLE
Fix mruby install - change mruby 'lib' directory to 'mrblib'

### DIFF
--- a/scripts/functions/manage/mruby
+++ b/scripts/functions/manage/mruby
@@ -65,7 +65,7 @@ mruby_install()
 
   mkdir -p "$rvm_ruby_home/";
 
-  rvm_ruby_make_install=${rvm_ruby_make_install:-"/bin/\cp -Rf \"${rvm_src_path}/$rvm_ruby_string\"/{bin,lib,include} \"$rvm_ruby_home/\""}
+  rvm_ruby_make_install=${rvm_ruby_make_install:-"/bin/\cp -Rf \"${rvm_src_path}/$rvm_ruby_string\"/{bin,mrblib,include} \"$rvm_ruby_home/\""}
   if __rvm_run "install" "$rvm_ruby_make_install" "$rvm_ruby_string - #installing "
   then true
   else


### PR DESCRIPTION
In mruby the 'lib' directory is called 'mrblib'. Right now `rvm install mruby` errors out on the trying to cp the lib directory: `.rvm/src/mruby-head/lib: No such file or directory`.
This commit changes 'lib' to 'mrblib' to address this issue.

Tested this locally and everything works as it should.
