### PR TITLE
Add sqlite[-devel] to centos/opensuse/arch requirements

### DIFF
--- a/scripts/functions/requirements/arch
+++ b/scripts/functions/requirements/arch
@@ -70,10 +70,10 @@ requirements_arch_define()
       requirements_check clang llvm llvm-libs patch curl zlib readline autoconf automake diffutils make libtool bison
       ;;
     (*-head)
-      requirements_check gcc patch curl zlib readline autoconf automake diffutils make libtool bison git
+      requirements_check gcc patch curl zlib readline autoconf automake diffutils make libtool bison sqlite git
       ;;
     (*)
-      requirements_check gcc patch curl zlib readline autoconf automake diffutils make libtool bison
+      requirements_check gcc patch curl zlib readline autoconf automake diffutils make libtool bison sqlite
       ;;
   esac
 }

--- a/scripts/functions/requirements/centos
+++ b/scripts/functions/requirements/centos
@@ -199,7 +199,7 @@ requirements_centos_define()
       if [[ ${#rvm_patch_names[@]} -gt 0 ]]
       then requirements_version_minimal autoconf 2.67
       fi
-      requirements_check autoconf gcc-c++ glibc-devel patch readline readline-devel zlib zlib-devel libffi-devel openssl-devel make bzip2 automake libtool bison
+      requirements_check autoconf gcc-c++ glibc-devel patch readline readline-devel zlib zlib-devel libffi-devel openssl-devel make bzip2 automake libtool bison sqlite-devel
       ;;
   esac
 }

--- a/scripts/functions/requirements/openmandriva
+++ b/scripts/functions/requirements/openmandriva
@@ -67,7 +67,7 @@ requirements_openmandriva_define()
       else requirements_check libyaml-devel libffi-devel
       fi
 
-      requirements_check autoconf gcc-c++ glibc-devel patch readline \
+      requirements_check autoconf gcc-c++ glibc-devel patch readline sqlite3-devel \
         readline-devel zlib zlib-devel openssl-devel make bzip2 automake libtool bison
       ;;
   esac

--- a/scripts/functions/requirements/opensuse
+++ b/scripts/functions/requirements/opensuse
@@ -28,7 +28,7 @@ requirements_opensuse_define_default()
 {
   requirements_check automake binutils bison bzip2 libtool m4 make patch \
     gdbm-devel glibc-devel libffi-devel libopenssl-devel readline-devel \
-    zlib-devel libdb-4_5 "$@"
+    zlib-devel libdb-4_5 sqlite3-devel "$@"
   case ${__type} in
     (suse)
       requirements_opensuse_lib_installed libyaml-devel ||


### PR DESCRIPTION
Right now one cannot be sure if sqlite3 gem is available or not after `rvm install ruby`.
This patch makes behaviour more consistent between linux distros.
