### PR TITLE
Openssl compilation fix for 1.9.3, 1.9.2, ree

### DIFF
--- a/patches/ree/1.8.7/ossl-fix.patch
+++ b/patches/ree/1.8.7/ossl-fix.patch
@@ -1,0 +1,12 @@
+--- a/ext/openssl/ossl_ssl.c
++++ b/ext/openssl/ossl_ssl.c
+@@ -1453,7 +1453,9 @@ Init_ossl_ssl()
+     ossl_ssl_def_const(OP_NETSCAPE_REUSE_CIPHER_CHANGE_BUG);
+     ossl_ssl_def_const(OP_SSLREF2_REUSE_CERT_TYPE_BUG);
+     ossl_ssl_def_const(OP_MICROSOFT_BIG_SSLV3_BUFFER);
++#if defined(OP_MSIE_SSLV2_RSA_PADDING)
+     ossl_ssl_def_const(OP_MSIE_SSLV2_RSA_PADDING);
++#endif
+     ossl_ssl_def_const(OP_SSLEAY_080_CLIENT_DH_BUG);
+     ossl_ssl_def_const(OP_TLS_D5_BUG);
+     ossl_ssl_def_const(OP_TLS_BLOCK_PADDING_BUG);

--- a/patches/ruby/1.9.2/p290/ossl-fix.patch
+++ b/patches/ruby/1.9.2/p290/ossl-fix.patch
@@ -1,0 +1,12 @@
+--- a/ext/openssl/ossl_ssl.c
++++ b/ext/openssl/ossl_ssl.c
+@@ -1665,7 +1665,9 @@ Init_ossl_ssl()
+     ossl_ssl_def_const(OP_NETSCAPE_REUSE_CIPHER_CHANGE_BUG);
+     ossl_ssl_def_const(OP_SSLREF2_REUSE_CERT_TYPE_BUG);
+     ossl_ssl_def_const(OP_MICROSOFT_BIG_SSLV3_BUFFER);
++#if defined(OP_MSIE_SSLV2_RSA_PADDING)
+     ossl_ssl_def_const(OP_MSIE_SSLV2_RSA_PADDING);
++#endif
+     ossl_ssl_def_const(OP_SSLEAY_080_CLIENT_DH_BUG);
+     ossl_ssl_def_const(OP_TLS_D5_BUG);
+     ossl_ssl_def_const(OP_TLS_BLOCK_PADDING_BUG);

--- a/patches/ruby/1.9.3/ossl-fix.patch
+++ b/patches/ruby/1.9.3/ossl-fix.patch
@@ -1,0 +1,12 @@
+--- a/ext/openssl/ossl_ssl.c
++++ b/ext/openssl/ossl_ssl.c
+@@ -1985,7 +1985,9 @@ Init_ossl_ssl()
+     ossl_ssl_def_const(OP_NETSCAPE_REUSE_CIPHER_CHANGE_BUG);
+     ossl_ssl_def_const(OP_SSLREF2_REUSE_CERT_TYPE_BUG);
+     ossl_ssl_def_const(OP_MICROSOFT_BIG_SSLV3_BUFFER);
++#if defined(OP_MSIE_SSLV2_RSA_PADDING)
+     ossl_ssl_def_const(OP_MSIE_SSLV2_RSA_PADDING);
++#endif
+     ossl_ssl_def_const(OP_SSLEAY_080_CLIENT_DH_BUG);
+     ossl_ssl_def_const(OP_TLS_D5_BUG);
+     ossl_ssl_def_const(OP_TLS_BLOCK_PADDING_BUG);

--- a/patchsets/ree/1.8.7/default
+++ b/patchsets/ree/1.8.7/default
@@ -2,3 +2,4 @@ tcmalloc
 stdout-rouge-fix
 no_sslv2
 ssl_no_ec2m
+ossl-fix

--- a/patchsets/ruby/1.9.2/default
+++ b/patchsets/ruby/1.9.2/default
@@ -1,0 +1,1 @@
+ossl-fix

--- a/patchsets/ruby/1.9.3/default
+++ b/patchsets/ruby/1.9.3/default
@@ -1,0 +1,1 @@
+ossl-fix


### PR DESCRIPTION
As discussed in #2539. I hope I got it right.
