### PR TITLE
Switch default homebrew gcc to 4.8 for OS X Yosemite (and beyond)

### DIFF
--- a/scripts/functions/requirements/osx_brew
+++ b/scripts/functions/requirements/osx_brew
@@ -213,7 +213,9 @@ requirements_osx_brew_libs_default_check_gcc()
 
 requirements_osx_brew_libs_default_add_gcc_v_auto()
 {
-  if __rvm_version_compare "${_system_version}" -ge 10.7
+  if __rvm_version_compare "${_system_version}" -ge 10.10
+  then requirements_osx_brew_libs_default_add_gcc_v 4.8
+  elif __rvm_version_compare "${_system_version}" -ge 10.7
   then requirements_osx_brew_libs_default_add_gcc_v 4.6
   else requirements_osx_brew_libs_default_add_gcc_v 4.2
   fi


### PR DESCRIPTION
Currently, gcc 4.6 cannot compile on OS X 10.10 without patching.

Fixes #3096.

I evaluated adding support for gcc 4.9, but one of the Ruby versions I tried (1.9.2-p318) will not build with that compiler. I'm not sure if teaching RVM 1.x to use an older compiler for older Ruby versions is practical. In any case, gcc 4.8 is still a current, supported gcc version.
