### PR TITLE
Recommend 'rvm get stable', not 'rvm get head'

### DIFF
--- a/scripts/cli
+++ b/scripts/cli
@@ -837,7 +837,7 @@ rvm()
       __rvm_${rvm_action}
       ;;
     update)
-      printf "%b" "ERROR: rvm update has been removed. Try 'rvm get head' or see the 'rvm get' and rvm 'rubygems' CLI API instead\n"
+      printf "%b" "ERROR: rvm update has been removed. Try 'rvm get stable' or see the 'rvm get' and rvm 'rubygems' CLI API instead\n"
       ;;
     reboot)
       source "$rvm_scripts_path/functions/cleanup"


### PR DESCRIPTION
## My Use Case

Today, I decided to upgrade `rvm` because the current version didn't have a MD5 checksum for the version of ruby I was installing.  As a typical "cowboy developer", I decided to just try the first command I thought would do the job:

``` shell
$ rvm update
```

This prompted me with the error message that has been updated in the commit.  Since it recommended that I use `rvm get head`, that is was I did without a second thought.  Unfortunately, this caused an error with the ruby installation and I was stuck.  Thanks to the suggestion of a co-worker (after much "head-desking" and hair loss), I tried `rvm get stable` and all was well with the world
## Regarding the Change

I realize that this doesn't do much, and is probably not solving the issue that I had with the head version of RVM, but if it saves another developer some frustration, I think it is worth it IMHO.

Since rvm2 development is underway, I can see that this might be better suited to be pulled into the `stable` branch for now, but I figured I would let the maintainers be the judge of that (I can always close this PR and create a new one).

Regardless if this gets merged in or not, thanks for all your work on this awesome tool!
