### PR TITLE
added the after_use_textmate hook

### DIFF
--- a/hooks/after_use_textmate
+++ b/hooks/after_use_textmate
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#
+# Automatically sets the wrappers for textmate's use
+# Based on article posted: http://www.christopherirish.com/2010/06/28/how-to-setup-textmate-to-use-rvm/
+# Set up the TM_RUBY shell variable as described and remove the Builder as described and restart TextMate
+#
+# Make this script executable and you should be good to go!  TextMate will stay in sync with rvm, which 
+# generally means the last project folder you switched into from terminal shell.
+#
+if [[ $TM_WRAPPING != "1" ]]; then
+	export TM_WRAPPING="1"
+	rvm wrapper ${RUBY_VERSION} textmate
+	unset TM_WRAPPING
+fi


### PR DESCRIPTION
Simple script to perform "rvm wrapper" against currently active Ruby for textmate.  The TM_RUBY shell variable should point to the ~/.rvm/bin/textmate_ruby symlinked node.
