### PR TITLE
Automatically set the login shell option for gnome-terminal

### DIFF
--- a/scripts/functions/installer
+++ b/scripts/functions/installer
@@ -760,7 +760,7 @@ setup_login_shell()
     then
       :
     else
-      sed -i "/<gconf>/ a<entry name='login_shell' mtime='`date +%s`' type='bool' value='true'/>" ~/.gconf/apps/gnome-terminal/profiles/Default/%gconf.xml
+      _rvm_sed_i "/<gconf>/ a<entry name='login_shell' mtime='`date +%s`' type='bool' value='true'/>" ~/.gconf/apps/gnome-terminal/profiles/Default/%gconf.xml
     fi
   fi
 }

--- a/scripts/functions/installer
+++ b/scripts/functions/installer
@@ -99,6 +99,7 @@ install_rvm()
     install_patchsets
     install_man_pages
     setup_configuration_files
+    setup_login_shell
   )
   # not using elif for clarity
   if (( rvm_user_install_flag == 1 ))
@@ -749,6 +750,19 @@ setup_configuration_files()
   \command \mv user/rvmrcs.new user/rvmrcs
 
   __rvm_cd "${_save_dir}"
+}
+
+setup_login_shell()
+{
+  if [ "$COLORTERM" = "gnome-terminal" ]
+  then
+    if grep "entry name=['\"]login_shell['\"]" ~/.gconf/apps/gnome-terminal/profiles/Default/%gconf.xml > /dev/null
+    then
+      :
+    else
+      sed -i "/<gconf>/ a<entry name='login_shell' mtime='`date +%s`' type='bool' value='true'/>" ~/.gconf/apps/gnome-terminal/profiles/Default/%gconf.xml
+    fi
+  fi
 }
 
 check_file_group()

--- a/scripts/functions/installer
+++ b/scripts/functions/installer
@@ -756,11 +756,11 @@ setup_login_shell()
 {
   if [ "$COLORTERM" = "gnome-terminal" ]
   then
-    if grep "entry name=['\"]login_shell['\"]" ~/.gconf/apps/gnome-terminal/profiles/Default/%gconf.xml > /dev/null
+    if __rvm_grep "entry name=['\"]login_shell['\"]" ~/.gconf/apps/gnome-terminal/profiles/Default/%gconf.xml > /dev/null
     then
       :
     else
-      _rvm_sed_i "/<gconf>/ a<entry name='login_shell' mtime='`date +%s`' type='bool' value='true'/>" ~/.gconf/apps/gnome-terminal/profiles/Default/%gconf.xml
+      __rvm_sed_i "/<gconf>/ a<entry name='login_shell' mtime='`date +%s`' type='bool' value='true'/>" ~/.gconf/apps/gnome-terminal/profiles/Default/%gconf.xml
     fi
   fi
 }


### PR DESCRIPTION
This greps for the login-shell option in the Default profile of gnome-terminal and sets it, if not already existing. Thus you will never have to set it manually, avoiding the 'RVM is not a function' message

Solves issue #3395