### PR TITLE
Update binscripts/rvm-installer

### DIFF
--- a/binscripts/rvm-installer
+++ b/binscripts/rvm-installer
@@ -40,7 +40,7 @@ else
       fi
       rvm_tar_command=gtar
       ;;
-    (Darwin) # it's not possible to autodetect on OSX, the help/man does not mention all flags
+    (Darwin|FreeBSD) # it's not possible to autodetect on OSX, the help/man does not mention all flags
       rvm_tar_command=tar
       ;;
   esac


### PR DESCRIPTION
FreeBSD tar actually supports --strip-components, though it is not documented in `tar --help`. It is, however, in the manual:
     --strip-components count -(x mode only) Remove the specified number of leading path elements.  Pathnames with fewer elements will be silently skipped. Note that the pathname is edited after checking inclusion/exclusion patterns but before security checks.
