### PR TITLE
removing sqlite requirement for OS X (homebrew)

### DIFF
--- a/scripts/functions/requirements/osx_brew
+++ b/scripts/functions/requirements/osx_brew
@@ -150,7 +150,7 @@ requirements_osx_brew_libs_default()
     }
   fi
   brew_libs_conf=(
-    libyaml readline libxml2 libxslt libksba sqlite
+    libyaml readline libxml2 libxslt libksba
   )
   case "$1" in
     (ruby-1.8*|ree-1.8*)


### PR DESCRIPTION
All versions of OS X already include sqlite3. 

Homebrew warns when trying to install sqlite on Mac OS X that: "Mac OS X already provides this software and installing another version in parallel can cause all kinds of trouble."
