### PR TITLE
__rvm_unload skips unset of many all caps variables on Debian GNU/kFreeBSD with zsh

### DIFF
--- a/scripts/functions/env
+++ b/scripts/functions/env
@@ -232,6 +232,7 @@ __rvm_unload()
 
   # variables
   __rvm_unload_action unset <(
+    IFS=$' \t\n'
     set |
       awk -F"=" 'BEGIN{v=0;} /^[a-zA-Z_][a-zA-Z0-9_]*=/{v=1;} v==1&&$2~/^['\''\$]/{v=2;}
         v==1&&$2~/^\(/{v=3;} v==2&&/'\''$/&&!/'\'\''$/{v=1;} v==3&&/\)$/{v=1;} v{print;} v==1{v=0;}' |


### PR DESCRIPTION
I noticed that many all caps variables such as `$IRBRC` or `$MY_RUBY_HOME` were not being unset by `__rvm_unload` when running with zsh on Debian GNU/kFreeBSD Wheezy.

The problem seems to be that my shell was using a weird value for `$IFS`:

```
$ echo "$IFS" | od -b
0000000 040 011 012 000 012
0000005
```

The second to last character, `000`, is a little weird, and I think it was causing some funky behavior in the parsing of the output `set` with the `awk` script.

So temporarily setting a more normal value of `$IFS` in `__rvm_unload` can prevent such bugs by making this parsing more predictable.
