### PR TITLE
Fix error locating openssl executable in homebrew-based rvm install

### DIFF
--- a/scripts/functions/requirements/osx_brew
+++ b/scripts/functions/requirements/osx_brew
@@ -32,7 +32,7 @@ requirements_osx_brew_version_list()
 
 requirements_osx_brew_lib_installed_prefix_check()
 {
-  brew_lib_prefix="$( brew --prefix "${brew_lib}" 2>/dev/null )" &&
+  brew_lib_prefix="$( brew --prefix "$1" 2>/dev/null )" &&
   [[ -n "${brew_lib_prefix}" && -d "${brew_lib_prefix}/bin" ]] ||
   return $?
 }


### PR DESCRIPTION
The refactoring that introduced requirements_osx_brew_lib_installed_prefix_check broke homebrew-based installation: rvm install fails with "Somehow it happened there is no executable 'openssl'…" even though brew install openssl succeeded.

The reason seems to be that requirements_osx_brew_lib_installed_prefix_check() reads $brew_lib instead of $1. Suggest replacing ${brew_lib} with $1 on this line: this lets "rvm install" finish here.
