### PR TITLE
Allow for proper display of Unicode characters in help documentation

### DIFF
--- a/scripts/functions/utility_logging
+++ b/scripts/functions/utility_logging
@@ -103,7 +103,7 @@ __rvm_debug_command()
 
 __rvm_pager_or_cat_v()
 {
-  eval "${PAGER:-\cat -v} '$1'"
+  eval "${PAGER:-\cat} '$1'"
 }
 
 __rvm_ask_for()


### PR DESCRIPTION
Some of the RVM help files include Unicode characters. When running 'rvm help [command]' from the command line, the Unicode characters are not properly displayed. I confirmed identical behavior in sh, bash, and Zsh. The following commands display this behavior:

```
rvm help benchmark
rvm help cleanup
rvm help wrapper
rvm help use
```

...and several others...

Sample output of 'rvm help use' can be seen at https://gist.github.com/dougjohnston/6454744

The attached code uses plain old 'cat' to display the help pages, rather than 'cat -v'. The -v option (to make non-printing characters visible) does not seem to be necessary here. The modified __rvm_pager_or_cat_v() method is only referenced in 'rvm help' commands and in the 'rvm list known' command. This change does not adversely affect output from either command.
