### PR TITLE
SSL certificate validation errors with pre-built Yosemite ruby-2.1.5 binary

### DIFF
--- a/scripts/functions/osx-ssl-certs
+++ b/scripts/functions/osx-ssl-certs
@@ -49,7 +49,7 @@ requirements_osx_update_openssl_cert_create_cert()
 requirements_osx_update_openssl_cert_target_move()
 {
   [[ "$__target" == "$cert_file" ]] ||
-  __rvm_try_sudo \command \mv -f "$__target" "$cert_file" ||
+  __rvm_try_sudo \command \tee "$cert_file" < "$__target" > /dev/null ||
   {
     typeset __ret=$?
     rm -f "$__target"


### PR DESCRIPTION
I installed the [pre-built binary ruby-2.1.5](https://rvm.io/binaries/osx/10.10/x86_64/ruby-2.1.5.tar.bz2) via the latest stable RVM on my Yosemite box. I'm having problems connecting to the [PuppetLabs forge](https://forgeapi.puppetlabs.com) with SSL certificate validation errors:

```
AtrisoBook:idalko-cibg ringods$ librarian-puppet install
/usr/local/rvm/rubies/ruby-2.1.5/lib/ruby/2.1.0/net/http.rb:920:in `connect': SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed (Faraday::SSLError)
    from /usr/local/rvm/rubies/ruby-2.1.5/lib/ruby/2.1.0/net/http.rb:920:in `block in connect'
    from /usr/local/rvm/rubies/ruby-2.1.5/lib/ruby/2.1.0/timeout.rb:76:in `timeout'
    from /usr/local/rvm/rubies/ruby-2.1.5/lib/ruby/2.1.0/net/http.rb:920:in `connect'
    from /usr/local/rvm/rubies/ruby-2.1.5/lib/ruby/2.1.0/net/http.rb:863:in `do_start'
    from /usr/local/rvm/rubies/ruby-2.1.5/lib/ruby/2.1.0/net/http.rb:852:in `start'
    from /usr/local/rvm/rubies/ruby-2.1.5/lib/ruby/2.1.0/net/http.rb:1369:in `request'
    from /usr/local/rvm/rubies/ruby-2.1.5/lib/ruby/2.1.0/net/http.rb:1128:in `get'
    ...
```

When using a ruby 2.1.4 built from source, I don't have these problems. Which certificates are used by the pre-built binary version?
