### PR TITLE
separate --with-opt-dir= handling for rbx

### DIFF
--- a/scripts/functions/build
+++ b/scripts/functions/build
@@ -113,7 +113,10 @@ __rvm_update_configure_env()
 __rvm_update_configure_opt_dir()
 {
   case "$1" in
-    (ruby-head*|ruby-2*|rbx*|rubinius*)
+    (rbx*|rubinius*)
+      __rvm_update_configure_opt_dir_options "$2"
+      ;;
+    (ruby-head*|ruby-2*)
       __rvm_update_configure_opt_dir_option "$2"
       ;;
     (ruby-1.9.3-p*)
@@ -137,6 +140,14 @@ __rvm_update_configure_opt_dir()
   esac
 }
 
+# add multiple --with-opt-dir=
+__rvm_update_configure_opt_dir_options()
+{
+  rvm_debug "rvm_configure_flags+=( --with-opt-dir=$1 )"
+  rvm_configure_flags+=( --with-opt-dir="$1" )
+}
+
+# update single --with-opt-dir=
 __rvm_update_configure_opt_dir_option()
 {
   rvm_debug "rvm_configure_flags+=( --with-opt-dir=$1 )"


### PR DESCRIPTION
Fixes RBX compilation on OSX - missing `libyaml`
