### PR TITLE
backport Hash#reject regression fix for 2.1.0- and 2.1.1-railsexpress

### DIFF
--- a/patchsets/ruby/2.1.0/railsexpress
+++ b/patchsets/ruby/2.1.0/railsexpress
@@ -9,3 +9,4 @@ https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/2.1.0/railsexpres
 https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/2.1.0/railsexpress/09-funny-falcon-stc-pool-allocation.patch
 https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/2.1.0/railsexpress/10-aman-opt-aset-aref-str.patch
 https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/2.1.0/railsexpress/11-funny-falcon-method-cache.patch
+https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/2.1.0/railsexpress/12-backport-r44370.patch

--- a/patchsets/ruby/2.1.1/railsexpress
+++ b/patchsets/ruby/2.1.1/railsexpress
@@ -8,3 +8,4 @@ https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/2.1.1/railsexpres
 https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/2.1.1/railsexpress/08-funny-falcon-stc-pool-allocation.patch
 https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/2.1.1/railsexpress/09-aman-opt-aset-aref-str.patch
 https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/2.1.1/railsexpress/10-funny-falcon-method-cache.patch
+https://raw.github.com/skaes/rvm-patchsets/master/patches/ruby/2.1.1/railsexpress/11-backport-r44370.patch


### PR DESCRIPTION
can you please merge?

this is a serious bug which should be fixed a.s.a.p.

thx a lot in advance.
