### PR TITLE
fix bash version check

### DIFF
--- a/binscripts/rvm-installer
+++ b/binscripts/rvm-installer
@@ -11,7 +11,7 @@ rvm_install_initialize()
   BASH_MIN_VERSION="3.2.25"
   if
     [[ -n "${BASH_VERSION:-}" &&
-      "$(\printf "%b" "${BASH_VERSION:-}\n${BASH_MIN_VERSION}\n" | LC_ALL=C \sort -n -t"." | \head -n1)" != "${BASH_MIN_VERSION}"
+      "$(\printf "%b" "${BASH_VERSION:-}\n${BASH_MIN_VERSION}\n" | LC_ALL=C \sort -t"." -k1,1n -k2,2n -k3,3n | \head -n1)" != "${BASH_MIN_VERSION}"
     ]]
   then
     echo "BASH ${BASH_MIN_VERSION} required (you have $BASH_VERSION)"


### PR DESCRIPTION
The current rvm-installer accepts unsupported bash versions(3.2.3 ~ 3.2.9) due to the incorrect version comparison.

ex) The following code which is extracted from rvm-installer does not show the error message.

```
BASH_VERSION="3.2.3"  # Set unsupported bash version for debug
BASH_MIN_VERSION="3.2.25"
if
    [[ -n "${BASH_VERSION:-}" &&
    "$(\printf "%b" "${BASH_VERSION:-}\n${BASH_MIN_VERSION}\n" | LC_ALL=C \sort -n -t"." | \head -n1)" != "${BASH_MIN_VERSION}"
    ]]
then
    echo "BASH ${BASH_MIN_VERSION} required (you have $BASH_VERSION)"
    exit 1
fi
```

I've fixed it by changing the sort option.
