### PR TITLE
Added reference to rvm-mini

### DIFF
--- a/docs/alt.md
+++ b/docs/alt.md
@@ -22,6 +22,8 @@ Other implementations allowing to switch ruby environment:
 - http://zentest.rubyforge.org/ZenTest/Multiruby.html (Ruby)
 - http://www.dribin.org/dave/blog/archives/2006/01/07/rails_encap/ (Tutorial)
 - http://www.mjwall.com/2008/08/multiple-versions-of-ruby-with-stow/ (Tutorial)
+- https://github.com/TomFreudenberg/rvm-mini
+
 
 # RVM is not the only Ruby Version Manager
 
@@ -34,6 +36,7 @@ Other implementations allowing to install ruby versions:
 - https://github.com/jayferd/ry
 - https://github.com/sstephenson/ruby-build
 - https://github.com/mugenken/p5-Ruby-VersionManager (Perl!)
+- https://github.com/TomFreudenberg/rvm-mini
 
 
 # RVM IDE support


### PR DESCRIPTION
Inspired by rvm (http://rvm.io) we created a very small ruby installer and runtime environment based on binaries of rvm - I call it little rvm brother. Conceptional changes were done based on discussion about vulnarables with @mpapis. Details at: https://github.com/TomFreudenberg/rvm-mini/issues/2

Would be nice if you could append the references to the list.
