### PR TITLE
handle fact that RUBY_VERSION not being set in rvm's env

### DIFF
--- a/hooks/after_use_textmate
+++ b/hooks/after_use_textmate
@@ -4,11 +4,11 @@
 # Based on article posted: http://www.christopherirish.com/2010/06/28/how-to-setup-textmate-to-use-rvm/
 # Set up the TM_RUBY shell variable as described and remove the Builder as described and restart TextMate
 #
-# Make this script executable and you should be good to go!  TextMate will stay in sync with rvm, which 
+# Make this script executable and you should be good to go! TextMate will stay in sync with rvm, which
 # generally means the last project folder you switched into from terminal shell.
 #
 if [[ $TM_WRAPPING != "1" ]]; then
-	export TM_WRAPPING="1"
-	rvm wrapper ${RUBY_VERSION} textmate
-	unset TM_WRAPPING
+  export TM_WRAPPING="1"
+  rvm wrapper ${RUBY_VERSION:-${GEM_HOME##*/}} textmate
+  unset TM_WRAPPING
 fi


### PR DESCRIPTION
Fix for textmate hook so it works when RUBY_VERSION is not set in rvm env.
