### PR TITLE
rvm-pkg issues / please re-include libyaml

### DIFF
--- a/help/autolibs.md
+++ b/help/autolibs.md
@@ -49,7 +49,7 @@ Using 3 only once:
 rvm install --autolibs=packages
 ```
 
-You can also optionally enforce a package manager if you are using smf or on OS X by issuing one of the following instead of 4: `brew, homebrew, osx_brew, port, macports, osx_port, fink, osx_fink`
+You can also optionally enforce a package manager if you are using smf or on OS X by issuing one of the following instead of 4: `brew, homebrew, osx_brew, port, macports, osx_port, fink, osx_fink, rvm_pkg`
 
 ## Other options (2, 1 and 0).
 
@@ -68,3 +68,4 @@ Autolibs also has three other options and these options are 2, which will read p
 * `fink`, `osx_fink` - Like 4, enforces Fink.
 * `smf` - Like 4, enforce SM Framework.
 * `port`, `macports`, `osx_port` - Like 4, enforce MacPorts.
+* `rvm_pkg` - Make use of old `rvm pkg` code, uses extra `pkg-config` code to detect existing libraries.

--- a/scripts/functions/autolibs
+++ b/scripts/functions/autolibs
@@ -48,9 +48,9 @@ __rvm_autolibs_translate()
       rvm_autolibs_flag_number=4
       rvm_autolibs_flag_runner="osx_fink"
       ;;
-    (smf)
+    (smf|rvm_pkg)
       rvm_autolibs_flag_number=4
-      rvm_autolibs_flag_runner="smf"
+      rvm_autolibs_flag_runner="${rvm_autolibs_flag}"
       ;;
     (*)
       rvm_debug "Unknown 'rvm_autolibs_flag' value '$rvm_autolibs_flag'."

--- a/scripts/functions/build_requirements
+++ b/scripts/functions/build_requirements
@@ -7,7 +7,7 @@ __rvm_requirements_run()
   __type=$1
   __lib_type=$1
   shift
-  for __iterator in load reset before define summary update install custom after
+  for __iterator in load reset before define summary update custom install after
   do
     __rvm_requirements_run_${__iterator} "$@" || return $?
   done
@@ -128,6 +128,25 @@ __rvm_requirements_run_update()
   fi
 }
 
+__rvm_requirements_run_custom()
+{
+  if
+    is_a_function requirements_${__lib_type}_install_custom
+  then
+    rvm_requiremnts_fail_or_run_action 2 \
+      "Skipping ${packages_custom[*]} installation, make sure listed packages are installed." \
+      "requirements_${__lib_type}_install_custom" "${packages_custom[@]}" || return $?
+  else
+    typeset __package
+    for __package in "${packages_custom[@]}"
+    do
+      rvm_requiremnts_fail_or_run_action 2 \
+        "Skipping ${__package} installation, make sure ${__package} is installed." \
+        "requirements_${__lib_type}_install_${__package}" || return $?
+    done
+  fi
+}
+
 __rvm_requirements_run_install()
 {
   (( ${#packages_to_install[@]} == 0 )) ||
@@ -137,16 +156,6 @@ __rvm_requirements_run_install()
       "requirements_${__lib_type}_libs_install" "${packages_to_install[@]}" ||
       return $?
   }
-}
-
-__rvm_requirements_run_custom()
-{
-  for __package in "${packages_custom[@]}"
-  do
-    rvm_requiremnts_fail_or_run_action 2 \
-      "Skipping ${__package} installation, make sure ${__package} is installed." \
-      "requirements_${__lib_type}_install_${__package}" || return $?
-  done
 }
 
 __rvm_requirements_run_after()
@@ -175,6 +184,15 @@ requirements_check()
     do __rvm_filter_installed_package_check "requirements_${__lib_type}_lib_installed" "${_package_name}"
     done
   fi
+}
+
+requirements_check_custom()
+{
+  typeset __package
+  for __package
+  do
+    __rvm_which "${__package}" >/dev/null || packages_custom+=( "${__package}" )
+  done
 }
 
 __rvm_filter_installed_package_from_missing()

--- a/scripts/functions/pkg
+++ b/scripts/functions/pkg
@@ -135,6 +135,10 @@ install_readline()
   patches="$rvm_patches_path/$package-$version/patch-shobj-conf.diff"
   install_package
 }
+readline_installed()
+{
+  package_installed "readline/readline.h" "libreadline" || return $?
+}
 
 install_iconv()
 {
@@ -242,6 +246,11 @@ install_gettext()
 {
   package="gettext" ; version="0.17" ; archive_format="tar.gz"
   install_package
+}
+
+install_libxml()
+{
+  install_libxml2 "$@"
 }
 
 install_libxml2()

--- a/scripts/functions/requirements/freebsd
+++ b/scripts/functions/requirements/freebsd
@@ -85,7 +85,7 @@ requirements_freebsd_define()
       requirements_check mono
       ;;
     (opal)
-      __rvm_which node >/dev/null || packages_custom+=( node )
+      requirements_check_custom node
       ;;
     (*-head)
       # OpenSSL is installed by default http://www.freebsd.org/crypto.html

--- a/scripts/functions/requirements/openbsd
+++ b/scripts/functions/requirements/openbsd
@@ -40,7 +40,7 @@ requirements_openbsd_define()
       requirements_check mono
       ;;
     (opal)
-      __rvm_which node >/dev/null || packages_custom+=( node )
+      requirements_check_custom node
       ;;
     (*-head)
       # OpenSSL is installed by default http://www.openbsd.org/crypto.html

--- a/scripts/functions/requirements/rvm_pkg
+++ b/scripts/functions/requirements/rvm_pkg
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+
+source "$rvm_scripts_path/functions/pkg"
+
+requirements_rvm_pkg_config()
+{
+  PKG_CONFIG_PATH="${rvm_usr_path:-${rvm_path}/usr}/lib/pkgconfig:${rvm_usr_path:-${rvm_path}/usr}/lib64/pkgconfig:/opt:/usr:/usr/local" pkg-config "$@"
+}
+
+requirements_rvm_pkg_lib_installed()
+{
+  if is_a_function ${1}_installed && ${1}_installed
+  then return 0
+  fi
+  requirements_rvm_pkg_config --list-all | grep "^$1[- ]" >/dev/null || return $?
+  true
+}
+
+requirements_rvm_pkg_libs_install()
+{
+  while
+    (( $# ))
+  do
+    PKG_CONFIG_LIBDIR="${rvm_usr_path:-${rvm_path}/usr}/lib/pkgconfig" install_$1 || return $?
+    shift
+  done
+}
+
+requirements_rvm_pkg_wait_key()
+{
+  rvm_is_a_shell_function no_warning ||
+  {
+    rvm_error "
+You are using 'rvm autolibs rvm_pkg', this does not know how to install some of the packages, make sure to install those first.
+"
+    return 1
+  }
+  rvm_log "press any key to continue"
+  typeset _read_char_flag anykey
+  [[ -n "${ZSH_VERSION:-}" ]] && _read_char_flag=k || _read_char_flag=n
+  builtin read -${_read_char_flag} 1 -s -r anykey
+}
+
+requirements_rvm_pkg_install_custom()
+{
+  if
+    (( $# > 0 ))
+  then
+    rvm_warn "Before continuing install: $*"
+    requirements_rvm_pkg_wait_key || return $?
+  fi
+}
+
+requirements_rvm_pkg_before()
+{
+  rvm_warn "
+Warning, you are using 'rvm autolibs rvm_pkg', this is rarely used and can produce errors,
+make sure to report any problems to https://github.com/wayneeseguin/rvm/issues
+"
+}
+
+requirements_rvm_pkg_update_system()
+{
+  rvm_warn "Always update your system first!"
+}
+
+requirements_rvm_pkg_define()
+{
+  case "$1" in
+    (rvm)
+      requirements_check_custom bash curl patch
+      ;;
+    (jruby*head)
+      requirements_check_custom java git
+      ;;
+    (jruby*)
+      requirements_check_custom java
+      ;;
+    (ir*)
+      requirements_check_custom mono
+      ;;
+    (opal)
+      requirements_check_custom node
+      ;;
+    (yaml|zlib|openssl|readline|xml2|xslt)
+      true # just skip the packages
+      ;;
+    (*-head)
+      requirements_check_custom git
+      requirements_rvm_pkg_define "${1%-head}"
+      ;;
+    (*)
+      requirements_check_custom gcc g++ libtool bison bzip2
+      requirements_check yaml zlib openssl readline libxml libxslt
+      ;;
+  esac
+}
+
+requirements_rvm_pkg_after_uniqe_paths()
+{
+  typeset __lib __lib_full_name
+  for __lib in yaml zlib openssl readline libxml libxslt
+  do
+    __lib_full_name=$( requirements_rvm_pkg_config --list-all | awk "/^${__lib}[- ]/{print \$1}" )
+    if
+      [[ -n "${__lib_full_name}" ]]
+    then
+      requirements_rvm_pkg_config ${__lib_full_name} --variable=prefix
+    elif
+      [[ "${__lib}" == 'readline' ]]
+    then
+      # http://lists.gnu.org/archive/html/bug-readline/2010-09/msg00002.html
+      echo ${rvm_usr_path:-${rvm_path}/usr}
+    else
+      rvm_error "Can not find ${__lib} in 'pkg-config'"
+    fi
+  done | sort -u
+}
+
+requirements_rvm_pkg_after()
+{
+  typeset __package
+  while
+    read __package
+  do
+    __rvm_update_configure_opt_dir "$1" "$__package"
+  done < <(
+    requirements_rvm_pkg_after_uniqe_paths
+  )
+}

--- a/scripts/functions/requirements/unknown
+++ b/scripts/functions/requirements/unknown
@@ -61,6 +61,11 @@ for details how to disable this message.
   builtin read -${_read_char_flag} 1 -s -r anykey
 }
 
+requirements_unknown_update_system()
+{
+  echo "Always update your system first!"
+}
+
 requirements_unknown_define()
 {
   typeset __reqirement


### PR DESCRIPTION
Old version before 1.9
https://gist.github.com/maus-/50df9bf9de82530707b5
On update it breaks / complains to use autolibs..

this "should" work however..
https://gist.github.com/mpapis/55e2330db7d3509e15dc

this creates a bunch of build issues. (refer to gist for specifics)

This actually runs (Thanks btw mpapis)
https://gist.github.com/mpapis/55e2330db7d3509e15dc

However libyaml is no longer included as a default library causing ruby complain relentlessly. 
