### PR TITLE
Solaris 11 fix regression on ps since update #2950

### DIFF
--- a/scripts/functions/installer
+++ b/scripts/functions/installer
@@ -813,7 +813,7 @@ setup_etc_profile()
   then return 0
   fi
 
-  typeset executable add_to_profile_flag zshrc_file
+  typeset executable add_to_profile_flag zshrc_file ps_ucomm_alias
   if
     [[ -d /etc/profile.d ]]
   then
@@ -823,6 +823,13 @@ setup_etc_profile()
     add_to_profile_flag=1
     executable=0
     mkdir -p /etc/profile.d
+  fi
+  if [[ "$(uname)" == "SunOS" ]]
+  then
+    # Solaris defaut ps doesn't provide ucomm
+    ps_ucomm_alias=comm 
+  else
+    ps_ucomm_alias=ucomm 
   fi
 
 # partial duplication marker dkjnkjvnckbjncvbkjnvkj
@@ -835,8 +842,8 @@ setup_etc_profile()
 
 if
   [ -n \"\${BASH_VERSION:-}\" -o -n \"\${ZSH_VERSION:-}\" ] &&
-  test \"\`\\\\command \\\\ps -p \$\$ -o ucomm=\`\" != dash &&
-  test \"\`\\\\command \\\\ps -p \$\$ -o ucomm=\`\" != sh
+  test \"\`\\\\command \\\\ps -p \$\$ -o ${ps_ucomm_alias}=\`\" != dash &&
+  test \"\`\\\\command \\\\ps -p \$\$ -o ${ps_ucomm_alias}=\`\" != sh
 then
   [[ -n \"\${rvm_stored_umask:-}\" ]] || export rvm_stored_umask=\$(umask)
   # Load user rvmrc configurations, if exist

--- a/scripts/rvm
+++ b/scripts/rvm
@@ -11,6 +11,7 @@ if
 then
   case "`uname`" in
     (CYGWIN*) __shell_name="`\command \ps -p $$ | \command \awk 'END {print $NF}'` 2>/dev/null" ;;
+    (SunOS)   __shell_name="`\command \ps -p $$ -o comm=`" ;;
     (*)       __shell_name="`\command \ps -p $$ -o ucomm=`" ;;
   esac
   case "$__shell_name" in


### PR DESCRIPTION
Default Solaris ps doesn't provide 'ps -o ucomm'

Todo: remove or fix is_parent_of() function from  scripts/functions/support
because it also use 'ps -o ucomm'

It seem's that it is not used anymore, perhaps it may be removed in future ?
