### PR TITLE
rvm-installer still believes it's performing a multi-user install when installing for root only

### DIFF
--- a/binscripts/rvm-installer
+++ b/binscripts/rvm-installer
@@ -272,7 +272,7 @@ fi
 
 # Variable initialization, remove trailing slashes if they exist on HOME
 true \
-  ${rvm_trace_flag:=0} ${rvm_debug_flag:=0} ${rvm_user_install_flag:=0}\
+  ${rvm_trace_flag:=0} ${rvm_debug_flag:=0}\
   ${rvm_ignore_rvmrc:=0} HOME="${HOME%%+(\/)}"
 
 
@@ -313,6 +313,20 @@ fi
 if [[ -z "${rvm_prefix}" ]]
 then
   rvm_prefix=$( dirname $rvm_path )
+fi
+ 
+# duplication marker kkdfkgnjfndgjkndfjkgnkfjdgn
+# guess rvm_user_install_flag if not set
+if
+  [[ -z "${rvm_user_install_flag}" ]]
+then
+  if
+    [[ "${rvm_prefix}" == "${HOME}" ]]
+  then
+    rvm_user_install_flag=1
+  else
+    rvm_user_install_flag=0
+  fi
 fi
 
 install_rubies=()

--- a/scripts/rvm
+++ b/scripts/rvm
@@ -92,10 +92,13 @@ then
   rvm_prefix=$( dirname $rvm_path )
 fi
 
+# duplication marker kkdfkgnjfndgjkndfjkgnkfjdgn
 # guess rvm_user_install_flag if not set
-if [[ -z "${rvm_user_install_flag}" ]]
+if
+  [[ -z "${rvm_user_install_flag}" ]]
 then
-  if [[ "${rvm_prefix}" == "${HOME}" ]]
+  if
+    [[ "${rvm_prefix}" == "${HOME}" ]]
   then
     rvm_user_install_flag=1
   else


### PR DESCRIPTION
I followed the instructions in section "I want to install for root only!" of the FAQ (see https://rvm.io/support/faq/), and rvm-installer still proceeded as if it was doing a system install in a couple of ways. Most importantly, it lays down an `/etc/rvmrc` file that forces `rvm` to use a umask that gives write permissions to the group.

It seems like we need to do something closer to what `scripts/rvm` already does for determining the value of the `$rvm_user_install_flag`.
