### PR TITLE
Change from :rubygems to https://rubygems.org

### DIFF
--- a/scripts/gemsets
+++ b/scripts/gemsets
@@ -543,7 +543,7 @@ gemset_export()
   if
     [[ "${rvm_file_name}" =~ Gemfile ]]
   then
-    printf "%b" "source ''https://rubygems.org'
+    printf "%b" "source 'https://rubygems.org'
 
 #ruby=${GEM_HOME##*/}
 


### PR DESCRIPTION
default export Gemfile will use :gemsets as source. However, this is warned by bundle. Bundle recommends https://rubygems.rog instead, so we should move to this.
