### PR TITLE
Allow Ruby to be compiled statically but use dynamic extensions

### DIFF
--- a/scripts/cli
+++ b/scripts/cli
@@ -637,7 +637,7 @@ __rvm_parse_args()
             export rvm_rvmrc_flag="${rvm_token}"
             ;;
 
-          --head|--static|--self|--gem|--reconfigure|--default|--force|--export|--summary|--latest|--yaml|--json|--archive|--shebang|--path|--cron|--tail|--delete|--verbose|--import|--sticky|--create|--gems|--docs|--skip-autoreconf|--force-autoconf|--auto-dotfiles|--autoinstall-bundler|--disable-binary|--ignore-gemsets|--skip-gemsets|--debug|--quiet|--silent|--skip-openssl|--fuzzy|--quiet-curl|--skip-pristine)
+          --head|--static|--self|--gem|--reconfigure|--default|--force|--export|--summary|--latest|--yaml|--json|--archive|--shebang|--path|--cron|--tail|--delete|--verbose|--import|--sticky|--create|--gems|--docs|--skip-autoreconf|--force-autoconf|--auto-dotfiles|--autoinstall-bundler|--disable-binary|--ignore-gemsets|--skip-gemsets|--debug|--quiet|--silent|--skip-openssl|--fuzzy|--quiet-curl|--skip-pristine|--dynamic-extensions)
             rvm_token=${rvm_token#--}
             rvm_token=${rvm_token//-/_}
             export "rvm_${rvm_token}_flag"=1

--- a/scripts/functions/environment
+++ b/scripts/functions/environment
@@ -139,7 +139,7 @@ __variables_definition()
   # a corrupt PATH, breaking the RVM installation.
   __variables_list=(
     rvm_head_flag rvm_ruby_selected_flag rvm_user_install_flag rvm_path_flag rvm_cron_flag
-    rvm_static_flag rvm_default_flag rvm_loaded_flag rvm_llvm_flag rvm_skip_autoreconf_flag
+    rvm_static_flag rvm_default_flag rvm_loaded_flag rvm_llvm_flag rvm_skip_autoreconf_flag rvm_dynamic_extensions_flag
     rvm_18_flag rvm_19_flag rvm_20_flag rvm_21_flag
     rvm_force_autoconf_flag rvm_dump_environment_flag rvm_curl_flags rvm_rubygems_version
     rvm_verbose_flag rvm_debug_flag rvm_trace_flag __array_start rvm_skip_pristine_flag

--- a/scripts/functions/manage/ruby
+++ b/scripts/functions/manage/ruby
@@ -121,7 +121,7 @@ __rvm_post_configure_ruby()
 {
   typeset option
   if
-    (( ${rvm_static_flag:-0} == 1 ))
+    (( ${rvm_static_flag:-0} == 1 )) && (( ${rvm_dynamic_extensions_flag:-0} == 0 ))
   then
     for option in 'option nodynamic' openssl psych zlib readline
     do


### PR DESCRIPTION
This might be a solution to a problem that doesn't need solving, but I was trying to install MRI 1.9.3 on CentOS 5.10 with the `--static` flag, and the installation kept failing during the `make` stage when any of the extensions that were uncommented from `ext/Setup` were compiled.  It looks like this was due to `make` trying to run `make` in each of the extension directories, which was failing due to there not actually being a `Makefile` present.  While there's probably a simple solution for that, the simpler solution in my case, since I was trying to recreate a hand-compiled Ruby that was compiled with the `--disable-shared` flag but did not use statically compiled extensions, was to add a `--dynamic-extensions` flag that causes RVM to skip over the updating of the `ext/Setup` file that would otherwise happen when the `--static` flag is passed.  This allows RVM to pass the `--disable-shared` flag without forcing static compilation of extensions when called with the `--static --dynamic-extensions` flags.
