### PR TITLE
patchlevel on Gemfile on mac os x broken in latest version

### DIFF
--- a/scripts/functions/rvmrc_project
+++ b/scripts/functions/rvmrc_project
@@ -130,7 +130,11 @@ __rvm_load_project_config()
 
       rvm_ruby_string="$( \command \tr -d '\r' <"$1" | __rvm_sed -n '/^#ruby=/ {s/#ruby=//;p;}' | tail -n 1 )"
       [[ -n "${rvm_ruby_string}" ]] || {
-        rvm_ruby_string="$( \command \tr -d '\r' <"$1" | __rvm_sed -n "s/[[:space:]]+rescue[[:space:]]+nil$//; /^\s*ruby[[:space:](]/ {s/^\s*ruby//; s/[[:space:]()'\"]//g; p;}" | tail -n 1 )"
+        rvm_ruby_string="$(
+          \command \tr -d '\r' <"$1" |
+          __rvm_sed -n "s/[[:space:]]+rescue[[:space:]]+nil$//; /^\s*ruby[[:space:](]/ {s/^\s*ruby//; s/[[:space:]()'\"]//g; p;}" |
+          \tail -n 1
+        )"
         [[ -n "${rvm_ruby_string}" ]] || return 2
       } #'
       rvm_ruby_string="${rvm_ruby_string/,:patchlevel=>/-p}"


### PR DESCRIPTION
I think this commit:

https://github.com/wayneeseguin/rvm/commit/0faf9a801967df00d1b0b97e385d8cde7b94628f

Broke 'patchlevel' Gemfile support. Doing:

$ rvm get 1.26.2
$ cd my_dir
ruby-1.9.3-p551 is not installed.
To install do: 'rvm install ruby-1.9.3-p551'

Then upgrading to 1.26.3:

$ rvm get 1.26.3
...
$ cd ../jnsq_server/
Unknown ruby string (do not know how to handle): ruby-1.9.3,pachlevel:551.
ruby-1.9.3,pachlevel:551 is not installed.
To install do: 'rvm install ruby-1.9.3,pachlevel:551'

Note it's stripping the 't' from patchfile. The Gemfile line is:

ruby '1.9.3', patchlevel: '551'

I'm pretty sure the issue is the sed on mac os x does not support tab characters like '\t'. I'd submit a fix but I'm not sure what a good cross platform one is on off the top of my head.
