### PR TITLE
Fix FreeBSD requirements

### DIFF
--- a/scripts/functions/requirements/freebsd
+++ b/scripts/functions/requirements/freebsd
@@ -66,7 +66,11 @@ requirements_freebsd_update_system()
 {
   case "${__lib_type}" in
     (freebsd_pkgng)
-      __rvm_try_sudo pkg update || return $?
+      if
+        [[ -s /usr/local/etc/pkg.conf ]]
+      then
+        __rvm_try_sudo pkg update || return $?
+      fi
       ;;
   esac
 }


### PR DESCRIPTION
Commit 72e53ae broke requirements check on FreeBSD systems that use
pkgng with the ports tree. This commit attempts to fix it by running
`pgk update` only on systems that actually use binary packages.
