### PR TITLE
FreeBSD pkg.conf check does not account for manually added packages.

### DIFF
--- a/scripts/functions/requirements/freebsd
+++ b/scripts/functions/requirements/freebsd
@@ -48,7 +48,7 @@ requirements_freebsd_before_detect_package_manager()
     __lib_type="freebsd"
     if
       __rvm_which pkg >/dev/null    &&
-      [[ -s /usr/local/etc/pkg.conf && -s /var/db/pkg/local.sqlite ]]
+      [[ -s /var/db/pkg/local.sqlite ]]
     then
       __lib_type+='_pkgng'
     fi


### PR DESCRIPTION
The pkg.conf system file or PACKAGESITE ENV variable must exist to be able to update or install from a remote repository catalog using 'pkg install', but since packages can be manually added using 'pkg add' it makes sense to remove this check.

We still need to keep the '/var/db/pkg/local.sqlite' check, because without the local sqlite3 DB, you've either not installed or initialized pkgng, or you do not have any locally installed packages actively being managed by pkgng; pkgng will exit with status 0 and list no packages if the local.sqlite db does not exist.
