### PR TITLE
Fixed splitting on nil error.

### DIFF
--- a/scripts/irbrc.rb
+++ b/scripts/irbrc.rb
@@ -42,7 +42,7 @@ rvm_ruby_string = ENV["rvm_ruby_string"] ||
     ENV['GEM_HOME'] &&
     ( path = ( File.realpath(ENV['GEM_HOME'].to_s) rescue nil ) ) &&
     ( path = $1 if path =~ /(.+)\/$/ ; true ) &&
-    path.split(/\//).last.split(/@/).first
+    String(String(path).split(/\//).last).split(/@/).first
   ) ||
   ("#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}" rescue nil) ||
   (RUBY_DESCRIPTION.split(" ")[1].sub('p', '-p') rescue nil ) ||


### PR DESCRIPTION
```
~$ irb
load error: /home/user/.rvm/rubies/ruby-2.1.2/.irbrc
NoMethodError: undefined method `split' for nil:NilClass
    /home/user/.rvm/scripts/irbrc.rb:45:in `<top (required)>'
    /home/user/.rvm/rubies/ruby-2.1.2/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    /home/user/.rvm/rubies/ruby-2.1.2/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    /home/user/.rvm/rubies/ruby-2.1.2/.irbrc:11:in `<top (required)>'
    /home/user/.rvm/rubies/ruby-2.1.2/lib/ruby/2.1.0/irb/init.rb:236:in `load'
    /home/user/.rvm/rubies/ruby-2.1.2/lib/ruby/2.1.0/irb/init.rb:236:in `run_config'
    /home/user/.rvm/rubies/ruby-2.1.2/lib/ruby/2.1.0/irb/init.rb:19:in `setup'
```
