### PR TITLE
Check that GEM_HOME include '/' and doesn't ends with it to prevent exception in split

### DIFF
--- a/scripts/irbrc.rb
+++ b/scripts/irbrc.rb
@@ -38,7 +38,12 @@ end
 
 # Calculate the ruby string.
 rvm_ruby_string = ENV["rvm_ruby_string"] ||
-  (ENV['GEM_HOME'] && ENV['GEM_HOME'].split(/\//).last.split(/@/).first) ||
+  (
+    ENV['GEM_HOME'] &&
+    path = ( File.realpath(ENV['GEM_HOME'].to_s) rescue nil ) &&
+    ( path = $1 if path =~ /(.+)\/$/ ; true ) &&
+    path.split(/\//).last.split(/@/).first
+  ) ||
   ("#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}" rescue nil) ||
   (RUBY_DESCRIPTION.split(" ")[1].sub('p', '-p') rescue nil ) ||
   (`ruby -v` || '').split(" ")[1].sub('p', '-p')


### PR DESCRIPTION
Gem `spring` sets GEM_HOME to empty string, which causes exception in line: 
`(ENV['GEM_HOME'] && ENV['GEM_HOME'].split(/\//).last.split(/@/).first) ||`

`split` in case of empty string will return nil which not responds to `last`. Also `GEM_HOME` can be set as `'something/'` which will cause exception too after second split.
