### PR TITLE
Fix: binscripts/rvm-installer is sending malformed arguments to scripts/install when using the --add-to-rvm-group on multiuser environments

### DIFF
--- a/binscripts/rvm-installer
+++ b/binscripts/rvm-installer
@@ -435,7 +435,6 @@ do
       ;;
 
     (--add-to-rvm-group)
-      flags+=( "$token" )
       export rvm_add_users_to_rvm_group="$1"
       shift
       ;;


### PR DESCRIPTION
While installing a multiuser RVM environment using the **--add-to-rvm-group** argument I have found that the **binscripts/rvm-installer** script is sending a malformed argument to  **script/install**. Specifically, it does not send the user list for this argument.

Expected result is a normal install with the specified users already added to the rvm group.

Received result is a script/install call error, "Unrecognized option: /usr/local/rvm", and the usage syntax of this particular script.

Since this user list is already set in the environment variables on binscripts/rvm-installer, there is no need to send it again by parameters. The fix in this pull request simply removes the argument, and lets scripts/install use the rvm_add_users_to_rvm_group to add the users.

Gist whit the error: https://gist.github.com/ldnunes/5374835
