### PR TITLE
Creates ~/.rvmrc and not respecting rvm_path when running install. 

### DIFF
--- a/scripts/functions/installer
+++ b/scripts/functions/installer
@@ -396,6 +396,7 @@ create_install_paths()
   return 0
 }
 
+# duplication marker kdfkjkjfdkfjdjkdfkjfdkj
 load_custom_flags()
 {
   if
@@ -997,17 +998,6 @@ pick_a_file()
 
 setup_user_profile_check()
 {
-  if
-    [[ -n "${rvm_ignore_dotfiles_flag:-}" ]]
-  then
-    if
-      __rvm_grep "rvm_ignore_dotfiles_flag=" ~/.rvmrc >/dev/null
-    then
-      __rvm_sed_i ~/.rvmrc -e 's/^rvm_ignore_dotfiles_flag=.*$/rvm_ignore_dotfiles_flag="'"${rvm_ignore_dotfiles_flag}"'"/'
-    else
-      printf "%b" "\nrvm_ignore_dotfiles_flag=\"${rvm_ignore_dotfiles_flag}\"\n" >> ~/.rvmrc
-    fi
-  fi
   case "${rvm_ignore_dotfiles_flag:-${rvm_ignore_dotfiles:-no}}" in
     (yes|1) return 1 ;;
   esac

--- a/scripts/notes
+++ b/scripts/notes
@@ -84,6 +84,21 @@ $notes_type Notes:
 "
 fi
 
+# duplication marker kdfkjkjfdkfjdjkdfkjfdkj
+load_custom_flags()
+{
+  if
+    [[ -s "${rvm_path:-}/user/custom_flags" ]]
+  then
+    typeset __key __value
+    while IFS== read __key __value
+    do
+      eval "export ${__key}=\"\${__value}\""
+    done < "${rvm_path:-}/user/custom_flags"
+  fi
+}
+load_custom_flags
+
 # this block groups generated and static notes,
 # to add generated msgs put them below in code
 # for general messages put them in help/upgrade-notes.txt


### PR DESCRIPTION
Keywords:

Duplicate settings/ignore: 

$ cat ~/.rvmrc
rvm_ignore_dotfiles_flag="1"

Should be in rvm_path/user/… 
