### PR TITLE
Makes `dscl` usage service-agnostic when checking for user shell

### DIFF
--- a/scripts/functions/utility_system
+++ b/scripts/functions/utility_system
@@ -320,7 +320,7 @@ __rvm_get_user_shell()
       ;;
     (Darwin)
       typeset __version
-      __version="$(dscl localhost -read "/Local/Default/Users/$USER" shell)" ||
+      __version="$(dscl localhost -read "/Search/Users/$USER" UserShell)" ||
       {
         rvm_error "Error checking user shell via dscl ... something went wrong, report a bug."
         return 3


### PR DESCRIPTION
The fix for #2029 prevents installation for OS X users managed by, e.g., Active Directory.
