### PR TITLE
backported ca050a8d57a771d24de2cdf3e3d56e5ff6bc278c to railsexpress

### DIFF
--- a/patchsets/ruby/2.1.0/railsexpress
+++ b/patchsets/ruby/2.1.0/railsexpress
@@ -3,3 +3,4 @@ https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/2.1.0/railsexpres
 https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/2.1.0/railsexpress/03-display-more-detailed-stack-trace.patch
 https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/2.1.0/railsexpress/04-show-full-backtrace-on-stack-overflow.patch
 https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/2.1.0/railsexpress/05-fix-missing-c-return-event.patch
+https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/2.1.0/railsexpress/06-backport-ca050a8d57a771d24de2cdf3e3d56e5ff6bc278c.patch


### PR DESCRIPTION
patches for 2.1.0.

can you please merge?
