### PR TITLE
fix snapshot script: __rvm_tar is not a bash variable

### DIFF
--- a/scripts/snapshot
+++ b/scripts/snapshot
@@ -129,7 +129,7 @@ snapshot_save()
   (
     __rvm_cd "$snapshot_temp_path"
     __rvm_rm_rf "$destination_path/$1.tar.gz"
-    $__rvm_tar czf "$destination_path/$1.tar.gz" .
+    __rvm_tar czf "$destination_path/$1.tar.gz" .
     result="$?"
     __error_on_result "$result" "Error creating archive $destination_path/$1.tar.gz" && return "$result"
   )
@@ -169,7 +169,7 @@ snapshot_load()
   rvm_log "Extracting snapshot"
   (
     __rvm_cd "$snapshot_temp_path"
-    $__rvm_tar xzf "$snapshot_archive"
+    __rvm_tar xzf "$snapshot_archive"
     result="$?"
     __error_on_result "$result" "Error extracting the archive '$snapshot_archive'" && return "$result"
   )


### PR DESCRIPTION
on lines 132 and 172, $__rvm_tar should have $ removed; as it is, it produces the error:
line 132: czf: command not found
