### PR TITLE
Added ALTLinux release workaround detection. 

### DIFF
--- a/scripts/functions/utility_system
+++ b/scripts/functions/utility_system
@@ -34,6 +34,11 @@ __rvm_detect_system()
         _system_name="Manjaro"
         _system_version="$(awk -F'=' '$1=="DISTRIB_RELEASE"{print $2}' /etc/lsb-release)"
       elif
+        [[ -f /etc/altlinux-release ]]
+      then
+        _system_name="Arch"
+        _system_version="libc-$(ldd --version  | \awk 'NR==1 {print $NF}' | \awk -F. '{print $1"."$2}')"
+      elif
         [[ -f /etc/os-release ]] &&
         GREP_OPTIONS="" \grep "ID=opensuse" /etc/os-release >/dev/null
       then


### PR DESCRIPTION
Now it detects an ALTLinux release as the Arch linux with glib 2.17. If the RVM repos will have a specific ruby for the ALTLinux,
the detect procedure can be changed to a proper one.
