### PR TITLE
scripts/functions/requirements/osx_brew, fix spelling wrong

### DIFF
--- a/scripts/functions/requirements/osx_brew
+++ b/scripts/functions/requirements/osx_brew
@@ -202,7 +202,7 @@ requirements_osx_brew_update_system()
     {
       typeset ret=$?
       rvm_error "
-Xcode version older then 4.6.2 installed, download and install never version from:
+Xcode version older than 4.6.2 installed, download and install newer version from:
 
     http://connect.apple.com
 


### PR DESCRIPTION
Fixing 2 words:
1. then => than
2. never => newer
