### PR TITLE
remove superfluous characters that cause error if entered verbatim

### DIFF
--- a/help/rvmrc.md
+++ b/help/rvmrc.md
@@ -1,7 +1,7 @@
     $ rvm rvmrc {trust,untrust,trusted,load,reset} [optional-path]
     $ rvm rvmrc create {ruby-version} [--rvmrc|--ruby-version|--versions-conf]
     $ rvm rvmrc warning [ignore|reset|list] [<optional-path>|all.rvmrcs|allGemfiles]
-    $ rvm rvmrc to [.]ruby-version
+    $ rvm rvmrc to ruby-version
 
 Tools for dealing with and loading the rvmrc trust for a given directory.
 All actions take an optional path to a directory to check.

--- a/help/rvmrc/to.md
+++ b/help/rvmrc/to.md
@@ -1,3 +1,3 @@
-    $ rvm rvmrc to [.]ruby-version
+    $ rvm rvmrc to ruby-version
 
 Migrate .rvmrc to .ruby-version

--- a/scripts/functions/rvmrc_warning
+++ b/scripts/functions/rvmrc_warning
@@ -140,7 +140,7 @@ __rvmrc_warning_display_for_rvmrc()
     ! __rvmrc_warning_check_quiet "${__rvmrc_warning_file:-${2:-}}"
   then
     rvm_warn "You are using '.rvmrc', it requires trusting, it is slower and it is not compatible with other ruby managers,
-you can switch to '.ruby-version' using 'rvm rvmrc to [.]ruby-version'
+you can switch to '.ruby-version' using 'rvm rvmrc to ruby-version'
 or ignore this warning with 'rvm rvmrc warning ignore $1',
 '.rvmrc' will continue to be the default project file in RVM 1 and RVM 2,
 to ignore the warning for all files run 'rvm rvmrc warning ignore all.rvmrcs'.


### PR DESCRIPTION
Including [.] in the documentation and warning is confusing and unnecessary. I see no rational justification for including it, and a Google search reveals many people are actually copying and pasting or typing in the brackets which of course results in an error. Why sabotage people's ability to use rvm for no good reason?
