### PR TITLE
Minor FreeBSD pkgng detection improvements

### DIFF
--- a/scripts/functions/requirements/freebsd
+++ b/scripts/functions/requirements/freebsd
@@ -48,7 +48,7 @@ requirements_freebsd_before_detect_package_manager()
     __lib_type="freebsd"
     if
       __rvm_which pkg >/dev/null &&
-      [ -f /etc/make.conf ] &&
+      [[ -f /etc/make.conf ]] &&
       grep -i "WITH_PKGNG=[\s\"']*YES" /etc/make.conf >/dev/null
     then
       __lib_type+='_pkgng'


### PR DESCRIPTION
- Mutes error message
- Detect pkgng with case-insensitive grep
