### PR TITLE
Fix escaping of backslash for bash 4.3

### DIFF
--- a/scripts/functions/env
+++ b/scripts/functions/env
@@ -276,7 +276,7 @@ __rvm_env_print()
   then
     \command \cat "$environment_file_path" |
       __rvm_grep -Eo "[^ ]+=[^;]+" |
-      __rvm_sed -e 's/\$PATH/'"${PATH//\//\/}"'/' -e 's/\${PATH}/'"${PATH//\//\/}"'/'
+      __rvm_sed -e 's/\$PATH/'"${PATH//\//\\/}"'/' -e 's/\${PATH}/'"${PATH//\//\\/}"'/'
   else
     \command \cat "$environment_file_path"
   fi


### PR DESCRIPTION
`rvm cron setup` fails on bash 4.3.11 with:

```
sed: -e expression #1, char 11: unknown option to `s'
```

Fixed escaping, works well both in 4.3.11 and 4.2.45
