### PR TITLE
Improve regex that replaces ".md" in help filenames 

### DIFF
--- a/scripts/help
+++ b/scripts/help
@@ -51,7 +51,7 @@ __rvm_help()
     rvm_log "
   Commands available with 'rvm help':
 
-      $(__rvm_find "${rvm_help_path}" -type f | __rvm_sed -e 's#.*/help/##' -e 's#\.md##' | sort | \tr "\n" ' ' )
+      $(__rvm_find "${rvm_help_path}" -type f | __rvm_sed -e 's#.*/help/##' -e 's#\.md$##' | sort | \tr "\n" ' ' )
   "
   fi
 


### PR DESCRIPTION
The issue I was seeing with "gemdir.md" being changed to "gir.md" instead of "gemdir" is fixed by the first commit here by escaping the ".". I think adding the dollar sign to anchor this replacement to the end improves it more, but that case is probably rare, so I made that change in a separate commit so that it'd be easy for you to take just one. Or I'm happy to squash, let me know! :heart_eyes: 
