### PR TITLE
SmartOS: use eval so that gnu_tools_path is set in __rvm_grep

### DIFF
--- a/scripts/functions/support
+++ b/scripts/functions/support
@@ -197,10 +197,7 @@ case "$(uname)" in
     esac
     [[ -x $gnu_tools_path/grep ]] ||
       rvm_error "ERROR: Missing GNU grep. Make sure it is installed in $gnu_tools_path/grep before using RVM!"
-    __rvm_grep()
-    {
-      GREP_OPTIONS="" $gnu_tools_path/grep "$@" || return $?;
-    }
+    eval "__rvm_grep() { GREP_OPTIONS="" $gnu_tools_path/grep \"\$@\" || return $?; }"
 
     for gnu_util in "${gnu_utils[@]}"
     do


### PR DESCRIPTION
Patches under #2132 almost worked, but the $gnu_tools_path variable wasn't set in the __rvm_grep() function.
