### PR TITLE
Redhat or RedHat

### DIFF
--- a/scripts/functions/requirements/centos
+++ b/scripts/functions/requirements/centos
@@ -100,7 +100,7 @@ requirements_centos_define()
       else requirements_check libyaml-devel
       fi
       if
-        [[ "${_system_name}" == "Redhat" && ${_system_version:-0} -ge 6 ]] &&
+        [[ ("${_system_name}" == "RedHat" || "${_system_name}" == "Redhat") && ${_system_version:-0} -ge 6 ]] &&
         ! requirements_centos_lib_available libffi-devel
       then
         rvm_warn "


### PR DESCRIPTION
`_system_name` can be `RedHat` on later versions of RHEL.  Issue #2583
