### PR TITLE
document managing ruby patchlevels with alias

### DIFF
--- a/help/alias.md
+++ b/help/alias.md
@@ -43,16 +43,19 @@ You can also list all current aliases
 Managing Generic Ruby Versions
 
   You can use aliases to set a specific ruby patchlevel for a generic ruby
-  version. You may want to specify the gemset as well to scope this change
-  to a certain project. This is useful if you have upgraded RVM and can no
-  longer switch to the requested ruby. For example, if your project specifies
+  version. This is useful if you have upgraded RVM and can no longer switch
+  to the requested ruby. For example, if your project specifies
   `ruby-1.9.3@my-project` you can do this:
 
-    $ cd my-project
+    $ cd my-project/
     ruby-1.9.3-p448 is not installed.
     To install do: 'rvm install ruby-1.9.3-p448'
-    $ rvm alias ruby-1.9.3@my-project ruby-1.9.3-p422@my-project
-    $ cd ../my-project
+    $ rvm alias create ruby-1.9.3 ruby-1.9.3-p429
+    Creating alias ruby-1.9.3 for ruby-1.9.3-p429.
+    Recording alias ruby-1.9.3 for ruby-1.9.3-p429.
+    $ cd .
+    $ ruby -v
+    ruby 1.9.3p429 (2013-05-15 revision 40747) [x86_64-linux]
 
 Documentation:
 


### PR DESCRIPTION
I'm not sure alias is the right place to document this since you'd need to know the solution to find it essentially, maybe it should go in troubleshooting? If there is a better place for it I'd be happy to move it.

Googling around for "can't switch ruby after rvm upgrade" and "specify rvm ruby patchlevel" didn't have great results. There is a StackOverflow question but this should probably be in the docs since they are normally the top 3 results for anything "rvm" related.
