### PR TITLE
Fix for #1911 - sed: 1: "s/Basepath:\s+?(.+)$/\1/": RE error: repetition-operator operand invalid

### DIFF
--- a/scripts/functions/requirements/osx_fink
+++ b/scripts/functions/requirements/osx_fink
@@ -146,7 +146,7 @@ requirements_osx_fink_ensure_fink_can_install()
   (( rvm_autolibs_flag_number > 2 )) || return 0
 
   typeset __packages_path
-  __packages_path="$(grep -E '^Basepath:' /sw/etc/fink.conf | sed -E 's/Basepath:\s+?(.+)$/\1/')"
+  __packages_path="$(grep -E '^Basepath:' /sw/etc/fink.conf | sed -E 's/Basepath:\s?(.+)$/\1/')"
   if
     [[ -w "${__packages_path%/*}/bin" ]] &&
     [[ -w "${__packages_path}" || ! -e "${__packages_path}" ]]


### PR DESCRIPTION
The sed command had an error with two preceding pattern operands

As seen here:  https://github.com/wayneeseguin/rvm/issues/1911
