### PR TITLE
Fix building ruby-2.1.1 on Arch Linux (Ruby bug #9578)

### DIFF
--- a/patches/ruby/2.1.1/changeset_r45225.diff
+++ b/patches/ruby/2.1.1/changeset_r45225.diff
@@ -1,0 +1,11 @@
+--- a/ext/readline/readline.c	(revision 45224)
++++ b/ext/readline/readline.c	(revision 45225)
+@@ -1974,7 +1974,7 @@
+ 
+     rl_attempted_completion_function = readline_attempted_completion_function;
+ #if defined(HAVE_RL_PRE_INPUT_HOOK)
+-    rl_pre_input_hook = (Function *)readline_pre_input_hook;
++    rl_pre_input_hook = (rl_hook_func_t *)readline_pre_input_hook;
+ #endif
+ #ifdef HAVE_RL_CATCH_SIGNALS
+     rl_catch_signals = 0;

--- a/patches/ruby/2.1.1/changeset_r45240.diff
+++ b/patches/ruby/2.1.1/changeset_r45240.diff
@@ -1,0 +1,22 @@
+--- a/ext/readline/extconf.rb	(revision 45239)
++++ b/ext/readline/extconf.rb	(revision 45240)
+@@ -19,6 +19,10 @@
+   return super(func, headers)
+ end
+ 
++def readline.have_type(type)
++  return super(type, headers)
++end
++
+ dir_config('curses')
+ dir_config('ncurses')
+ dir_config('termcap')
+@@ -94,4 +98,8 @@
+ readline.have_func("rl_redisplay")
+ readline.have_func("rl_insert_text")
+ readline.have_func("rl_delete_text")
++unless readline.have_type("rl_hook_func_t")
++  $DEFS << "-Drl_hook_func_t=Function"
++end
++
+ create_makefile("readline")

--- a/patchsets/ruby/2.1.1/default
+++ b/patchsets/ruby/2.1.1/default
@@ -1,0 +1,2 @@
+changeset_r45225
+changeset_r45240


### PR DESCRIPTION
Same as https://github.com/wayneeseguin/rvm/pull/2678, except for ruby-2.1.1
