### PR TITLE
sourcing $RVM_PATH/scripts/rvm sets wrong environment variable for rvm_bin_path and rvm_prefix

### DIFF
--- a/scripts/base
+++ b/scripts/base
@@ -78,7 +78,7 @@ then
   if [[ -n "${BASH_SOURCE:-$0}" && -f "${BASH_SOURCE:-$0}" ]]
   then
     rvm_path="${BASH_SOURCE:-$0}"
-    rvm_path="${rvm_path%/scripts/rvm}"
+    rvm_path="$( \cd ${rvm_path%/scripts/base}; pwd )"
   elif (( UID == 0 )) && [[ -d "/usr/local/rvm" ]]
   then rvm_path="/usr/local/rvm"
   elif [[ -d "${HOME}/.rvm" ]]

--- a/scripts/extras/chruby.sh
+++ b/scripts/extras/chruby.sh
@@ -12,7 +12,7 @@ function mrvm()
     if [[ -n "${BASH_SOURCE:-$0}" && -f "${BASH_SOURCE:-$0}" ]]
     then
       export rvm_path="${BASH_SOURCE:-$0}"
-      rvm_path="${rvm_path%/scripts/initialize}"
+      rvm_path="$( \cd ${rvm_path%/scripts/extras/chruby.sh}; pwd )"
     elif [[ -x "$HOME/.rvm/bin/rvm" ]]
     then export rvm_path="$HOME/.rvm"
     elif [[ -x "/usr/local/rvm/bin/rvm" ]]

--- a/scripts/initialize
+++ b/scripts/initialize
@@ -81,7 +81,7 @@ Error:
     if [[ -n "${BASH_SOURCE:-$0}" && -f "${BASH_SOURCE:-$0}" ]]
     then
       rvm_path="${BASH_SOURCE:-$0}"
-      rvm_path="${rvm_path%/scripts/initialize}"
+      rvm_path="$( \cd ${rvm_path%/scripts/initialize}; pwd )"
     elif (( UID == 0 )) && [[ -d "/usr/local/rvm" ]]
     then rvm_path="/usr/local/rvm"
     elif [[ -d "${HOME}/.rvm" ]]

--- a/scripts/rvm
+++ b/scripts/rvm
@@ -63,7 +63,7 @@ then
   if [[ -n "${BASH_SOURCE:-$0}" && -f "${BASH_SOURCE:-$0}" ]]
   then
     rvm_path="${BASH_SOURCE:-$0}"
-    rvm_path="${rvm_path%/scripts/rvm}"
+    rvm_path="$( \cd ${rvm_path%/scripts/rvm}; pwd )"
     rvm_prefix=$( dirname $rvm_path )
   elif (( UID == 0 ))
   then


### PR DESCRIPTION
<pre>
$ pwd
/home/rockj/nav-mirror-netmap/tools
$ source .rvm/scripts/rvm
$ env | grep rvm
rvm_bin_path=.rvm/bin
GEM_HOME=/home/rockj/nav-mirror-netmap/tools/.rvm/gems/ruby-1.9.2-p320
IRBRC=/home/rockj/nav-mirror-netmap/tools/.rvm/rubies/ruby-1.9.2-p320/.irbrc
MY_RUBY_HOME=/home/rockj/nav-mirror-netmap/tools/.rvm/rubies/ruby-1.9.2-p320
rvm_path=/home/rockj/nav-mirror-netmap/tools/.rvm
rvm_prefix=.
PATH=.rvm/bin:/home/rockj/nav-mirror-netmap/tools/.rvm/gems/ruby-1.9.2-p320/bin:/home/rockj/nav-mirror-netmap/tools/.rvm/gems/ruby-1.9.
2-p320@global/bin:/home/rockj/nav-mirror-netmap/tools/.rvm/rubies/ruby-1.9.2-p320/bin:/home/rockj/nav-mirror-netmap/tools/.rvm/bin:/usr
/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games
rvm_env_string=ruby-1.9.2-p320
rvm_version=1.22.2 (/bugfix/github_issue_2149)
rvm_ruby_string=ruby-1.9.2-p320
GEM_PATH=/home/rockj/nav-mirror-netmap/tools/.rvm/gems/ruby-1.9.2-p320:/home/rockj/nav-mirror-netmap/tools/.rvm/gems/ruby-1.9.2-p320@gl
obal
</pre>


I expect environment variables to use full path as relative paths will easily go wrong. 

propose for fix ie:

<pre>
$( cd $(dirname $0) ; pwd -P )
</pre>
