### PR TITLE
Installation script crashes when zsh exists but ZSH_VERSION unset or null

### DIFF
--- a/scripts/notes
+++ b/scripts/notes
@@ -177,7 +177,7 @@ $notes_type Notes:
     [[ -n "${ZSH_VERSION:-}" ]] || \which zsh >/dev/null
   then
     ( # make the ZSH_VERSION local to this piece of code
-      : ${ZSH_VERSION:-$(zsh -c 'echo $ZSH_VERSION' 2>/dev/null)}
+      : ${ZSH_VERSION:=$(zsh -c 'echo $ZSH_VERSION' 2>/dev/null)}
       typeset __zsh_version=$(( 65536 * ${ZSH_VERSION:0:1} + 256 * ${ZSH_VERSION:2:1} + ${ZSH_VERSION:4} ))
       if
         (( __zsh_version != 262924 && __zsh_version < 327680 ))


### PR DESCRIPTION
RVM crashed on installation.  Turned out it was because zsh was installed but not in use.  Fixed one keystroke in scripts/notes.  Looks like this has been broken <1 day.
