### PR TITLE
Fix typo in suggested "rvm autolibs" command

### DIFF
--- a/help/upgrade-notes.txt
+++ b/help/upgrade-notes.txt
@@ -48,7 +48,7 @@
     read more about it in `rvm help autolibs`
 
   * RVM 1.20 changes default behavior of Autolibs to Enabled - if you prefer the 1.19 behavior
-    then run "rvm autolibs read fail", read more details: rvm help autolibs
+    then run "rvm autolibs read-fail", read more details: rvm help autolibs
 
   * RVM 1.20.12 removes thee automated --progress-bar from curl options,
     if you liked this then you can restore this behavior with:


### PR DESCRIPTION
In the upgrade notes text for RVM 1.20, it was suggested to run "rvm autolibs read fail" to revert to the pre-1.20 autolibs setting.  The actual setting is "read-fail", which has an equivalent integer value of 2.  If the command is executing as given, with a space instead of a dash, the setting will be effectively changed to "read-only" (equivalent integer value 1):

```
turnip:~ blandingj$ rvm autolibs read fail
turnip:~ blandingj$ rvm autolibs status

---
value: read
number: 1
runner: osx
description: Allow RVM to use package manager if found but do not install or fail if dependencies are missing.
```

This could cause RVM to ignore missing library requirements when installing rubies.
