### PR TITLE
make utf-8 prompt support ruby 2.2

### DIFF
--- a/bin/rvm-prompt
+++ b/bin/rvm-prompt
@@ -127,6 +127,7 @@ then
           (1.9.3)  unicode="➈❸" ;;
           (2.0.0)  unicode="➋" ;;
           (2.1.*)  unicode="➋➀" ;;
+          (2.2.*)  unicode="➋➁" ;;
           (*)      unicode="⦿"  ;;
         esac ;;
       (*) unicode="⦿" ;;


### PR DESCRIPTION
The traditional _prompt_ PR :)
