### PR TITLE
SmartOS: explicitly set path for `which` under SmartOS

### DIFF
--- a/scripts/functions/support
+++ b/scripts/functions/support
@@ -204,8 +204,10 @@ case "$(uname)" in
       gnu_missing+=( ${gnu_prefix}grep )
     fi
 
-    if
-      [[ -x $gnu_tools_path/${gnu_prefix}which ]]
+    if [[ "$(uname -v)" =~ joyent ]];
+    then
+      eval "__rvm_which() { /usr/bin/which \"\$@\" || return \$?; }"
+    elif [[ -x $gnu_tools_path/${gnu_prefix}which ]]
     then
       eval "__rvm_which() { $gnu_tools_path/${gnu_prefix}which \"\$@\" || return \$?; }"
     else


### PR DESCRIPTION
Workaround issue from https://github.com/wayneeseguin/rvm/commit/56a84d4004cbac5b7112bcc486dfe07dacc18737 where SmartOS path to `which` is not in same directory as other gnu tools.
