### PR TITLE
An initial support for Sabayon Linux

### DIFF
--- a/scripts/functions/requirements/sabayon
+++ b/scripts/functions/requirements/sabayon
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+source "$rvm_scripts_path/functions/requirements/gentoo"
+
+requirements_sabayon_define()
+{
+  requirements_gentoo_define "$@"
+}
+
+requirements_sabayon_lib_installed()
+{
+  __rvm_try_sudo equo query installed "$1" >/dev/null || return $?
+}
+
+requirements_sabayon_libs_install()
+{
+  __rvm_try_sudo equo install "$@" || return $?
+}
+
+requirements_sabayon_update_system()
+{
+  __rvm_try_sudo equo update || return $?
+}

--- a/scripts/functions/utility_system
+++ b/scripts/functions/utility_system
@@ -82,6 +82,12 @@ __rvm_detect_system()
         _system_name="amazon"
         _system_version="$(\grep -Eo '[[:digit:]\.]+' /etc/system-release | awk -F. '{print $1"."$2}')"
       elif
+        [[ -f /etc/sabayon-release ]]
+      then
+        # needs to be before gentoo
+        _system_name="sabayon"
+        _system_version="$(\cat /etc/sabayon-release | awk 'NR==1 {print $NF}' | awk -F. '{print $1"."$2}')"
+      elif
         [[ -f /etc/gentoo-release ]]
       then
         _system_name="gentoo"


### PR DESCRIPTION
Hi,

May I suggest this kind of "hook" for Sabayon users. Actually, Sabayon is recognized as a Gentoo system because Sabayon is based on it, so RVM try to install requirements via portage (ie from sources) instead of using its binary packages (Sabayon has its own package manager: equo).
