### PR TITLE
Fix syntax error in migrate script

### DIFF
--- a/scripts/migrate
+++ b/scripts/migrate
@@ -94,7 +94,8 @@ migrate_rubies()
     esac
 
     if [[ -n "$gemset_name" ]]
-    thendestination_gemset="${destination_gemset}${rvm_gemset_separator:-"@"}${gemset_name}"
+    then
+      destination_gemset="${destination_gemset}${rvm_gemset_separator:-"@"}${gemset_name}"
     fi
 
     echo "Moving $origin_gemset to $destination_gemset"


### PR DESCRIPTION
Fixes:

```
migrate: line 98: syntax error near unexpected token `fi'
```
