### PR TITLE
SSE2-CPU required for compiling Ruby 2.1.1 with rvm?

### DIFF
--- a/scripts/functions/manage/ruby
+++ b/scripts/functions/manage/ruby
@@ -119,6 +119,24 @@ ${_memo}"
 
 __rvm_post_configure_ruby()
 {
+  __rvm_post_configure_ruby_fix_athlon_sse2
+  __rvm_post_configure_ruby_update_setup
+}
+
+__rvm_post_configure_ruby_fix_athlon_sse2()
+{
+  if
+    [[ -f /proc/cpuinfo && -f Makefile ]] &&
+    __rvm_grep "^XCFLAGS = .*-msse2" Makefile >/dev/null &&
+    __rvm_grep "Athlon" /proc/cpuinfo &&
+    ! __rvm_grep "^flags.*sse2" /proc/cpuinfo
+  then
+    __rvm_sed_i Makefile -e '/^XCFLAGS =/s/-msse2//'
+  fi
+}
+
+__rvm_post_configure_ruby_update_setup()
+{
   typeset option
   if
     (( ${rvm_static_flag:-0} == 1 )) && (( ${rvm_dynamic_extensions_flag:-0} == 0 ))


### PR DESCRIPTION
Hi,
I have the following problem with installing Ruby 2.1.1:
when I call `rvm install 2.1.1` on a Debian testing/jessie machine that has an Athlon XP 2600+ processor (no SSE2-support), the compiling process is aborted after a few minutes with the following output:

``` bash
carsten@debbie ~ % rvm install 2.1.1
ruby-2.1.1 - #removing src/ruby-2.1.1 - please wait
Searching for binary rubies, this might take some time.
No binary rubies available for: debian/jessie_sid/i386/ruby-2.1.1.
Continuing with compilation. Please read 'rvm help mount' to get more information on binary rubies.
Checking requirements for debian.
Requirements installation successful.
Installing Ruby from source to: /home/carsten/.rvm/rubies/ruby-2.1.1, this may take a while depending on your cpu(s)...
ruby-2.1.1 - #downloading ruby-2.1.1, this may take a while depending on your connection...
ruby-2.1.1 - #extracting ruby-2.1.1 to /home/carsten/.rvm/src/ruby-2.1.1 - please wait
ruby-2.1.1 - #applying patch /home/carsten/.rvm/patches/ruby/changeset_r45225.diff - please wait
ruby-2.1.1 - #applying patch /home/carsten/.rvm/patches/ruby/changeset_r45240.diff - please wait
ruby-2.1.1 - #configuring - please wait
ruby-2.1.1 - #post-configuration - please wait
ruby-2.1.1 - #compiling - please wait
Error running '__rvm_make -j1',
showing last 15 lines of /home/carsten/.rvm/log/1399922963_ruby-2.1.1/make.log
compiling ./enc/ascii.c
compiling ./enc/us_ascii.c
compiling ./enc/unicode.c
compiling ./enc/utf_8.c
compiling newline.c
compiling ./missing/strlcpy.c
compiling ./missing/strlcat.c
compiling ./missing/setproctitle.c
compiling addr2line.c
compiling dmyext.c
linking miniruby
uncommon.mk:543: recipe for target '.rbconfig.time' failed
make: *** [.rbconfig.time] Ungültiger Maschinenbefehl (Speicherauszug erstellt)
  257,40s user 9,16s system 53% cpu 8:21,28 total
+__rvm_make:0:cmdor> return 2
There has been an error while running make. Halting the installation.
```

'Ungültiger Maschinenbefehl (Speicherauszug erstellt)' would be 'Illegal instruction (core dumped)' in English.

Performing the same operation on an Intel Pentium 4 M (SSE2-support) with the same Linux distribution completes without errors. I'm using rvm 1.25.25 (stable) by the way.

Is it possible to work around this issue somehow? I hope I don't have to get a new computer to keep up with current Ruby development...

Regards,
Carsten
