### PR TITLE
Added rubygems 2.2.0.rc.1 for ruby-2.1.0-rc1

### DIFF
--- a/config/db
+++ b/config/db
@@ -30,6 +30,7 @@ ruby_1.8.5_rubygems_version=1.3.5
 ruby_1.8.6_rubygems_version=1.3.7
 ruby_1.8.7_rubygems_version=latest-2.0
 ruby_1.9.1_rubygems_version=latest-1.8
+ruby_2.1.0_rc1_rubygems_version=2.2.0.rc.1
 ruby_head_rubygems_version=head
 gem_wrappers_minimal_version=1.2.1
 rbx_version=2.2.1


### PR DESCRIPTION
This is the correct version.

From the release notes: https://www.ruby-lang.org/en/news/2013/12/20/ruby-2-1-0-rc1-is-released/
