### PR TITLE
Updating verification for question mark in url

### DIFF
--- a/scripts/functions/checksum
+++ b/scripts/functions/checksum
@@ -145,7 +145,7 @@ __rvm_checksum_read()
   do
     list+=( "$_name" )
     if
-      [[ "$_name" =~ "?" ]] # try url without ?... like ?rvm={version}
+      [[ "$_name" == *"?"* ]] # try url without ?... like ?rvm={version}
     then
       list+=( "${_name%\?*}" )
     fi


### PR DESCRIPTION
OS: RHEL 5.9
RVM version: 1.22.18

Issue: Unable to install jruby due to parameters not getting stripped off of URL for checksum comparison

quick test (Centos5.9):

```
something="https://github.com/oldNoakes/rvm?foobar=blah"
[[ "$something" =~ "?" ]]
echo $?

[[ "$something" == *"?"* ]]
echo $?

Output:
2
0
```

debug log from installation attempt:

```
rvm --debug install jruby
jruby - install
Searching for binary rubies, this might take some time.
Remote file does not exist https://rvm.io/binaries/redhat/5/x86_64/1.7.5/jruby-bin-1.7.5.tar.gz
Found remote file http://jruby.org.s3.amazonaws.com/downloads/1.7.5/jruby-bin-1.7.5.tar.gz
rvm_autolibs_flag=4
Checking requirements for redhat.
requirements code for redhat loaded
which: no update-alternatives in (/usr/kerberos/bin:/usr/local/bin:/bin:/usr/bin:/var/go/bin:/sbin:/usr/lib/oracle/11.2/client64/bin:/var/go/.rvm/bin)
Requirements installation successful.
jruby-1.7.5 - #configure
jruby-1.7.5 - #download
There is no checksum for 'http://jruby.org.s3.amazonaws.com/downloads/1.7.5/jruby-bin-1.7.5.tar.gz?rvm=1.22.18' or 'jruby-bin-1.7.5.tar.gz', it's not possible to validate it.
This could be because your RVM install's list of versions is out of date. You may want to
update your list of rubies by running 'rvm get stable' and try again.
If that does not resolve the issue and you wish to continue with unverified download
add '--verify-downloads 1' after the command.

Downloading http://jruby.org.s3.amazonaws.com/downloads/1.7.5/jruby-bin-1.7.5.tar.gz failed.
__rvm_rm_rf already gone: /var/go/.rvm/rubies/jruby-1.7.5
Mounting remote ruby failed, trying to compile.
__rvm_setup_compile_environment_setup jruby-1.7.5
rvm_autolibs_flag=4
__rvm_setup_compile_environment_movable_early jruby-1.7.5
__rvm_setup_compile_environment_requirements jruby-1.7.5
```

Can only replicate this issue in RHEL5/Centos5 - the current code works in Ubuntu/Centos6/OSX

The changes committed work in all of the above as well as in RHEL5/Centos5
