### PR TITLE
RVM was not able to detect your system type

### DIFF
--- a/scripts/functions/requirements/centos
+++ b/scripts/functions/requirements/centos
@@ -91,8 +91,19 @@ requirements_amazon_before()
   __lib_type=centos
 }
 
+requirements_fedora_before_update_cache()
+{
+  yum clean all
+  yum makecache
+}
+
 requirements_fedora_before()
 {
+  yum list --cacheonly --quiet yum >/dev/null 2>&1 ||
+    rvm_requiremnts_fail_or_run_action 2 \
+      "It is not possible to check if packages are installed, make sure the cache is up to date with 'yum makecache' and try again." \
+      __rvm_log_command fedora_update_cache "Updating packages cache" __rvm_try_sudo requirements_fedora_before_update_cache ||
+      return $?
   __lib_type=centos
 }
 


### PR DESCRIPTION
My local OS is ubuntu 12.10, and I want to install rvm and ruby on remote server through capistrano. The remote server is SUSE Linux Enterprise Server 11

When I execute "cap rvm:install_ruby", it reports below error: 
RVM was not able to detect your system type and does not know how to load extra library paths for your system (if it's needed), read:

PS. 
1. rvm 1.20.13 (stable) was successfully install on remote server by executing "rvm:install_rvm"
2. If I set rvm_autolibs_flag to disable, ruby can be installed successfully.

How can I install ruby with rvm_autolibs_flag = enable?
