### PR TITLE
allow use of errexit (-e) when scripting rvm

### DIFF
--- a/scripts/functions/rvmrc_project
+++ b/scripts/functions/rvmrc_project
@@ -236,11 +236,15 @@ __rvm_project_dir_check()
   if
     [[ "${_found_file##*/}" == "Gemfile" ]]
   then
-    [[ -s "$_found_file" ]] && {
+    if [[ -s "$_found_file" ]] && {
       __rvm_grep    "^#ruby="  "$_found_file" >/dev/null ||
       __rvm_grep -E "^\s*ruby" "$_found_file" >/dev/null
-    } ||
+    }
+    then
+      true
+    else
       _found_file=""
+    fi
   elif
     [[ "${_found_file}" == "$HOME/.rvmrc" ]]
   then


### PR DESCRIPTION
The cd hook is broken when scripting rvm with `set -e` (errexit),
in the particular case where a Gemfile is present and does _not_ contain a ruby version directive
### Steps to reproduce

Running this script:

```
#!/bin/bash
set -e

source "$HOME/.rvm/scripts/rvm" #so 'cd' will change gemset when dotfiles present

#setup
rm -rf ~/tmp/dir_with_gemfile
mkdir -p ~/tmp/dir_with_gemfile

# a Gemfile with no ruby version information
echo "source 'https://rubygems.org'" > ~/tmp/dir_with_gemfile/Gemfile
echo "gem 'rails'" >> ~/tmp/dir_with_gemfile/Gemfile
#end setup

#works
echo 'pre cd ~'
cd ~
echo 'post cd ~'

#exits after "cd"
echo 'pre cd ~/tmp/dir_with_gemfile'
cd ~/tmp/dir_with_gemfile
echo 'post cd ~/tmp/dir_with_gemfile'
```

The output is: (notice it does not get to the last line)

```
pre cd ~
post cd ~
pre cd ~/tmp/dir_with_gemfile
```

running with `set -x` I get the following as the last few lines of output:

```
+ [[ -s /Users/dholdren/tmp/dir_with_gemfile/Gemfile ]]
+ __rvm_grep '^#ruby=' /Users/dholdren/tmp/dir_with_gemfile/Gemfile
+ GREP_OPTIONS=
+ command grep '^#ruby=' /Users/dholdren/tmp/dir_with_gemfile/Gemfile
+ grep '^#ruby=' /Users/dholdren/tmp/dir_with_gemfile/Gemfile
```
### Solution

bash won't cause an exit while using `errexit` if the command is within an `if` expression, so I moved the greps for a ruby directive in the Gemfile into an `if`
