### PR TITLE
Fix issue with java depends for Gentoo in autolibs

### DIFF
--- a/scripts/functions/requirements/gentoo
+++ b/scripts/functions/requirements/gentoo
@@ -28,10 +28,10 @@ requirements_gentoo_define()
       requirements_check net-misc/curl sys-devel/patch app-shells/bash
       ;;
     (jruby*head)
-      requirements_check dev-java/sun-jdk dev-java/sun-jre-bin dev-vcs/git
+      requirements_check virtual/jdk dev-vcs/git dev-java/ant-core
       ;;
     (jruby*)
-      requirements_check dev-java/sun-jdk dev-java/sun-jre-bin
+      requirements_check virtual/jre
       ;;
     (ir*)
       requirements_check dev-lang/mono


### PR DESCRIPTION
- Gentoo uses virtual/jre and virtual/jdk to fulfill JDK/JRE requirements
- These virtuals map to Sun, Oracle, and IcedTea (OpenJDK) implementations
