### PR TITLE
Remove whitespace padding from version string

### DIFF
--- a/scripts/version
+++ b/scripts/version
@@ -21,5 +21,5 @@ __rvm_version()
   rvm_meta_authors="${rvm_meta_authors[*]}"
   rvm_meta_authors="${rvm_meta_authors//:/, }"
 
-  echo -e "\nrvm ${rvm_meta_version} by ${rvm_meta_authors} [${rvm_meta_website}]\n"
+  echo "rvm ${rvm_meta_version} by ${rvm_meta_authors} [${rvm_meta_website}]"
 }


### PR DESCRIPTION
IMHO putting the output on the first line better follows the conventions of command-line utilities.
