### PR TITLE
oh-my-zsh alias breaks after_use_maglev hook

### DIFF
--- a/hooks/after_use_maglev
+++ b/hooks/after_use_maglev
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. "${rvm_path}/scripts/functions/hooks/maglev"
+\. "${rvm_path}/scripts/functions/hooks/maglev"
 
 if
   [[ "${rvm_ruby_string}" =~ "maglev" ]]


### PR DESCRIPTION
In the RVM documentation for ZSH: https://rvm.io/integration/zsh/

There's a section where it says:

> The latest RVM HEAD properly escapes the sourcing '.' so this should no longer be an issue. 

But it looks like the sourcing `.` is not actually escaped in RVM HEAD, so I'm still getting an error. Could the escape be added back in?
