### PR TITLE
Solaris 11 fallback to /usr/bin/sudo if /opt/csw/bin/sudo is not found #...

### DIFF
--- a/scripts/functions/support
+++ b/scripts/functions/support
@@ -289,6 +289,13 @@ __rvm_setup_sudo_function_Solaris()
     {
       /opt/csw/bin/sudo "$@"
     }
+  elif
+    [[ -x /usr/bin/sudo ]]
+  then
+    __rvm_sudo()
+    {
+      /usr/bin/sudo "$@"
+    }
   else
     rvm_debug "Warning: No '/opt/csw/bin/sudo' found."
   fi


### PR DESCRIPTION
...3087

__rvm_setup_sudo_function_Solaris() fallback to /usr/bin/sudo if /opt/csw/bin/sudo is not found #3087
