### PR TITLE
updated patches for current 2.1 head

### DIFF
--- a/patchsets/ruby/2.1/head/railsexpress
+++ b/patchsets/ruby/2.1/head/railsexpress
@@ -2,9 +2,7 @@ https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.1/he
 https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.1/head/railsexpress/02-improve-gc-stats.patch
 https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.1/head/railsexpress/03-display-more-detailed-stack-trace.patch
 https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.1/head/railsexpress/04-show-full-backtrace-on-stack-overflow.patch
-https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.1/head/railsexpress/05-fix-missing-c-return-event.patch
-https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.1/head/railsexpress/06-backport-006e66b6680f60adfb434ee7397f0dbc77de7873.patch
-https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.1/head/railsexpress/07-funny-falcon-stc-density.patch
-https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.1/head/railsexpress/08-funny-falcon-stc-pool-allocation.patch
-https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.1/head/railsexpress/09-aman-opt-aset-aref-str.patch
-https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.1/head/railsexpress/10-funny-falcon-method-cache.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.1/head/railsexpress/05-funny-falcon-stc-density.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.1/head/railsexpress/06-funny-falcon-stc-pool-allocation.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.1/head/railsexpress/07-aman-opt-aset-aref-str.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.1/head/railsexpress/08-funny-falcon-method-cache.patch


### PR DESCRIPTION
upstream ruby has incorporated some of the fixes in 2.1. head branch, so I had to remove them.

can you please merge?
