### PR TITLE
Small addition to usage doc for "list"

### DIFF
--- a/docs/rvm.txt
+++ b/docs/rvm.txt
@@ -191,7 +191,7 @@ ACTIONS
     Performs an archive / src fetch only of the selected ruby.
 
 *list*::
-    Show currently installed rubies, interactive output.
+    Show currently installed or available rubies, interactive output.
     https://rvm.io/rubies/list/
 
 *pkg*::


### PR DESCRIPTION
Provides a clue which command to look at to get a list of all available rubies. Aligns the output of "rvm usage" with "rvm help list".

I've found the usage doc confusing because it doesn't provide a clue for how to get a list of available rubies. IMO, the core basic use case for rvm is:
1. See what rubies are available
2. Install one

The usage doc has a lot of info about #2, but not about #1. This pull request is a small change in that direction.
