### PR TITLE
Added some missing ${}s to install scripts

### DIFF
--- a/binscripts/rvm-installer
+++ b/binscripts/rvm-installer
@@ -388,7 +388,7 @@ rvm_install_gpg_setup()
   export rvm_gpg_command
   {
     rvm_gpg_command="$( \which gpg2 2>/dev/null )" &&
-    [[ rvm_gpg_command != "/cygdrive/"* ]]
+    [[ ${rvm_gpg_command} != "/cygdrive/"* ]]
   } ||
     rvm_gpg_command="$( \which gpg 2>/dev/null )" ||
     rvm_gpg_command=""

--- a/scripts/functions/cli
+++ b/scripts/functions/cli
@@ -203,7 +203,7 @@ rvm_install_gpg_setup()
 {
   {
     rvm_gpg_command="$( \which gpg2 2>/dev/null )" &&
-    [[ rvm_gpg_command != "/cygdrive/"* ]]
+    [[ ${rvm_gpg_command} != "/cygdrive/"* ]]
   } ||
     rvm_gpg_command="$( \which gpg 2>/dev/null )" ||
     rvm_gpg_command=""


### PR DESCRIPTION
Should fix #3213.

Tested with the presence of `gpg2.exe` provided by Gpg4win and `gpg.exe` provided by Cygwin, with and without a stand-in `gpg2.exe` (just a copy of `gpg.exe`) in the Cygwin path. In each case, Gpg4win's version was ignored as desired, and rvm installation proceeded happily.