### PR TITLE
Restore some known jruby versions

### DIFF
--- a/config/known
+++ b/config/known
@@ -29,6 +29,8 @@ mruby[-head]
 jruby-1.6.8
 jruby-1.7.6
 jruby-1.7.9
+jruby-1.7.10
+jruby-1.7.11
 jruby[-1.7.12]
 jruby-head
 

--- a/config/known_strings
+++ b/config/known_strings
@@ -1,6 +1,9 @@
 # this strings are matched only when partial version was provided
-jruby-1.5.6
 jruby-1.6.8
+jruby-1.7.6
+jruby-1.7.9
+jruby-1.7.10
+jruby-1.7.11
 jruby-1.7.12
 rbx-2.0.0
 rbx-2.1.0


### PR DESCRIPTION
Looks like 1.7.10 and 1.7.11 were accidentally removed in recent jruby upgrades.  Restore them.

Also clean up `known_strings` to match `known` jrubys.
