### PR TITLE
Detect custom Maven setup on Debian-based systems

### DIFF
--- a/scripts/functions/requirements/ubuntu
+++ b/scripts/functions/requirements/ubuntu
@@ -77,7 +77,7 @@ requirements_debian_define()
         if
           is_jruby_post17 "$1"
         then
-          update-alternatives --list mvn >/dev/null 2>&1 || requirements_check_fallback maven maven2
+          update-alternatives --list mvn >/dev/null 2>&1 || __rvm_with mvn >/dev/null || requirements_check_fallback maven maven2
         else
           update-alternatives --list ant >/dev/null 2>&1 || requirements_check ant
         fi


### PR DESCRIPTION
**Context:** On any platform, Maven is now a requirement to install `jruby-head`. 

**Problem:** On Ubuntu (and other Debian-like systems) `rvm` currently only detects whether `maven` or `maven2` apt package is installed.

As discussed yesterday with @mpapis, I also verified the situations on [Mac OS X](https://github.com/wayneeseguin/rvm/blob/master/scripts/functions/requirements/osx_brew#L285) and [Redhat-based](https://github.com/wayneeseguin/rvm/blob/master/scripts/functions/requirements/centos#L79) Linux (with a CentOS 6.4 box), where current behavior is following (for both platform types):
- custom maven installation is detected :smile:
- if `autolibs` is enabled, `rvm` doesn't try to install Maven from any package system (e.g. `yum` or `brew`), but directly performs the custom embedded installation as `~/.rvm/bin/mvn`.

For now, I didn't check other OS requirements.

Personnally I would be happy enough if provided patch is merged (target is Ubuntu / Travis CI), but it is maybe worth to check how these different Maven handlings could be reorganized (see `requirements_centos_check_binary mvn` in `centos`, `requirements_check_custom_after mvn=maven` in `osx_...`, etc.). Could it be shared in a common `scripts/functions/build_requirements_helpers` function, or something similar?

**Note:** This discussion could also be extended to requirement check on `ant` build tool.
