### PR TITLE
Fixed install for nokogiri on fedora 18 and CentOS

### DIFF
--- a/scripts/functions/requirements/centos
+++ b/scripts/functions/requirements/centos
@@ -54,7 +54,7 @@ function requirements_yum()
         true # not that easy
         ;;
       (*)
-        "${command_to_run[@]}" yum install "${command_flags[@]}" gcc-c++ patch readline readline-devel zlib zlib-devel libyaml-devel libffi-devel openssl-devel make bzip2 autoconf automake libtool bison iconv-devel
+        "${command_to_run[@]}" yum install "${command_flags[@]}" gcc-c++ patch readline readline-devel zlib zlib-devel libyaml-devel libffi-devel openssl-devel make bzip2 autoconf automake libtool bison iconv-devel libxml2-devel libxslt-devel
         ;;
     esac
     shift


### PR DESCRIPTION
As discussed on IRC with @mpapis, this adds the requirements for nokogiri (and several other popular gems) to `rvm requirements`.
