### PR TITLE
Clarify rvm update deprecation error.

### DIFF
--- a/scripts/cli
+++ b/scripts/cli
@@ -969,7 +969,7 @@ Please do one of the following:
       __rvm_${rvm_action}
       ;;
     update)
-      printf "%b" "ERROR: rvm update has been removed. See 'rvm get' and rvm 'rubygems' CLI API instead\n"
+      printf "%b" "ERROR: rvm update has been removed. Try 'rvm get head' or see the 'rvm get' and rvm 'rubygems' CLI API instead\n"
       ;;
     reboot)
       source "$rvm_scripts_path/functions/cleanup"


### PR DESCRIPTION
Every once in a long while I remember to try updating rvm to fix some issue and I always forget the new command. This seems a little bit clearer to me.
