### PR TITLE
Adding libxml2/libxslt + devel packages to the requirements list on redhat based distros

### DIFF
--- a/scripts/functions/requirements/centos
+++ b/scripts/functions/requirements/centos
@@ -54,7 +54,7 @@ function requirements_yum()
         true # not that easy
         ;;
       (*)
-        "${command_to_run[@]}" yum install "${command_flags[@]}" gcc-c++ patch readline readline-devel zlib zlib-devel libyaml-devel libffi-devel openssl-devel make bzip2 autoconf automake libtool bison iconv-devel
+        "${command_to_run[@]}" yum install "${command_flags[@]}" gcc-c++ patch readline readline-devel zlib zlib-devel libyaml-devel libffi-devel openssl-devel make bzip2 autoconf automake libtool bison iconv-devel libxml2 libxml2-devel libxslt libxslt-devel
         ;;
     esac
     shift


### PR DESCRIPTION
This is needed to allow nokogiri (a fairly popular gem) to compile properly. These requirements are taken from the official HP http://nokogiri.org/tutorials/installing_nokogiri.html
