### PR TITLE
Fix MacPorts port name for pkg-config

### DIFF
--- a/scripts/functions/requirements/osx_port
+++ b/scripts/functions/requirements/osx_port
@@ -26,7 +26,7 @@ requirements_port_libs_default()
 {
   typeset -a port_libs
   port_libs=(
-    autoconf automake libtool pkg-config
+    autoconf automake libtool pkgconfig
   )
   # install gcc-4.2 only if not yet available
   if


### PR DESCRIPTION
This is a one char change, updating the port name for pkg-config for MacPorts. I had to make this change to get rvm head to work just now, but I'm not sure how this could have been working at all? Was nobody using this yet, or have I missed something?

http://www.macports.org/ports.php?by=library&substr=pkgconfig
