### PR TITLE
fix minor wording errors describing SSL certificate updates

### DIFF
--- a/scripts/functions/osx-ssl-certs
+++ b/scripts/functions/osx-ssl-certs
@@ -92,7 +92,7 @@ requirements_osx_update_openssl_cert()
       requirements_osx_update_openssl_cert_run ||
       return $?
   else
-    rvm_log "Certificates in '$cert_file' already are up to date."
+    rvm_log "Certificates in '$cert_file' are already up to date."
   fi
 }
 
@@ -124,7 +124,7 @@ __rvm_osx_ssl_certs_update_for_path()
     fi
   else
     if (( ${rvm_silent_flag:-0} == 0 ))
-    then printf "%b" "Already are up to date.\n"
+    then printf "%b" "Already up to date.\n"
     fi
   fi
 }


### PR DESCRIPTION
This is just a minor patch fixing the issue of 'already are' and 'are already'. The meaning is, of course, clear when seen in context. However, it's grammatically more correct to say that the "certificates are already up to date."
