### PR TITLE
Fixed typo in Guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,5 +34,5 @@ rvm reload
 rvm --trace [command]
 ```
 
-## Codding guidelines
+## Coding guidelines
 https://github.com/wayneeseguin/rvm/blob/master/FORMATTING.md


### PR DESCRIPTION
Fixed typo: Coding was misspelled
