### PR TITLE
Running an rvm process from within another process

### DIFF
--- a/scripts/set
+++ b/scripts/set
@@ -2,6 +2,8 @@
 
 source "$rvm_scripts_path/base"
 
+rvm_is_not_a_shell_function=0 # for nested invocations of rvm
+
 __rvm_attempt_single_exec()
 {
   # Return if we have multiple rubies. or we're not running exec.


### PR DESCRIPTION
I often use the shebang: 

```
#!/usr/bin/env rvm 1.9 do ruby 
```

However, if that script which is running then needs to invoke another ruby process, it says that rvm is not a function, rvm was not loaded correctly, etc. I tracked it down, and it looks like
this is happening because running with the above shebang sets the environment variable "rvm_is_not_a_shell_function". This then is still active when I try to perform rvm actions, e.g.
"rvm use ...", which causes rvm to warn me about rvm not being a function, even though it actually _is_, at that point.

I got around this problem by setting: 

```
rvm_is_not_a_shell_function=0
```

inside the command line which starts the process which eventually invokes rvm. 

A better solution would be for rvm to not set the environment variable and to check to see if rvm is a function whenever this result is actually needed. I would also be willing to investigate this, myself.
