### PR TITLE
Typo fix

### DIFF
--- a/scripts/rvm
+++ b/scripts/rvm
@@ -166,7 +166,7 @@ then
         [[ "${__path_to_ruby}" == "${rvm_path}/bin/ruby" ]]
       then
         if [[ -s "${rvm_environments_path:-${rvm_path}/environments}/default" ]]
-        then source "${rvm_environments_path:-${rvm_path}/environments/default"
+        then source "${rvm_environments_path:-${rvm_path}/environments}/default"
         fi
         if
           [[ ${rvm_project_rvmrc:-1} -gt 0 ]] &&


### PR DESCRIPTION
Commit b0d1c78 was missing a closing curly brace causing the `source .rvm/scripts/rvm` command to fail (at least on OSX).
