### PR TITLE
pkgng bootstrap code plus only run portsnap extract if ports isn't there yet

### DIFF
--- a/scripts/functions/requirements/freebsd
+++ b/scripts/functions/requirements/freebsd
@@ -47,10 +47,11 @@ requirements_freebsd_bootstrap_pkgng()
 {
   # pkgng should work fine on FreeBSD 8.0+ upwards
   # The bootstrapper is natively available in 9.1+
-  if __rvm_version_compare "$_system_version" -ge 9.1; then
+  if __rvm_version_compare "$_system_version" -ge 9.1
+  then
     __rvm_try_sudo /usr/sbin/pkg || return $?
   else
-    __rvm_try_sudo make -C /usr/ports/ports-mgmt/pkg install clean
+    __rvm_try_sudo make -C /usr/ports/ports-mgmt/pkg install clean || return $?
   fi
 }
 


### PR DESCRIPTION
@mpapis this patch adds bootstrap code for pkgng to support your new usage of it, plus it fixes a bug where we were extracting a fresh ports tree even if one already exists.
