### PR TITLE
Remove deprecated sudoers checks

### DIFF
--- a/bin/rvmsudo
+++ b/bin/rvmsudo
@@ -31,26 +31,7 @@ done
 
 if (( $# ))
 then
-  if
-    [[ "${rvmsudo_secure_path:-0}" == 1 ]]
-  then
-    sudo_args+=( "/usr/bin/env" )
-  elif
-    [[ -f "/etc/sudoers" ]]
-  then
-    if
-      [[ ! -r "/etc/sudoers" ]]
-    then
-      sudo_args+=( "/usr/bin/env" )
-      printf "%b" 'Warning: can not check `/etc/sudoers` for `secure_path`, falling back to call via `/usr/bin/env`, this breaks rules from `/etc/sudoers`. export rvmsudo_secure_path=1 to avoid the warning.'
-    elif
-      \grep -E '^[[:space:]]*Defaults[[:space:]]+secure_path=' "/etc/sudoers" >/dev/null
-    then
-      sudo_args+=( "/usr/bin/env" )
-      printf "%b" 'Warning: `secure_path` found in `/etc/sudoers`, falling back to call via `/usr/bin/env`, this breaks rules from `/etc/sudoers`. export rvmsudo_secure_path=1 to avoid the warning.'
-    fi
-  fi
-  eval command sudo \"\${sudo_args[@]}\" $(
+  eval command sudo $(
     /usr/bin/env |
       awk -F= 'BEGIN{v=0;}/^[a-zA-Z_][a-zA-Z0-9_]*=/{v=1;}v==1&&$2~/^['\''\$]/{v=2;} v==1&&$2~/^\(\) \{/{v=0;} v==1&&$2~/^\(/{v=3;}v==2&&/'\''$/&&!/'\'\''$/{v=1;}v==3&&/\)$/{v=1;}v{print;}v==1{v=0;}' |
       GREP_OPTIONS="" \grep -E '^rvm|^gemset|^http_|^PATH|^IRBRC|RUBY|GEM' |


### PR DESCRIPTION
It would seem that the checks made by `rvmsudo` against the `/etc/sudoers` file had already previously been rendered unnecessary by the inclusion of a subshell in the `sudo` command, which _always_ (regardless of the `/etc/sudoers` checks) makes a call to `env` with an `awk` script to force all the required environment variables through. After my edits, this is seen in lines 34-39 of the file.

The _additional_ prefixing of `env` does not appear to be necessary, as the subshell _always_ pushes the environment variables anyway. So on my Ubuntu system where `/etc/sudoers` is readable only by root, and in addition has `secure_path` enabled, this modified version a) doesn't produce a warning, and b) works just fine - $PATH, as well as the other vrm/ruby environment variables pass through alright.

Am I wrong? Is the _additional_ prefixing of `env` required for some specific reason I'm not seeing?
