### PR TITLE
Fixing a minor typo [ci skip]

### DIFF
--- a/scripts/notes
+++ b/scripts/notes
@@ -354,7 +354,7 @@ rvm_debug "    found: $__found - missing rubies: $__search_path_rubies"
   if
     (( __need_a_cleanup ))
   then
-    important_message "  * It looks some old stuff is laying around RVM, you can cleanup with: rvm cleanup all
+    important_message "  * It looks like some old stuff is laying around RVM, you can cleanup with: rvm cleanup all
 "
   fi
 


### PR DESCRIPTION
Came across this message while installing. Fixed the typo.
