### PR TITLE
Fix help doc typo in example of SSL cert update.

### DIFF
--- a/help/osx-ssl-certs.md
+++ b/help/osx-ssl-certs.md
@@ -30,15 +30,15 @@ You can check status, update certificates manually or schedule an automated upda
 
 ## Examples
 
-Show the status for all installed rubies
+Show the status for all installed rubies:
 
     rvm osx-ssl-certs status all
 
-Update certificates for current ruby OpenSSL
+Update OpenSSL certificates for current ruby:
 
-    rvm osx-ssl-certs status all
+    rvm osx-ssl-certs update
 
-Schedule daily update of certificates
+Schedule daily update of certificates:
 
     rvm osx-ssl-certs cron install
 


### PR DESCRIPTION
There's a list in the file 'help/osx-ssl-certs.md' of three example usages of rvm osx-ssl-certs. The second example should be rvm osx-ssl-certs update.
