### PR TITLE
Add user-supplied repo support to rvm-installer

### DIFF
--- a/binscripts/rvm-installer
+++ b/binscripts/rvm-installer
@@ -134,7 +134,7 @@ install_head()
   esac
   log "Downloading RVM from ${_repo} branch ${_branch}"
   get_and_unpack \
-    https://github.com/wayneeseguin/rvm/archive/${_branch}.tar.gz \
+    https://github.com/${_repo}/rvm/archive/${_branch}.tar.gz \
     ${_repo}-rvm-${_branch//\//_}.tgz
 }
 


### PR DESCRIPTION
Fixed support for using a user supplied repo when invoking the installer from get.rvm.io
