### PR TITLE
getting regex error in zsh

### DIFF
--- a/scripts/functions/env
+++ b/scripts/functions/env
@@ -136,7 +136,10 @@ __rvm_clean_path()
 
   for _iterator_path in "${_old_path[@]}"
   do
-    [[ ":${_new_path[*]}:" =~ :${_iterator_path}: ]] || _new_path+=( "${_iterator_path}" )
+    case ":${_new_path[*]}:" in
+      (*:${_iterator_path}:*) true ;;
+      (*) _new_path+=( "${_iterator_path}" ) ;;
+    esac
   done
   PATH="${_new_path[*]}"
   builtin hash -r


### PR DESCRIPTION
after installing rvm on Ubuntu 12.10 
in zsh with prezto this is the error I am getting
__rvm_clean_path:12: failed to compile regex: Invalid content of {}
if any info is need do tell me.
