### PR TITLE
Removed double listed libc6-dev package from requirements.

### DIFF
--- a/scripts/functions/requirements/ubuntu
+++ b/scripts/functions/requirements/ubuntu
@@ -99,7 +99,7 @@ requirements_debian_define()
       requirements_check \
         g++ gcc make libc6-dev patch openssl ca-certificates libreadline6 \
         libreadline6-dev curl zlib1g zlib1g-dev libssl-dev libyaml-dev \
-        libsqlite3-dev sqlite3 autoconf libc6-dev \
+        libsqlite3-dev sqlite3 autoconf \
         libgdbm-dev libncurses5-dev automake libtool bison pkg-config libffi-dev
       ;;
   esac


### PR DESCRIPTION
Removed double listed libc6-dev package from requirements.
