### PR TITLE
Redirect stderr for "which gpg*" commands to /dev/null.

### DIFF
--- a/binscripts/rvm-installer
+++ b/binscripts/rvm-installer
@@ -386,8 +386,8 @@ Could not download '${_url}'.
 rvm_install_gpg_setup()
 {
   export rvm_gpg_command
-  rvm_gpg_command="$( \which gpg2 )"  ||
-    rvm_gpg_command="$( \which gpg )" ||
+  rvm_gpg_command="$( \which gpg2 2>/dev/null )"  ||
+    rvm_gpg_command="$( \which gpg 2>/dev/null )" ||
     rvm_gpg_command=""
   debug "Detected GPG program: '$rvm_gpg_command'"
   [[ -n "$rvm_gpg_command" ]] || return $?

--- a/scripts/functions/cli
+++ b/scripts/functions/cli
@@ -177,8 +177,8 @@ You can enable  auto-update  with:    echo rvm_autoupdate_flag=2 >> ~/.rvmrc
 # duplication marker flnglfdjkngjndkfjhsbdjgfghdsgfklgg
 rvm_install_gpg_setup()
 {
-  rvm_gpg_command="$( \which gpg2 )"  ||
-    rvm_gpg_command="$( \which gpg )" ||
+  rvm_gpg_command="$( \which gpg2 2>/dev/null )"  ||
+    rvm_gpg_command="$( \which gpg 2>/dev/null )" ||
     rvm_gpg_command=""
   rvm_debug "Detected GPG program: '$rvm_gpg_command'"
   [[ -n "$rvm_gpg_command" ]] || return $?


### PR DESCRIPTION
Adding `2>/dev/null` to the `which gpg2` and `which gpg` commands makes things a little less noisy.
