### PR TITLE
Update patchsets for Scientific support

### DIFF
--- a/patchsets/ruby/1.8.7/scientific
+++ b/patchsets/ruby/1.8.7/scientific
@@ -1,0 +1,1 @@
+ssl_no_ec2m

--- a/patchsets/ruby/1.9.2/scientific
+++ b/patchsets/ruby/1.9.2/scientific
@@ -1,0 +1,1 @@
+ssl_no_ec2m

--- a/patchsets/ruby/1.9.3/scientific
+++ b/patchsets/ruby/1.9.3/scientific
@@ -1,0 +1,1 @@
+ssl_no_ec2m

--- a/patchsets/ruby/2.0.0/scientific
+++ b/patchsets/ruby/2.0.0/scientific
@@ -1,0 +1,1 @@
+ssl_no_ec2m


### PR DESCRIPTION
Adding support for Scientific Linux prevents the RedHat patch sets from being applied. 
