### PR TITLE
Remove dev-db/sqlite from Gentoo "requirements".

### DIFF
--- a/scripts/functions/requirements/gentoo
+++ b/scripts/functions/requirements/gentoo
@@ -51,7 +51,7 @@ requirements_gentoo_define()
       requirements_check dev-vcs/git
       ;;
     (*)
-      requirements_check virtual/libiconv sys-libs/readline sys-libs/zlib dev-libs/openssl net-misc/curl dev-libs/libyaml dev-db/sqlite sys-devel/libtool sys-devel/gcc sys-devel/autoconf sys-devel/automake sys-devel/bison sys-devel/m4
+      requirements_check virtual/libiconv sys-libs/readline sys-libs/zlib dev-libs/openssl net-misc/curl dev-libs/libyaml sys-devel/libtool sys-devel/gcc sys-devel/autoconf sys-devel/automake sys-devel/bison sys-devel/m4
       ;;
   esac
 }


### PR DESCRIPTION
This is not truly a requirement. Ruby can and does install and operate fine without dev-db/sqlite . If I'm wrong about that, I'm open to hearing how sqlite is a requirement.
