### PR TITLE
Fix on topaz URL parsing regex

### DIFF
--- a/scripts/functions/manage/topaz
+++ b/scripts/functions/manage/topaz
@@ -20,7 +20,7 @@ topaz_install()
 	rvm_error "Topaz only provides binary packages for Linux i386 and x86_64 and Darwin x86_64. You try to build the HEAD version"
 	;;
     esac
-    rvm_ruby_package_file="$(curl "${rvm_ruby_url}" | grep -Eo "topaz-${version}-[^.]+.tar.bz2" | head -1)"
+    rvm_ruby_package_file="$(curl "${rvm_ruby_url}" | grep -Eo "topaz-${version}-[^.]+\.tar\.bz2" | head -1)"
     rvm_ruby_url="${rvm_ruby_url}/${rvm_ruby_package_file}"
 
     __rvm_cd "${rvm_archives_path}"


### PR DESCRIPTION
RVM checks a list of packages from http://builds.topazruby.com/ before downloading the actual package. The current grep is overly greedy as shown here:

```
cwgem@elixer ~ $ grep -Eo "topaz-linux64-.*?.tar.bz2" topaz.xml | head -n 1                                                                                                                               
topaz-linux64-04ab1983cf39127e0d8ed4efdbdccbe819eb2992.tar.bz2</Key><LastModified>2013-02-06T15:29:56.000Z</LastModified><ETag>&quot;d6baa1e6e69de6764a552717c6d00857&quot;</ETag><Size>3658550</Size><Owner><ID>09584dbfd79bab8e60ed2c2d9d99cc1c2b36cd1ac937cf712e954ba3a366f68b</ID><DisplayName>alex.gaynor</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents><Contents><Key>topaz-msvc-i386-51466ba4ab8a921527de436da15f467c2b503fc5.tar</Key><LastModified>2013-02-06T16:19:11.000Z</LastModified><ETag>&quot;aa6a2990289fef6a3be411ee68e87f73&quot;</ETag><Size>6563840</Size><StorageClass>STANDARD</StorageClass></Contents><Contents><Key>topaz-osx64-242eebe5ce38a6c9808ccecaa46bfa427d53e2d4.tar.bz2
```

This addresses it by being more specific on the regex:

```
topaz-${version}-[^.]+.tar.bz2
topaz-linux64-04ab1983cf39127e0d8ed4efdbdccbe819eb2992.tar.bz2
```

Which matches the hash part with "One or more characters that are not a period". 

```
cwgem@elixer ~ $ grep -Eo "topaz-linux64-[^.]+.tar.bz2" topaz.xml | head -n 1                                                                                                                             
topaz-linux64-04ab1983cf39127e0d8ed4efdbdccbe819eb2992.tar.bz2
```
