### PR TITLE
Removes useless spaces

### DIFF
--- a/scripts/functions/manage/base
+++ b/scripts/functions/manage/base
@@ -247,7 +247,7 @@ __rvm_install_source()
 
   rvm_ruby_make_install=${rvm_ruby_make_install:-"make install"}
 
-  if __rvm_run "install" "$rvm_ruby_make_install" "$rvm_ruby_string - #installing "
+  if __rvm_run "install" "$rvm_ruby_make_install" "$rvm_ruby_string - #installing"
   then true
   else
     result=$?

--- a/scripts/functions/manage/mruby
+++ b/scripts/functions/manage/mruby
@@ -66,7 +66,7 @@ mruby_install()
   mkdir -p "$rvm_ruby_home/";
 
   rvm_ruby_make_install=${rvm_ruby_make_install:-"/bin/cp -Rf \"${rvm_src_path}/$rvm_ruby_string\"/{bin,mrblib,include} \"$rvm_ruby_home/\""}
-  if __rvm_run "install" "$rvm_ruby_make_install" "$rvm_ruby_string - #installing "
+  if __rvm_run "install" "$rvm_ruby_make_install" "$rvm_ruby_string - #installing"
   then true
   else
     result=$?


### PR DESCRIPTION
When running "rvm install 2.0.0" the output says:
ruby-2.0.0-p247 - #configuring......
ruby-2.0.0-p247 - #compiling......
ruby-2.0.0-p247 - #installing ......

This commit removes the space at the end of "# installing" to make it
more consistent with the other outputs ("configuring" and "compiling").
