### PR TITLE
Removing Patch dependency for OpenBSD

### DIFF
--- a/scripts/functions/requirements/openbsd
+++ b/scripts/functions/requirements/openbsd
@@ -24,7 +24,7 @@ function requirements_openbsd()
         curl ftp://ftp.openbsd.org/pub/OpenBSD/$(uname -r)/ports.tar.gz | __rvm_try_sudo tar -C /usr -zx
       ;;
     (rvm)
-      requirements_openbsd_ensure_libs bash curl git patch
+      requirements_openbsd_ensure_libs bash curl git
       ;;
     (jruby-head*)
       requirements_openbsd_ensure_libs jdk apache-ant


### PR DESCRIPTION
This seemed to go along with the work in #1554. No available package provides the 'patch' binary:

```
[~/projects/shell-rvm] $> which patch
/usr/bin/patch
[~/projects/shell-rvm] $> pkg_info -E /usr/bin/patch
[~/projects/shell-rvm] $>
```

When using rvm-head, I consistently get missing dependency warnings without this. If there's additional improvements I missed re: this, I'll be happy to make them.
