### PR TITLE
rvm-prompt not working in Yosemite

### DIFF
--- a/bin/rvm-prompt
+++ b/bin/rvm-prompt
@@ -59,10 +59,10 @@ then
   ruby_string="${ruby_string##*/}"
   case "${GEM_HOME:-""}" in
     (*${rvm_gemset_separator:-"@"}*)
-      ruby_string="${ruby_string%%${rvm_gemset_separator:-"@"}*}"
       if (( ${gemset_flag:-0} ))
       then gemset="${rvm_gemset_separator:-"@"}${ruby_string##*${rvm_gemset_separator:-"@"}}"
       fi
+      ruby_string="${ruby_string%%${rvm_gemset_separator:-"@"}*}"
       ;;
   esac
   if


### PR DESCRIPTION
`rvm-prompt` currently returns blank in Yosemite. I realize this is a beta OS but thought it should be known.
