### PR TITLE
communicate apt sources 404 errors

### DIFF
--- a/scripts/functions/requirements/openmandriva
+++ b/scripts/functions/requirements/openmandriva
@@ -28,7 +28,7 @@ requirements_openmandriva_update_system()
     case ${__ret} in
       (100)
         rvm_error "There has been error while updating 'urpmi.update', please give it some time and try again later.
-For 404 errors check your sources configured in:
+404 errors should be fixed for rvm to proceed. Check your sources configured in:
     /etc/urpmi/urpmi.cfg
 "
         ;;

--- a/scripts/functions/requirements/ubuntu
+++ b/scripts/functions/requirements/ubuntu
@@ -2,6 +2,7 @@
 
 # AMD64, i386, ARM.
 requirements_debian_arch()
+
 {
   __architecture="$(dpkg --print-architecture)"
 }
@@ -44,7 +45,7 @@ requirements_debian_update_system()
     case ${__ret} in
       (100)
         rvm_error "There has been error while updating 'apt-get', please give it some time and try again later.
-For 404 errors check your sources configured in:
+404 errors should be fixed for rvm to proceed. Check your sources configured in:
     /etc/apt/sources.list
     /etc/apt/sources.list.d/*.list
 "


### PR DESCRIPTION
The issue has been raised in [stack overflow](http://stackoverflow.com/questions/23650992/ruby-rvm-apt-get-update-error). It will save some people some time.
