### PR TITLE
Removes yum-config-manager from centos reqs, EPEL comes enabled

### DIFF
--- a/scripts/functions/requirements/centos
+++ b/scripts/functions/requirements/centos
@@ -31,8 +31,7 @@ requirements_centos_update_system_install_epel()
   "${rvm_scripts_path}/fetch" "${epel_key}"
   "${rvm_scripts_path}/fetch" "${epel_rpm}"
   __rvm_try_sudo rpm --import   "${rvm_archives_path}/${epel_key##*/}"
-  __rvm_try_sudo rpm --quiet -i "${rvm_archives_path}/${epel_rpm##*/}" &&
-  __rvm_try_sudo yum-config-manager -q --enable epel ||
+  __rvm_try_sudo rpm --quiet -i "${rvm_archives_path}/${epel_rpm##*/}" ||
   {
     typeset __ret=$?
     rvm_error "Error installing EPEL, it is required for libyaml-devel,


### PR DESCRIPTION
**Problem**: `yum-config-manager` is not installed on CentOS minimal and the rvm install fails with:

```
Error running 'requirements_centos_update_system ruby-1.9.3-p547',
showing last 15 lines of /home/user/.rvm/log/1407555224_ruby-1.9.3-p547/update_system.log
++ /scripts/functions/logging : rvm_pretty_print()  81 > case "$1" in
++ /scripts/functions/logging : rvm_pretty_print()  83 > [[ -t 2 ]]
++ /scripts/functions/logging : rvm_pretty_print()  83 > return 1
++ /scripts/functions/logging : rvm_error()  117 > printf %b 'Error installing EPEL, it is required for libyaml-devel,
either there was an error installing EPEL package,
or there was problem checking if libyaml-devel is available / installed.\n'
Error installing EPEL, it is required for libyaml-devel,
either there was an error installing EPEL package,
or there was problem checking if libyaml-devel is available / installed.
++ /scripts/functions/requirements/centos : requirements_centos_update_system_install_epel()  41 > return 1
++ /scripts/functions/utility_logging : __rvm_log_command_simple()  83 > return 1
++ /scripts/functions/utility_logging : __rvm_log_command()  61 > return 1
++ /scripts/functions/build_requirements_helpers : rvm_requiremnts_fail_or_run_action()  158 > return 1
++ /scripts/functions/requirements/centos : requirements_centos_update_system_check_epel()  66 > return 1
++ /scripts/functions/requirements/centos : requirements_centos_update_system()  72 > return 1
Requirements installation failed with status: 1.
```

**Reasoning**: Installing EPEL enables it by default, there's no need to enable it again. This was tested on CentOS 5:

```
$ cat /etc/issue
CentOS release 5.7 (Final)
Kernel \r on an \m
$ rpm -qa | grep epel
$ sudo rpm -ivh http://mirror.steadfast.net/epel/5/i386/epel-release-5-4.noarch.rpm
Retrieving http://mirror.steadfast.net/epel/5/i386/epel-release-5-4.noarch.rpm
Preparing...                ########################################### [100%]
   1:epel-release           ########################################### [100%]
$ yum repolist enabled | grep epel
epel            Extra Packages for Enterprise Linux 5 - x86_64            7,739
```

And 6:

```
$ cat /etc/issue
CentOS release 6.5 (Final)
Kernel \r on an \m
$ rpm -qa | grep epel
$ sudo rpm -ivh http://fedora.mirrors.pair.com/epel/6/i386/epel-release-6-8.noarch.rpm
Retrieving http://fedora.mirrors.pair.com/epel/6/i386/epel-release-6-8.noarch.rpm
Preparing...                ########################################### [100%]
   1:epel-release           ########################################### [100%]
$ yum repolist enabled | grep epel
 * epel: mirror.prgmr.com
*epel            Extra Packages for Enterprise Linux 6 - x86_64           11,082
```

**Solution**: :ship: this PR :smile: 
