### PR TITLE
/bin/sh: line 6: `BASH_FUNC_rvm_debug%%': not a valid identifier

### DIFF
--- a/scripts/functions/logging
+++ b/scripts/functions/logging
@@ -147,7 +147,6 @@ rvm_debug()
   else printf "%b" "$*\n"
   fi >&2
 }
-export -f rvm_debug >/dev/null 2>&1
 
 rvm_debug_stream()
 {


### PR DESCRIPTION
I'm getting this error on random commands.

```
user@air:~/projects/xxx (master)$ git status
On branch master
nothing to commit, working directory clean
user@air:~/projects/xxx (master)$ git submodule status
/bin/sh: line 6: `BASH_FUNC_rvm_debug%%': not a valid identifier
user@air:~/projects/xxx (master)$ mysql.server status
/bin/sh: line 6: `BASH_FUNC_rvm_debug%%': not a valid identifier
user@air:~/projects/xxx (master)$ rvm --version
rvm 1.25.31 (stable) by Wayne E. Seguin <wayneeseguin@gmail.com>, Michal Papis <mpapis@gmail.com> [https://rvm.io/]
```

$BASH_VERSION
4.3.27(1)-release
