### PR TITLE
use new patch directory convention for ruby 2.1

### DIFF
--- a/patchsets/ruby/2.1.0/head/railsexpress
+++ b/patchsets/ruby/2.1.0/head/railsexpress
@@ -1,6 +1,0 @@
-https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/2.1.0/head/railsexpress/01-zero-broken-tests.patch
-https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/2.1.0/head/railsexpress/02-improve-gc-stats.patch
-https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/2.1.0/head/railsexpress/03-display-more-detailed-stack-trace.patch
-https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/2.1.0/head/railsexpress/04-show-full-backtrace-on-stack-overflow.patch
-https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/2.1.0/head/railsexpress/05-fix-missing-c-return-event.patch
-https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/2.1.0/head/railsexpress/06-backport-006e66b6680f60adfb434ee7397f0dbc77de7873.patch

--- a/patchsets/ruby/2.1/head/railsexpress
+++ b/patchsets/ruby/2.1/head/railsexpress
@@ -1,0 +1,6 @@
+https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/2.1/head/railsexpress/01-zero-broken-tests.patch
+https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/2.1/head/railsexpress/02-improve-gc-stats.patch
+https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/2.1/head/railsexpress/03-display-more-detailed-stack-trace.patch
+https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/2.1/head/railsexpress/04-show-full-backtrace-on-stack-overflow.patch
+https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/2.1/head/railsexpress/05-fix-missing-c-return-event.patch
+https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/2.1/head/railsexpress/06-backport-006e66b6680f60adfb434ee7397f0dbc77de7873.patch


### PR DESCRIPTION
As per request. Install works fine, but I find the output of rvm list known a bit confusing:

```
# MRI Rubies
[ruby-]1.8.6[-p420]
[ruby-]1.8.7[-p374]
[ruby-]1.9.1[-p431]
[ruby-]1.9.2[-p320]
[ruby-]1.9.3[-p484]
[ruby-]2.0.0-p195
[ruby-]2.0.0[-p353]
[ruby-]2.1.0
[ruby-]2.1.0-head
ruby-head
```

I think it should say `[ruby-]2.1-head`instead of `[ruby-]2.1.0-head`.
