### PR TITLE
`rvm osx-ssl-certs update all` ineffective 

### DIFF
--- a/scripts/functions/osx-ssl-certs
+++ b/scripts/functions/osx-ssl-certs
@@ -57,7 +57,7 @@ requirements_osx_update_openssl_cert_target_move()
   }
 }
 
-requirements_osx_update_openssl_cert_ensure_writable()
+requirements_osx_update_openssl_cert_ensure_readable()
 {
   __target="$cert_file"
   while
@@ -85,7 +85,6 @@ requirements_osx_update_openssl_cert_run()
   requirements_osx_update_openssl_cert_target_select   || return $?
   requirements_osx_update_openssl_cert_create_cert     || return $?
   requirements_osx_update_openssl_cert_target_move     || return $?
-  requirements_osx_update_openssl_cert_ensure_writable || return $?
 }
 
 requirements_osx_update_openssl_cert()
@@ -118,6 +117,7 @@ requirements_osx_update_openssl_cert()
   else
     rvm_log "Certificates in '$cert_file' are already up to date."
   fi
+  requirements_osx_update_openssl_cert_ensure_readable || return $?
 }
 
 __rvm_osx_ssl_certs_update_for_path()
@@ -151,6 +151,7 @@ __rvm_osx_ssl_certs_update_for_path()
     then printf "%b" "Already up to date.\n"
     fi
   fi
+  requirements_osx_update_openssl_cert_ensure_readable || return $?
 }
 
 __rvm_osx_ssl_certs_status_for_path()
@@ -186,6 +187,7 @@ __rvm_osx_ssl_certs_ensure_for_ruby()
       requirements_osx_update_openssl_cert_run ||
       true # Ignore failure - ruby is already installed
   fi
+  requirements_osx_update_openssl_cert_ensure_readable || return $?
   true # for osx
 }
 


### PR DESCRIPTION
```
$ rvm --debug osx-ssl-certs update all
ruby-2.0.0-p353 # getting ruby certs path
Running /Users/ethan/.rvm/hooks/after_use_maglev
ruby-2.0.0-p598 # getting ruby certs path
Running /Users/ethan/.rvm/hooks/after_use_maglev
ruby-2.1.5 # getting ruby certs path
Running /Users/ethan/.rvm/hooks/after_use_maglev
/etc/openssl/cert.pem # updating certs
Updating certificates for /etc/openssl/cert.pem: Updating certificates in '/etc/openssl/cert.pem'.
ethan password required for 'command mv -f /var/folders/h9/3150s5jj0nq61jvwgrs5fg200000gn/T//tmp.L1NQInnuQAfeySTXmb /etc/openssl/cert.pem': 
Updated.
__rvm_rm_rf already gone: /Users/ethan/.rvm/tmp/67857*

$ rvm --debug osx-ssl-certs status all
ruby-2.0.0-p353 # getting ruby certs path
Running /Users/ethan/.rvm/hooks/after_use_maglev
ruby-2.0.0-p598 # getting ruby certs path
Running /Users/ethan/.rvm/hooks/after_use_maglev
ruby-2.1.5 # getting ruby certs path
Running /Users/ethan/.rvm/hooks/after_use_maglev
/etc/openssl/cert.pem # updating certs
Certificates for /etc/openssl/cert.pem: Old.
__rvm_rm_rf already gone: /Users/ethan/.rvm/tmp/67857*
```

autolibs:

```
$ rvm autolibs status

---
value: 4
number: 4
runner: osx
```

this may or may not be causing issue with bundler on ruby-2.0.0-p353 not being able to install:

```
$ bundle 
Fetching source index from https://rubygems.org/
Could not verify the SSL certificate for https://rubygems.org/quick/Marshal.4.8/i18n-0.6.9.gemspec.rz.
There is a chance you are experiencing a man-in-the-middle attack, but most likely your system doesn't have the CA certificates needed for verification. For information about OpenSSL
certificates, see bit.ly/ruby-ssl. To connect without using SSL, edit your Gemfile sources and change 'https' to 'http'.
```
