### PR TITLE
Remove a mention of "rvm help" that is unnecessary

### DIFF
--- a/README
+++ b/README
@@ -157,7 +157,7 @@ export      :: Temporarily set an environment variable in the current shell.
 unexport    :: Undo changes made to the environment by 'rvm export'.
 requirements  :: Shows additional OS specific dependencies/requirements for
                  building various rubies.
-mount       :: Install rubies from external locations 'rvm help mount'.
+mount       :: Install rubies from external locations.
 
 == Implementation
 


### PR DESCRIPTION
This change was small enough that I felt comfortable just opening a PR to start with ;)

This sentence doesn't really make much sense with "rvm help mount" at
the end. None of the other actions explicitly mention "rvm help" in
their short descriptions because there's already a mention at the top
that "rvm help action-name" may provide more information, and "mount"
appears in the list of commands available with rvm help.
