### PR TITLE
SmartOS only use "rb_cv_have_signbit=no" workaround for ruby-2.0.0-p0

### DIFF
--- a/scripts/functions/build_config
+++ b/scripts/functions/build_config
@@ -403,10 +403,13 @@ __rvm_setup_compile_environment_smartos()
 {
   [[ "$(uname -v)" =~ ^joyent ]] || return 0
 
-  # work around a make error.. see https://bugs.ruby-lang.org/issues/8268
   if __rvm_string_match "$1" "ruby-2.0.*"; then
     __rvm_update_configure_env CFLAGS="-R -fPIC"
-    rvm_configure_env+=( rb_cv_have_signbit=no )
+  fi
+  if __rvm_string_match "$1" "ruby-2.0.0-p0"; then
+      # work around a make error.. see https://bugs.ruby-lang.org/issues/8268
+      # patch included in p195.
+      rvm_configure_env+=( rb_cv_have_signbit=no )
   fi
   return 0
 }


### PR DESCRIPTION
I had a look at the patches/patchset but it wasn't going to apply easily. Most people will be using the latest ruby which doesn't need a patch, so I'm happy with this one.

Is that okay?
