### PR TITLE
Checking for the existence of patch via a package manager is not necessary

### DIFF
--- a/scripts/functions/requirements/freebsd
+++ b/scripts/functions/requirements/freebsd
@@ -30,7 +30,7 @@ requirements_freebsd_run()
       }
       ;;
     (rvm)
-      requirements_freebsd_ensure_libs bash curl git patch
+      requirements_freebsd_ensure_libs bash curl git
       ;;
     (jruby-head*)
       requirements_freebsd_ensure_libs jdk apache-ant


### PR DESCRIPTION
The patch binary lives within the base system on FreeBSD (independent of the ports system or binary packages) - therefore it is always installed.
