### PR TITLE
Extend SSE2 workaround beyond Athlon processors

### DIFF
--- a/scripts/functions/manage/ruby
+++ b/scripts/functions/manage/ruby
@@ -128,7 +128,6 @@ __rvm_post_configure_ruby_fix_athlon_sse2()
   if
     [[ -f /proc/cpuinfo && -f Makefile ]] &&
     __rvm_grep "^XCFLAGS = .*-msse2" Makefile >/dev/null &&
-    __rvm_grep "Athlon" /proc/cpuinfo &&
     ! __rvm_grep "^flags.*sse2" /proc/cpuinfo
   then
     __rvm_sed_i Makefile -e '/^XCFLAGS =/s/-msse2//'


### PR DESCRIPTION
Extends beyond Athlon processors the existing workaround, here, for ruby-lang's (recent?) failure, during Ruby compilation, properly to handle processors without SSE2 capabilities.

The existing workaround shouldn't be limited to Athlon processors, because (at least) some Intel processors, for instance their Pentium III, also lack Intel's Streaming Single Instruction, Multiple Data (SIMD) Extensions 2 ([SSE2](http://en.wikipedia.org/wiki/SSE2)) processor supplementary instruction set.

Fixes #2850 on my Linux machine. Removes a line from commit f24eba6 at author's request.

Do you need me to make a bugfix branch?
