### PR TITLE
correctly set opt_dir when building ruby-head for freebsd, fix #3179

### DIFF
--- a/scripts/functions/requirements/freebsd
+++ b/scripts/functions/requirements/freebsd
@@ -62,6 +62,11 @@ requirements_freebsd_before()
   # TODO: when the time is out deprecate the old pkg_tools https://wiki.freebsd.org/pkgng/CharterAndRoadMap
 }
 
+requirements_freebsd_libs_default()
+{
+  requirements_check autoconf automake libtool bison readline libyaml sqlite3 gdbm
+}
+
 requirements_freebsd_update_system()
 {
   case "${__lib_type}" in
@@ -103,10 +108,12 @@ requirements_freebsd_define()
     (*-head)
       requirements_check git
       requirements_freebsd_define "${1%-head}"
+      requirements_freebsd_libs_default
+      __rvm_update_configure_opt_dir "$1" "/usr/local"
       ;;
     (*)
       # OpenSSL is installed by default http://www.freebsd.org/crypto.html
-      requirements_check autoconf automake libtool bison readline libyaml sqlite3 gdbm
+      requirements_freebsd_libs_default
       __rvm_update_configure_opt_dir "$1" "/usr/local"
       ;;
   esac


### PR DESCRIPTION
the second call to requirements_freebsd_define had -head removed which lead to wrong path in handling opt-dir to /usr/local
