### PR TITLE
order of OSX autolibs had not changed in docs

### DIFF
--- a/help/autolibs.md
+++ b/help/autolibs.md
@@ -45,7 +45,7 @@ Enabling 4:
 
 Most of the systems ships with a package manager so the `enable` mode is the same as `packages`.
 Unfortunately on OSX there is not package manger provided so RVM has to detect one of existing user efforts,
-The detection is in order: `macports`, `homebrew`, `smf`, `fink` if none of them is available then RVM will install `macports`.
+The detection is in order: `homebrew`, `macports`, `smf`, `fink` if none of them is available then RVM will install `macports`.
 
 You can also optionally enforce a package manager by using one of the following instead of `enable`:
 


### PR DESCRIPTION
Just noticed that I was warned that the default was now (1.24) `homebrew`, but the help message / docs still said otherwise.
