### PR TITLE
Fix autolibs on smartos

### DIFF
--- a/scripts/functions/installer
+++ b/scripts/functions/installer
@@ -267,7 +267,7 @@ setup_installer()
     [[ -z "${rvm_path:-}" ]]
   then
     if (( UID == 0 ))
-    then rvm_path="/opt/local/rvm"
+    then rvm_path="/usr/local/rvm"
     else rvm_path="${HOME}/.rvm"
     fi
     rvm_prefix="${rvm_path%/*}"
@@ -281,7 +281,7 @@ setup_installer()
 
   # duplication marker kkdfkgnjfndgjkndfjkgnkfjdgn
   case "$rvm_path" in
-    (/opt/local/rvm)         rvm_user_install_flag=0 ;;
+    (/usr/local/rvm)         rvm_user_install_flag=0 ;;
     ($HOME/*|/${USER// /_}*) rvm_user_install_flag=1 ;;
     (*)                      rvm_user_install_flag=0 ;;
   esac


### PR DESCRIPTION
This fixes the updated package names for git in smartos. Previously it was scmgit-base, now it is just git.
Also few gems require use of libxslt, so added that.
