### PR TITLE
Fixed #2995 execution of 'after_cd' hooks

### DIFF
--- a/scripts/cd
+++ b/scripts/cd
@@ -18,26 +18,23 @@ case "${rvm_project_rvmrc:-1}" in
 
   __rvm_after_cd()
   {
-    __rvm_do_with_env_before
     typeset rvm_hook
     rvm_hook="after_cd"
     if [[ -n "${rvm_scripts_path:-}" || -n "${rvm_path:-}" ]]
     then source "${rvm_scripts_path:-$rvm_path/scripts}/hook"
     fi
-    __rvm_do_with_env_after
   }
   __rvm_cd_functions_set()
   {
     __rvm_do_with_env_before
     __rvm_project_rvmrc >&2 || true
+    __rvm_after_cd
     __rvm_do_with_env_after
     return 0
   }
   export -a chpwd_functions
   [[ " ${chpwd_functions[*]} " == *" __rvm_cd_functions_set "* ]] ||
   chpwd_functions=( "${chpwd_functions[@]}" __rvm_cd_functions_set )
-  [[ " ${chpwd_functions[*]} " == *" __rvm_after_cd "* ]] ||
-  chpwd_functions=( "${chpwd_functions[@]}" __rvm_after_cd )
 
   # This functionality is opt-in by setting rvm_cd_complete_flag=1 in ~/.rvmrc
   # Generic bash cd completion seems to work great for most, so this is only

--- a/scripts/rvm
+++ b/scripts/rvm
@@ -174,13 +174,8 @@ then
         then
           # Reload the rvmrc, use promptless ensuring shell processes does not
           # prompt if .rvmrc trust value is not stored, revert to default on fail
-          if
-            rvm_current_rvmrc=""
-            rvm_project_rvmrc_default=2 rvm_promptless=1 __rvm_project_rvmrc
-          then
-            rvm_hook=after_cd
-            source "${rvm_scripts_path:-${rvm_path}/scripts}/hook"
-          fi
+          rvm_current_rvmrc=""
+          rvm_project_rvmrc_default=2 rvm_promptless=1 __rvm_project_rvmrc
         fi
       fi
       unset __path_to_ruby


### PR DESCRIPTION
Fix for #2995
Problem description:

`rmv_path/scripts/hook` ( http://git.io/PwckwQ ) contains:

``` bash
hooks=( "$rvm_hooks_path")
[[ "$PWD/.rvm/hooks" == "$rvm_hooks_path" ]] ||
  hooks+=( "$PWD/.rvm/hooks" )

_hooks_list=($(
  __rvm_find -L "${hooks[@]}" -iname "$rvm_hook*" -type f 2>/dev/null
))
```

but when env is not loaded `$rvm_hooks_path` is undefined. This leads
to `"${hooks[@]}"` contains a space and `find` will fail with
`find: ftsopen: No such file or directory` and tnx to `2>/dev/null`
error will be invisible.
