### PR TITLE
Fixes the "Warning! PATH is not properly" warning because of PATH order

### DIFF
--- a/scripts/functions/installer
+++ b/scripts/functions/installer
@@ -1105,7 +1105,7 @@ setup_user_profile_rc()
     do
       touch "$profile_file"
       printf "%b" "
-export PATH=\"\$PATH:$local_rvm_path/bin\" # Add RVM to PATH for scripting
+export PATH=\"$local_rvm_path/bin:\$PATH\" # Add RVM to PATH for scripting
 " >> "$profile_file"
     done
     user_rc_files=( "${target_rc[@]}" )


### PR DESCRIPTION
The defaults add the rvm path after the original path, making the

```
Warning! PATH is not properly set up, '/Users/mikal/.rvm/gems/ruby-2.1.2/bin' is not at first place,
         usually this is caused by shell initialization files - check them for 'PATH=...' entries,
         it might also help to re-add RVM to your dotfiles: 'rvm get stable --auto-dotfiles',
         to fix temporarily in this shell session run: 'rvm use ruby-2.1.2'.
```

spawn by default.

This fixes it. Other than that, thanks for a awesome software :)
