### PR TITLE
Fixed protocol replacement for FTP fallback

### DIFF
--- a/scripts/fetch
+++ b/scripts/fetch
@@ -110,7 +110,7 @@ reinstall Curl or consult with your distribution manual and contact support."
       [[ $try_ftp -eq 1 ]]
     then
       rvm_log "Trying ftp:// URL instead."
-      url="${url/http:/ftp:/}"
+      url="${url/http:/ftp:}"
     fi
     if
       [[ $try_ftp -eq 1 || $retry -eq 1 ]]


### PR DESCRIPTION
http -> ftp protocol replacement had an extra slash at the end causing the ftp URL to being ftp:///
#2095
