### PR TITLE
Update known rbx versions

### DIFF
--- a/config/known
+++ b/config/known
@@ -41,9 +41,8 @@ rbx-1.0.1
 rbx-1.1.1
 rbx-1.2.3
 rbx-1.2.4
-rbx[-head]
-rbx-2.0.testing
-rbx-2.0.0-rc1
+rbx[-2.0.0]
+rbx-head
 
 # Ruby Enterprise Edition
 ree-1.8.6


### PR DESCRIPTION
Also rbx doesn't have 2.0.testing branch any more, but I'm not sure how to change https://github.com/wayneeseguin/rvm/blob/7ff2430ce3fa7aa5e8bbb52f44b1dbeb8dbea663/scripts/selector#L49
