### PR TITLE
Adding proper shell detection for Cygwin.

### DIFF
--- a/scripts/functions/utility_system
+++ b/scripts/functions/utility_system
@@ -405,8 +405,8 @@ __list_remote_for_s3()
 
 __rvm_get_user_shell()
 {
-  case "${_system_type}" in
-    (Linux|SunOS|BSD)
+  case "${_system_type}:${_system_name}" in
+    (Linux:*|SunOS:*|BSD:*|*:Cygwin)
       __shell="$( getent passwd $USER )" ||
       {
         rvm_error "Error checking user shell via getent ... something went wrong, report a bug."
@@ -414,7 +414,7 @@ __rvm_get_user_shell()
       }
       echo "${__shell##*:}"
       ;;
-    (Darwin)
+    (Darwin:*)
       typeset __version
       __version="$(dscl localhost -read "/Search/Users/$USER" UserShell)" ||
       {


### PR DESCRIPTION
`getent passwd $USER` can be used to detect the shell for a user on Cygwin, as well.
