### PR TITLE
debian/ubuntu multiarch dependency checking

### DIFF
--- a/scripts/functions/requirements/ubuntu
+++ b/scripts/functions/requirements/ubuntu
@@ -17,7 +17,7 @@ requirements_debian_lib_installed()
 # In Debian dpkg this is present since 1.16.2. In Ubuntu this is present since natty (v1.15.8.10ubuntu1). Check by seeing if dpkg --print-foreign-architectures is understood.
 requirements_debian_is_multiarch()
 {
-  dpkg --print-foreign-architectures || return $?
+  dpkg --print-foreign-architectures >/dev/null 2>&1 || return $?
 }
 
 requirements_debian_libs_install()


### PR DESCRIPTION
Currently RVM uses "dpkg -s" to check if a required library is installed.  When using multiarch, this simple check will fail when you have multiple arch versions of a package installed.  

In my case it was zlib1g.

```
# dpkg -s zlib1g
dpkg-query: error: --status needs a valid package name but 'zlib1g' is not: ambiguous package name 'zlib1g' with more than one installed instance
```

In order for dpkg -s to report correctly, the machine arch needs to be appended.

```
# dpkg -s zlib1g:amd64
    Package: zlib1g
    Status: install ok installed
    .... etc

# dpkg -s zlib1g:i386
    Package: zlib1g
    Status: install ok installed
    .... etc
```
