### PR TITLE
Adjusting portageq to use match instead which will work on older versions

### DIFF
--- a/scripts/functions/requirements/gentoo
+++ b/scripts/functions/requirements/gentoo
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 
-requirements_gentoo_lib_installed()
-{
-  portageq best_visible / installed "$1" >/dev/null || return $?
-}
+requirements_gentoo_lib_installed() [[ -n "$(portageq match / "$1" 2>/dev/null)" ]]
 
 requirements_gentoo_libs_install()
 {


### PR DESCRIPTION
Older `portageq` versions do not support `best_visible` for installed packages so this uses `match` instead which works on both, and works for installed packages.
