### PR TITLE
Osx homebrew link

### DIFF
--- a/scripts/functions/requirements/osx_brew
+++ b/scripts/functions/requirements/osx_brew
@@ -59,7 +59,7 @@ requirements_osx_brew_libs_install()
 
 Try \`brew tap --repair\` and make sure \`brew doctor\` looks reasonable.
 
-Check Homebrew requirements https://github.com/mxcl/homebrew/wiki/Installation"
+Check Homebrew requirements https://github.com/Homebrew/homebrew/wiki/Installation"
     case "$_system_version" in
       (10.6)
         rvm_warn "
@@ -372,7 +372,7 @@ After installation open Xcode, go to Downloads and install Command Line Tools.
   {
     typeset ret=$?
     rvm_error "Failed to update Homebrew, follow instructions here:
-    https://github.com/mxcl/homebrew/wiki/Common-Issues
+    https://github.com/Homebrew/homebrew/wiki/Common-Issues
 and make sure \`brew update\` works before continuing."
     return $ret
   }

--- a/scripts/functions/requirements/smf
+++ b/scripts/functions/requirements/smf
@@ -56,7 +56,7 @@ requirements_smf_lib_install()
   {
     typeset ret=$?
     rvm_warn "There were package installation errors with SM Framework, make sure to read the log.
-If you see this on OSX, then you might want to try macports (http://www.macports.org/) or homebrew (http://mxcl.github.io/homebrew/) and tell RVM to use them by running:
+If you see this on OSX, then you might want to try macports (http://www.macports.org/) or homebrew (http://brew.sh/) and tell RVM to use them by running:
 
     rvm autolibs macports #OR
     rvm autolibs homebrew


### PR DESCRIPTION
The Homebrew repository at GitHub now has its own user at https://github.com/Homebrew.

I also noticed that requirements_osx_brew_installation_setup() that there's a variable setting the link to its old repository, namely:

./scripts/functions/requirements/osx_brew (line 386)
homebrew_repo="mxcl/homebrew"

Later on, it's used within the requirements_osx_brew_install() function. All links work now, even though they link to the older repository. I couldn't get the https://raw.githubusercontent.com/Homebrew/homebrew/go/install working (on line 410) so I left it alone.
