### PR TITLE
Debian Wheezy: rvm requirements is marking as missing packages installed for a few architectures

### DIFF
--- a/scripts/functions/requirements/ubuntu
+++ b/scripts/functions/requirements/ubuntu
@@ -23,7 +23,9 @@ requirements_debian_lib_installed()
       dpkg -s "$1" >/dev/null 2>/dev/null || return $?
       ;;
     (*)
-      dpkg -s "$1:$(dpkg --print-architecture)" >/dev/null 2>/dev/null || return $?
+      dpkg -s "$1" >/dev/null 2>/dev/null || 
+      dpkg -s "$1:$(dpkg --print-architecture)" >/dev/null 2>/dev/null ||
+      return $?
       ;;
   esac
 }


### PR DESCRIPTION
rvm requirements:

```
Missing required packages: libc6-dev, zlib1g, zlib1g-dev, libc6-dev.
```

Checking if first package is installed:
dpkg --get-selections | grep libc6-dev

```
libc6-dev:amd64                 install
libc6-dev:i386                  install
```

In my system all listed by rvm requirements packages are installed in amd64 and i386 versions.

My default architecture is amd64. If I have a package only in amd64 version then everything is ok. If I have it in amd64 and i386, like above, then rvm requirements is showing information that package is missing.

rvm --trace requirements after getting head from repository: https://gist.github.com/pskosinski/5380155

Additionally, as you can see on top, there is "libc6-dev, …, libc6-dev", I guess that one of them should be libc6.
