### PR TITLE
Ensure that zsh autocompletion won't be broken after invoking __rvm_unload`

### DIFF
--- a/scripts/functions/env
+++ b/scripts/functions/env
@@ -216,6 +216,12 @@ __rvm_unload()
   #PATH
   __rvm_remove_rvm_from_path
 
+  # fpath
+  if [[ -n "${ZSH_VERSION:-}" ]]
+  then
+    __rvm_remove_from_array fpath "$rvm_path/scripts/extras/completion.zsh" "${fpath[@]}"
+  fi
+
   # aliases
   __rvm_unload_action unalias  <(
     if [[ -n "${ZSH_VERSION:-}" ]]


### PR DESCRIPTION
Currently, `__rvm_unload` nukes the `$fpath` variable completely before it invokes `compinit` again for `zsh`; we need to make sure it merely removes the `zsh` completion path from `$fpath` while leaving everything else.
