### PR TITLE
Make package list copy/pasta

### DIFF
--- a/scripts/functions/build_requirements
+++ b/scripts/functions/build_requirements
@@ -99,7 +99,7 @@ __rvm_requirements_run_summary()
       rvm_debug "Install custom packages: ${_list// /, }."
     fi
     rvm_requiremnts_fail_or_run_action 3 \
-      "Missing custom packages: ${_list// /, }." \
+      "Missing custom packages: ${_list}" \
       true ||
       return $?
   }
@@ -117,7 +117,7 @@ __rvm_requirements_run_summary()
   {
     _list="${packages_missing[*]}"
     rvm_requiremnts_fail_or_run_action 2 \
-      "Missing required packages: ${_list// /, }." \
+      "Missing required packages: ${_list}" \
       true ||
       return $?
   }


### PR DESCRIPTION
By removing the commas the packages can now be copy pasted.

Before: package-manager install list, of, packages (fail)
After: package-manager install list of packages (pass)
