### PR TITLE
Directly ask MacPorts about available ports.

### DIFF
--- a/scripts/functions/requirements/osx_port
+++ b/scripts/functions/requirements/osx_port
@@ -24,7 +24,7 @@ requirements_find_osx_port()
 
 requirements_osx_port_lib_installed()
 {
-  __rvm_array_contains "$1" "${packages_available[@]}" || return $?
+  port -q installed $1 | \grep -q active || return $? ;
 }
 
 requirements_osx_port_libs_install()


### PR DESCRIPTION
@mpapis Could you take a quick look at this, it's the tiny outcome of our IRC discussion.  MacOS appears to have GNU grep by default, so `-q` is probably OK (even if other platforms would need `> /dev/null`).  What did you ask me to remove.. ?
