### PR TITLE
bash is installed in the FreeBSD basesystem by default.

### DIFF
--- a/scripts/functions/requirements/freebsd
+++ b/scripts/functions/requirements/freebsd
@@ -30,7 +30,7 @@ requirements_freebsd_run()
       }
       ;;
     (rvm)
-      requirements_freebsd_ensure_libs bash curl git
+      requirements_freebsd_ensure_libs curl git
       ;;
     (jruby-head*)
       requirements_freebsd_ensure_libs jdk apache-ant


### PR DESCRIPTION
```
[jps@~]$ bash --version
bash --version
GNU bash, version 4.2.20(0)-release (i386-portbld-freebsd9.0)
Copyright (C) 2011 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
[jps@~]$ which bash
which bash
/bin/bash
```
