### PR TITLE
Restore correct git package for smartos distro

### DIFF
--- a/scripts/functions/requirements/smartos
+++ b/scripts/functions/requirements/smartos
@@ -24,7 +24,7 @@ requirements_smartos_define()
 {
   case "$1" in
     (rvm)
-      requirements_check bash curl patch git
+      requirements_check bash curl patch scmgit-base
       ;;
     (jruby*)
       if


### PR DESCRIPTION
I'm trying to install ruby 2.1.1 on a smartos machine(**SunOS  5.11 joyent i86pc i386 i86pc Solaris**), and it fails when try to check git dependency

the error trace:

``` bash
Installing required packages: git...
Error running 'requirements_smartos_libs_install git',
showing last 15 lines of /home/deploy/.rvm/log/1403545127_ruby-2.1.1/package_install_git.log
++ missing_paths+=:/sbin
++ for sbin_path in /sbin /usr/sbin /usr/local/sbin
++ [[ -d /usr/sbin ]]
++ [[ ! :/home/deploy/.rvm/gems/ruby-2.0.0-p247/bin:/home/deploy/.rvm/gems/ruby-2.0.0-p247@global/bin:/home/deploy/.rvm/rubies/ruby-2.0.0-p247/bin:/home/deploy/.rvm/bin:/home/deploy/.rvm/bin:/opt/local/bin:/opt/local/sbin:/usr/bin:/usr/sbin: =~ :/usr/sbin: ]]
++ for sbin_path in /sbin /usr/sbin /usr/local/sbin
++ [[ -d /usr/local/sbin ]]
++ [[ -n :/sbin ]]
++ command_to_run=(/usr/bin/env PATH="${PATH}${missing_paths}" "${command_to_run[@]}")
++ command_to_run=(${sudo_path}sudo -p "%p password required for '$*': " "${command_to_run[@]}")
++ sudo -p '%p password required for '\''pkgin -y install git'\'': ' /usr/bin/env PATH=/home/deploy/.rvm/gems/ruby-2.0.0-p247/bin:/home/deploy/.rvm/gems/ruby-2.0.0-p247@global/bin:/home/deploy/.rvm/rubies/ruby-2.0.0-p247/bin:/home/deploy/.rvm/bin:/home/deploy/.rvm/bin:/opt/local/bin:/opt/local/sbin:/usr/bin:/usr/sbin:/sbin pkgin -y install git
git is not available on the repository
calculating dependencies... done.
nothing to do.
++ return 1
++ return 1
```

the error is because there is not a **git** package on smartos, but scmgit is still available, this is the list i have:

``` bash
pkgin search scmgit
scmgit-gitk-1.8.3.1  GIT Tree History Storage Tool (gitk)
scmgit-docs-1.8.3.1  GIT Tree History Storage Tool (documentation)
scmgit-base-1.8.3.1 = GIT Tree History Storage Tool (base package)
scmgit-1.8.3.1       GIT version control suite meta-package
```

and looking on the commits i found this change:
https://github.com/wayneeseguin/rvm/commit/f20e067aa26b3be635f3c951cb3bd0ed2f52d866

the old **'scmgit-base'** package was changed for **'git'** which does exist.

after edit the package name on the smartos script i was able to install 2.1.1
