### PR TITLE
Use rvm ruby for the auto_gem after install hook

### DIFF
--- a/hooks/after_install_auto_gem
+++ b/hooks/after_install_auto_gem
@@ -6,7 +6,7 @@ if
   ]]
 then
   typeset __sitelib
-  __sitelib="$( ruby -e "puts RbConfig::CONFIG['sitelibdir']" )"
+  __sitelib="$( $rvm_ruby_binary -e "puts RbConfig::CONFIG['sitelibdir']" )"
   if [[ -n "${__sitelib}" ]]
   then touch "${__sitelib}/auto_gem.rb"
   else echo "WARN: Installed ruby does not have valid 'sitelibdir', no 'auto_gem.rb' was created, please report a bug here: https://github.com/wayneeseguin/rvm/issues"


### PR DESCRIPTION
Fixes issue #1551 by using rvm specified ruby instead of the system ruby for getting `sitelibdir`
