### PR TITLE
Add gawk to requirements for Debian

### DIFF
--- a/scripts/functions/requirements/ubuntu
+++ b/scripts/functions/requirements/ubuntu
@@ -46,7 +46,7 @@ requirements_debian_define()
 
   case "$1" in
     (rvm)
-      requirements_check bash curl patch bzip2 ca-certificates
+      requirements_check bash curl patch bzip2 ca-certificates gawk
       ;;
 
     (jruby*head)


### PR DESCRIPTION
Some of the awk processing done in rvm requires GNU awk.
