### PR TITLE
add rubygems-2.1.11 md5

### DIFF
--- a/config/md5
+++ b/config/md5
@@ -440,6 +440,7 @@ rubygems-2.0.9.tgz=bc55898247297ffa190223276b1b1bd7
 rubygems-2.1.0.tgz=9a9d242baef5e58fbfe79ec5206cd316
 rubygems-2.1.1.tgz=b34d6f4028b69a84123a6b7cb0ac8028
 rubygems-2.1.10.tgz=6fa671d7d6605de73d16f529cf7bffb8
+rubygems-2.1.11.tgz=b561b7aaa70d387e230688066e46e448
 rubygems-2.1.2.tgz=b5c5c4430be60f911014216d41886ef3
 rubygems-2.1.3.tgz=ac7bbdfecd49f9304756aa5ebeb51400
 rubygems-2.1.4.tgz=aa502b1ea90fbdd14ca9b32634795c2b


### PR DESCRIPTION
Fix error:

There is no checksum for 'http://production.cf.rubygems.org/rubygems/rubygems-2.1.11.tgz' or 'rubygems-2.1.11.tgz', it's not possible to validate it.
This could be because your RVM install's list of versions is out of date. You may want to
update your list of rubies by running 'rvm get stable' and try again.
