### PR TITLE
Add category to zlib as packagename is ambiguous

### DIFF
--- a/scripts/functions/requirements/gentoo
+++ b/scripts/functions/requirements/gentoo
@@ -32,7 +32,7 @@ requirements_gentoo()
       requirements_gentoo_ensure_libs nodejs
       ;;
     (*)
-      requirements_gentoo_ensure_libs libiconv readline zlib openssl curl git libyaml sqlite libxslt libtool gcc autoconf automake bison m4
+      requirements_gentoo_ensure_libs libiconv readline sys-libs/zlib openssl curl git libyaml sqlite libxslt libtool gcc autoconf automake bison m4
       ;;
   esac
 }


### PR DESCRIPTION
Fixes the following problem:

   [ Results for search key : zlib ]
   [ Applications found : 2 ]

```
*  dev-haskell/zlib
     Latest version available: 0.5.3.3
     Latest version installed: 0.5.3.3
     Size of files: 122 kB
     Homepage:      http://hackage.haskell.org/package/zlib
     Description:   Compression and decompression in the gzip and zlib
     License:       BSD

*  sys-libs/zlib
     Latest version available: 1.2.7
     Latest version installed: 1.2.7
     Size of files: 547 kB
     Homepage:      http://www.zlib.net/
     Description:   Standard (de)compression library
     License:       ZLIB

!!! The short ebuild name "zlib" is ambiguous. Please specify
```

   !!! one of the above fully-qualified ebuild names instead.
