### PR TITLE
Fix bug in 10.10+ test for old rubies

### DIFF
--- a/scripts/functions/build_config_system
+++ b/scripts/functions/build_config_system
@@ -4,7 +4,7 @@
 __rvm_setup_compile_environment_system_early_osx_old_rubies()
 {
   # skip if 10.10+
-  __rvm_version_compare "${_system_version}" -lt 10.10 || return 0
+  __rvm_version_compare "${_system_version}" -ge 10.10 || return 0
 
   case ${rvm_ruby_string:-""} in
     ruby-1.8.7*)


### PR DESCRIPTION
I believe the test for building old rubies on 10.10+ was backwards, and this was preventing me from installing 1.9.2 on 10.9.

Before this change:

```
 ~ % rvm install ruby-1.9.2-p290
Searching for binary rubies, this might take some time.
No binary rubies available for: osx/10.9/x86_64/ruby-1.9.2-p290.
It is not possible to build movable binaries for rubies 1.8-1.9.2, but you can do it for your system only.
Continuing with compilation. Please read 'rvm help mount' to get more information on binary rubies.

RVM does not know how to build working ruby-1.9.2-p290 on OSX 10.9,
if you know please let us know by opening a ticket with instructions here:

    https://github.com/wayneeseguin/rvm/issues
```
