### PR TITLE
Improving requirements and build config for Solaris and SmartOS, including ruby-2.0.0

### DIFF
--- a/scripts/functions/build_config
+++ b/scripts/functions/build_config
@@ -309,6 +309,13 @@ __rvm_setup_compile_environment_smartos()
   __rvm_update_configure_opt_dir "$1" "/opt/local" # TODO do we needed the next line?
   __rvm_update_configure_env CCFLAGS="-I/opt/local/include"
   __rvm_add_to_path prepend "/opt/local/gnu/bin"
+
+	# work around a make error.. see https://bugs.ruby-lang.org/issues/8268
+	if __rvm_string_match "$1" "ruby-2.0.*"; then
+		__rvm_update_configure_env CFLAGS="-R -fPIC"
+		rvm_configure_env+=( rb_cv_have_signbit=no )
+	fi
+	return 0
 }
 
 __rvm_setup_compile_environment_sunos()
@@ -320,6 +327,10 @@ __rvm_setup_compile_environment_sunos()
       rvm_configure_flags+=( ac_cv_func_dl_iterate_phdr=no )
       ;;
   esac
+	if __rvm_string_match "$1" "ruby-2.0.*"
+	then rvm_configure_env+=( bash )
+	fi
+	return 0
 }
 
 __rvm_setup_compile_environment_openbsd()

--- a/scripts/functions/requirements/smartos
+++ b/scripts/functions/requirements/smartos
@@ -1,31 +1,49 @@
 #!/usr/bin/env bash
 
+requirements_smartos_lib_installed()
+{
+	pkgin ls | grep "^$1" >/dev/null 2>&1|| return $?
+}
+
+requirements_smartos_lib_install()
+{
+	__rvm_try_sudo pkgin -y install "$@" || return $?
+}
+
+requirements_smartos_ensure_libs()
+{
+	typeset -a packages_installed packages_missing packages_to_install
+	__rvm_filter_installed_packages smartos "$@" || return $?
+}
+
 requirements_smartos_run()
 {
   case "$1" in
     (update-system)
-      true
+      rvm_requiremnts_fail_or_run_action 3 \
+				"Skipping \`pkgin full-upgrade\` make sure your system is up to date." \
+				__rvm_try_sudo pkgin full-upgrade || return $?
       ;;
     (rvm)
-      __rvm_try_sudo pkgin in bash curl patch
+      requirements_smartos_ensure_libs bash curl scmgit-base patch
       ;;
-    (jruby*head)
-      __rvm_try_sudo pkgin in jdk apache-ant git
+    (jruby-head*)
+      requirements_smartos_ensure_libs jdk apache-ant scmgit-base
       ;;
     (jruby*)
-      __rvm_try_sudo pkgin in jdk
+      requirements_smartos_ensure_libs jdk
       ;;
     (ir*)
-      __rvm_try_sudo pkgin in mono
+      requirements_smartos_ensure_libs mono
       ;;
     (opal)
-      __rvm_try_sudo pkgin in node-devel
+      requirements_smartos_ensure_libs node-devel
       ;;
     (*-head)
-      __rvm_try_sudo pkgin in coreutils gcc47 gmake readline scmgit-base sqlite3 libxml2 libxslt ncurses autoconf automake git
+      requirements_smartos_ensure_libs coreutils gcc47 gmake readline scmgit-base sqlite3 libxml2 libxslt ncurses autoconf automake
       ;;
     (*)
-      __rvm_try_sudo pkgin in coreutils gcc47 gmake readline scmgit-base sqlite3 libxml2 libxslt ncurses autoconf automake
+      requirements_smartos_ensure_libs coreutils gcc47 gmake readline scmgit-base sqlite3 libxml2 libxslt ncurses autoconf automake
       ;;
   esac
 }

--- a/scripts/functions/requirements/solaris
+++ b/scripts/functions/requirements/solaris
@@ -1,8 +1,24 @@
 #!/usr/bin/env bash
 
-requirements_solaris_install()
+requirements_solaris_lib_installed()
 {
-  __rvm_try_sudo pkg install "$@" ||
+        pkg info "$1" >/dev/null  2>&1 || return $?
+}
+
+requirements_solaris_lib_install()
+{
+        __rvm_try_sudo pkg install "$@" || return $?
+}
+
+requirements_solaris_ensure_libs()
+{
+        typeset -a packages_installed packages_missing packages_to_install
+        __rvm_filter_installed_packages solaris "$@" || return $?
+}
+
+requirements_solaris_update_system()
+{
+  __rvm_try_sudo pkg refresh && __rvm_try_sudo pkg update ||
   {
     typeset ret=$?
     case $ret in
@@ -16,28 +32,32 @@ requirements_solaris_run()
 {
   case "$1" in
     (update-system)
-      true
+      rvm_requiremnts_fail_or_run_action 3 \
+        "Skipping \`pkg update\` make sure your system is up to date." \
+        requirements_solaris_update_system || return $?
+      
       ;;
     (rvm)
-      requirements_solaris_install bash curl patch
+      requirements_solaris_ensure_libs bash curl git text/gnu-patch
       ;;
-    (jruby*head)
-      requirements_solaris_install jdk apache-ant git
+    (jruby-head*)
+      requirements_solaris_ensure_libs jdk apache-ant git
       ;;
     (jruby*)
-      requirements_solaris_install jdk
+      requirements_solaris_ensure_libs jdk
       ;;
     (ir*)
-      requirements_solaris_install mono
+      requirements_solaris_ensure_libs mono
       ;;
     (opal)
-      requirements_solaris_install node-devel
+      requirements_solaris_ensure_libs node-devel
       ;;
     (*-head)
       requirements_solaris_install text/gnu-patch developer/gcc-45 developer/library/lint system/header system/library/math/header-math file/gnu-coreutils git
       ;;
     (*)
-      requirements_solaris_install text/gnu-patch developer/gcc-45 developer/library/lint system/header system/library/math/header-math file/gnu-coreutils
+      requirements_solaris_ensure_libs text/gnu-patch developer/gcc-45 \
+        system/header system/library/math file/gnu-coreutils
       ;;
   esac
 }


### PR DESCRIPTION
Updating SmartOS requirements to use autolibs aware check for package installation.
Updating requirements for Solaris to be autolibs aware.
Improving requirements for Solaris & SmartOS.
Using bash to run configure for non-portable configure code.
Update ruby-2.0.0 build config for SmartOS to use -R -fPIC to work around configure issue.

Relevant bugs recorded in ruby issue tracker:
https://bugs.ruby-lang.org/issues/5384
https://bugs.ruby-lang.org/issues/8071
https://bugs.ruby-lang.org/issues/8268
