### PR TITLE
SmartOS: fix escaping of GREP_OPTIONS and return result in eval of __rvm_grep

### DIFF
--- a/scripts/functions/support
+++ b/scripts/functions/support
@@ -197,7 +197,7 @@ case "$(uname)" in
     esac
     [[ -x $gnu_tools_path/grep ]] ||
       rvm_error "ERROR: Missing GNU grep. Make sure it is installed in $gnu_tools_path/grep before using RVM!"
-    eval "__rvm_grep() { GREP_OPTIONS="" $gnu_tools_path/grep \"\$@\" || return $?; }"
+    eval "__rvm_grep() { GREP_OPTIONS=\"\" $gnu_tools_path/grep \"\$@\" || return \$?; }"
 
     for gnu_util in "${gnu_utils[@]}"
     do


### PR DESCRIPTION
Incomplete escaping in my previous commit.

Fixes #2143
