### PR TITLE
Corrects typo in error message displayed to the user

### DIFF
--- a/scripts/functions/utility
+++ b/scripts/functions/utility
@@ -135,7 +135,7 @@ rvm_is_a_shell_function()
     rvm_warn '
 You need to change your terminal emulator preferences to allow login shell.
 Sometimes it is required to use `/bin/bash --login` as the command.
-Please visit https://rvm.io/integration/gnome-terminal/ for a example.
+Please visit https://rvm.io/integration/gnome-terminal/ for an example.
 '
   fi
   return ${rvm_is_not_a_shell_function:-0}


### PR DESCRIPTION
Replaces "for a example" with the correct "for an example".
