### PR TITLE
Alternatives to `port installed`.

### DIFF
--- a/scripts/functions/requirements/osx_port
+++ b/scripts/functions/requirements/osx_port
@@ -3,6 +3,10 @@
 requirements_port_lib_installed()
 {
   port installed | GREP_OPTIONS="" \grep "^\s*${1} @" >/dev/null || return $?
+
+  # Two alternatives:
+  # port installed active | GREP_OPTIONS="" \grep "^\s*${1} @" >/dev/null || return $?
+  # [[ "$(port installed ${1})" =~ '(active)' ]] && return $?
 }
 
 requirements_port_libs_install()


### PR DESCRIPTION
This PR is not for merging, it's to discuss how RVM detects installed ports. I've presented to alternatives, discussed below.

`port installed` can be slow, running a complete list for each library check increases run time.  Asking for a specific port name is faster, but is it suitable?

Also, the check does not consider 'inactive' ports.  For example, with `openssl` installed but inactive, this will result in a false positive for a satisfied dependency.  I think we should check against the list of active ports.
