### PR TITLE
1.8 series ruby needs to pull in -rrbconfig for RbConfig to work.

### DIFF
--- a/hooks/after_install_auto_gem
+++ b/hooks/after_install_auto_gem
@@ -6,7 +6,7 @@ if
   ]]
 then
   typeset __sitelib
-  __sitelib="$( $rvm_ruby_binary -e "puts RbConfig::CONFIG['sitelibdir']" )"
+  __sitelib="$( $rvm_ruby_binary -rrbconfig -e "puts RbConfig::CONFIG['sitelibdir']" )"
   if [[ -n "${__sitelib}" ]]
   then touch "${__sitelib}/auto_gem.rb"
   else echo "WARN: Installed ruby does not have valid 'sitelibdir', no 'auto_gem.rb' was created, please report a bug here: https://github.com/wayneeseguin/rvm/issues"


### PR DESCRIPTION
Otherwise the after install hook complains for Gentoo when doing an install of rubyee
