### PR TITLE
added fiber stack size patch

### DIFF
--- a/patchsets/ruby/1.9.3/head/railsexpress
+++ b/patchsets/ruby/1.9.3/head/railsexpress
@@ -12,3 +12,4 @@ https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/1.9.3/head/railse
 https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/1.9.3/head/railsexpress/12-falcon-array-queue.patch
 https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/1.9.3/head/railsexpress/13-railsbench-gc-fixes.patch
 https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/1.9.3/head/railsexpress/14-show-full-backtrace-on-stack-overflow.patch
+https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/1.9.3/head/railsexpress/15-configurable-fiber-stack-sizes.patch

--- a/patchsets/ruby/1.9.3/p392/railsexpress
+++ b/patchsets/ruby/1.9.3/p392/railsexpress
@@ -12,3 +12,4 @@ https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/1.9.3/p392/railse
 https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/1.9.3/p392/railsexpress/12-falcon-array-queue.patch
 https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/1.9.3/p392/railsexpress/13-railsbench-gc-fixes.patch
 https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/1.9.3/p392/railsexpress/14-show-full-backtrace-on-stack-overflow.patch
+https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/1.9.3/p392/railsexpress/15-configurable-fiber-stack-sizes.patch

--- a/patchsets/ruby/1.9.3/p429/railsexpress
+++ b/patchsets/ruby/1.9.3/p429/railsexpress
@@ -12,3 +12,4 @@ https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/1.9.3/p429/railse
 https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/1.9.3/p429/railsexpress/12-falcon-array-queue.patch
 https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/1.9.3/p429/railsexpress/13-railsbench-gc-fixes.patch
 https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/1.9.3/p429/railsexpress/14-show-full-backtrace-on-stack-overflow.patch
+https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/1.9.3/p429/railsexpress/15-configurable-fiber-stack-sizes.patch


### PR DESCRIPTION
this patch adds the possibility to change ruby defaults for fiber stack sizes.

Could you please merge?
