### PR TITLE
Bug fix for rvm_path in .bash_profile and .zprofile

### DIFF
--- a/scripts/functions/installer
+++ b/scripts/functions/installer
@@ -1124,7 +1124,7 @@ PATH=\$PATH:$local_rvm_path/bin # Add RVM to PATH for scripting
     do
       touch $profile_file
     printf "%b" "
-[[ -s \"\$HOME/.rvm/scripts/rvm\" ]] && source \"$local_rvm_path/scripts/rvm\" # Load RVM into a shell session *as a function*
+[[ -s \"$local_rvm_path/scripts/rvm\" ]] && source \"$local_rvm_path/scripts/rvm\" # Load RVM into a shell session *as a function*
 " >> $profile_file
     done
     user_login_files=( ${target_login[@]} )


### PR DESCRIPTION
fix rvm_path in .bash_profile/.zprofile when not default rvm_path is specified.
