### PR TITLE
Fixed rvm reinstall/remove ruby not working properly

### DIFF
--- a/scripts/cli
+++ b/scripts/cli
@@ -206,14 +206,14 @@ __rvm_parse_args()
             ;;
 
           gem|rake|ruby)
-            if
-              [[ "$rvm_token" == "ruby" ]] &&
-              [[ "$rvm_action" == "install" || "$rvm_action" == "use" ]]
-            then
-              rvm_ruby_string=ruby
-              rvm_ruby_strings=ruby
-              continue
-            fi
+            [[ "$rvm_token" == "ruby" ]] &&
+            case $rvm_action in
+              install|reinstall|use|remove)
+                rvm_ruby_string=ruby
+                rvm_ruby_strings=ruby
+                continue
+              ;;
+            esac
             # deprecated 2011.10.11 for RVM 1.9.0, removed 2012.09.13 for RVM 1.16.0
             rvm_action=error
             rvm_error_message="Please note that \`rvm $rvm_token ...\` was removed, try \`$rvm_token $next_token $*\` or \`rvm all do $rvm_token $next_token $*\` instead."


### PR DESCRIPTION
Related to issue #1550. Basically the `install` and `use` commands were treating `ruby` as a proper argument, but reinstall and remove were not. This address the issue by adding in reinstall and remove to the logic branch. Also cleaned it up into a case statement.
