### PR TITLE
Improved binstubs prompt

### DIFF
--- a/hooks/after_cd_bundler
+++ b/hooks/after_cd_bundler
@@ -53,9 +53,10 @@ then
       (${PWD}*)
         if
           __rvm_ask_for \
-         "The bundler binstubs directory is in the current directory, this may be unsafe.
+         "The bundler binstubs directory is in the current directory, which may be unsafe.
 Consider using rubygems-bundler instead => https://github.com/mpapis/rubygems-bundler
-Are you sure you want to add bundler binstubs directory to the path?" \
+Remove the BUNDLE_BIN line from .bundle/config to disable this prompt.
+Are you sure you want to add the bundler binstubs directory to the path?" \
          'Yes'
         then
           add_binstubs_to_path "${BUNDLER_BIN_PATH}" "${LAST_BUNDLER_BIN_PATH}"


### PR DESCRIPTION
Improve the binstubs security prompt so people know how to disable it. Even if the binstubs directory is removed and rubygems-bundler is used, the BUNDLE_BIN line remains and the prompt continues. 
