### PR TITLE
Installs fail with fink on Yosemite.

### DIFF
--- a/scripts/functions/requirements/osx_fink
+++ b/scripts/functions/requirements/osx_fink
@@ -84,8 +84,12 @@ requirements_osx_fink_gcc_version_detect()
     __rvm_version_compare "${_system_version}" -le 10.7
   then
     fink_libs+=( gcc46 )
-  else # 10.8+
-    fink_libs+=( gcc48 )
+  elif 
+    __rvm_version_compare "${_system_version}" -le 10.10
+  then 
+    _libs+=( gcc48 )
+  else # 10.10
+    fink_libs+=( gcc49 )
   fi
 }
 


### PR DESCRIPTION
Latest fink for yosemite has no gcc48 package available (only gcc49). 
