### PR TITLE
[Workaround] rbx-2.4.1 compile error under ubuntu with gcc

### DIFF
--- a/scripts/functions/requirements/ubuntu
+++ b/scripts/functions/requirements/ubuntu
@@ -99,10 +99,12 @@ requirements_debian_define()
     (rbx*head|rubinius*head)
       requirements_check_fallback git git-core
       requirements_ubuntu_libs_default clang llvm
+      rvm_configure_flags+=( --cc=clang --cxx=clang++ )
       ;;
 
     (rbx*|rubinius*)
       requirements_ubuntu_libs_default clang llvm
+      rvm_configure_flags+=( --cc=clang --cxx=clang++ )
       ;;
 
     (*-head)


### PR DESCRIPTION
Under:

```
Linux static 3.13.0-36-generic #63-Ubuntu SMP Wed Sep 3 21:30:07 UTC 2014 x86_64 x86_64 x86_64 GNU/Linux

(Ubuntu 14.04.1 LTS)
```

Running:

```
rvm install rbx-2.4.1
```

causes a compilke error:

`
ruby-2.1.5@rubinius - #bundle install..
rbx-2.4.1 - #configuring............
rbx-2.4.1 - #compiling........................................................................................................................................................................................................................
Error running '/home/user/.rvm/wrappers/ruby-2.1.5@rubinius/rake install --trace',
showing last 15 lines of /home/user/.rvm/log/1417793908_rbx-2.4.1/rake.log
{standard input}: Assembler messages:
{standard input}:260811: Warning: end of file in string; '"' inserted
g++: internal compiler error: Killed (program cc1plus)
Please submit a full bug report,
with preprocessed source if appropriate.
See <file:///usr/share/doc/gcc-4.8/README.Bugs> for instructions.
rake aborted!
Error compiling
/home/user/.rvm/gems/ruby-2.1.5@rubinius/gems/daedalus-core-0.1.0/lib/daedalus.rb:68:in `command'
/home/user/.rvm/gems/ruby-2.1.5@rubinius/gems/daedalus-core-0.1.0/lib/daedalus.rb:234:in `cxx_compile'
/home/user/.rvm/gems/ruby-2.1.5@rubinius/gems/daedalus-core-0.1.0/lib/daedalus.rb:221:in `compile'
/home/user/.rvm/gems/ruby-2.1.5@rubinius/gems/daedalus-core-0.1.0/lib/daedalus.rb:433:in `build'
/home/user/.rvm/gems/ruby-2.1.5@rubinius/gems/daedalus-core-0.1.0/lib/daedalus.rb:895:in `block (2 levels) in perform_tasks'
Tasks: TOP => install => build:build => vm/vm
Error: g++ -I/home/user/.rvm/src/rbx-2.4.1/vm -I/home/user/.rvm/src/rbx-2.4.1/vm/include -I/home/user/.rvm/src/rbx-2.4.1/vm/builtin -I. -Ivm/test/cxxtest -I/home/user/.rvm/src/rbx-2.4.1/vendor/udis86 -I/home/user/.rvm/src/rbx-2.4.1/vendor/libffi/include -Ivendor/double-conversion/src -DHAVE_CONFIG_H -I/home/user/.rvm/src/rbx-2.4.1/vm/include/capi -I/home/user/.rvm/src/rbx-2.4.1/vendor/oniguruma -I/home/user/.rvm/src/rbx-2.4.1/vendor/libtommath -pipe -Wall -fno-omit-frame-pointer -g  -Wno-unused-result -fPIC  -O2 -DHAS_EXECINFO -DHAVE_SPT_REUSEARGV -DHAVE_CLOCK_GETTIME -DHAVE_NL_LANGINFO -DHAVE_POSIX_FADVISE -DHAVE_STRNLEN -DHAVE_TIMERFD -DHAVE_INOTIFY -DHAVE_TM_GMTOFF -DHAVE_TM_ZONE -DHAVE_TIMEZONE -DHAVE_TZNAME -DHAVE_DAYLIGHT -DHAVE_ALLOCA_H -DHAVE_STRING_H -DHAVE_SYS_TIME_H -DHAVE_SYS_TIMES_H -DHAVE_SYS_TYPES_H -DHAVE_UNISTD_H -DHAVE_STDARG_H -DSTRERROR_R_CHAR_P -I/usr/lib/llvm-3.4/include -I/usr/lib/llvm-3.4/include -D_GNU_SOURCE -g -fPIC -DENABLE_LLVM -Wno-unused-function -Werror -DRBX_PROFILER -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -fno-rtti -fvisibility-inlines-hidden  -Wno-unused-result    -c -o vm/artifacts/method_primitives.cpp.o vm/method_primitives.cpp
`

Using clang solves it:

```
rvm install rbx-2.4.1 -- --cc=clang --cxx=clang++
```

In case clang is not installed:

```
sudo apt-get install clang-3.5
```

The same issue appears when installing the source manually via `bundle` and `rake`
