### PR TITLE
ZSH: Prevent $1:a from being exapanded as a variable with a modifier

### DIFF
--- a/scripts/functions/requirements/ubuntu
+++ b/scripts/functions/requirements/ubuntu
@@ -13,8 +13,8 @@ requirements_debian_arch()
 
 requirements_debian_lib_installed()
 {
-  dpkg-query -s "$1:${__architecture}" >/dev/null 2>&1 ||
-  dpkg-query -s "$1:all"               >/dev/null 2>&1 ||
+  dpkg-query -s "${1}:${__architecture}" >/dev/null 2>&1 ||
+  dpkg-query -s "${1}:all"               >/dev/null 2>&1 ||
   return $?
 }
 


### PR DESCRIPTION
Fix misdetecting missing required packages with zsh on debian
