### PR TITLE
rvm db doesn't respect autolibs=read-fail

### DIFF
--- a/scripts/db
+++ b/scripts/db
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-source "$rvm_scripts_path/functions/support"
+source "${rvm_scripts_path:-$rvm_path/scripts}/functions/support"
 
 usage()
 {


### PR DESCRIPTION
Tested with ubuntu 12.04 (LTS):

curl -L https://get.rvm.io | bash -s head --trace --ignore-dotfiles --autolibs=read-fail --path /tmp/foo

Outputs a few errors:

tools/.rvm/scripts/db: line 3: /functions/support: No such file or directory
tools/.rvm/scripts/db: line 35: __rvm_sed: command not found
tools/.rvm/scripts/db: line 46: __rvm_sed: command not found
