### PR TITLE
Add patches to fix Rubinius compilation on OS X. Fixes #3386

### DIFF
--- a/patches/rbx/2.5.2/clean_bundler_environment_before_running_homebrew.diff
+++ b/patches/rbx/2.5.2/clean_bundler_environment_before_running_homebrew.diff
@@ -1,0 +1,26 @@
+From bb2f37b12b4acfa29171ea234e8cee1be4e12dff Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Micha=C5=82=20Matyas?= <github@higher.lv>
+Date: Sun, 26 Apr 2015 20:33:10 +0200
+Subject: [PATCH] Clean bundler environment before running Homebrew during
+ configuration
+
+---
+ configure | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure b/configure
+index 3a35743..c487a3b 100755
+--- a/configure
++++ b/configure
+@@ -576,7 +576,7 @@ class Configure
+         if macports?
+           config = macports_llvm_config
+         else
+-          out = `brew list llvm | grep '/llvm-config$'`
++          out = Bundler.with_clean_env { `brew list llvm | grep '/llvm-config$'` }
+           config = out.chomp if $?.success?
+         end
+       end
+-- 
+2.3.5
+

--- a/patches/rbx/2.5.2/this_can_not_be_null.diff
+++ b/patches/rbx/2.5.2/this_can_not_be_null.diff
@@ -1,0 +1,27 @@
+From 50aa7356e3c750fadb6665508e66d2f6923c7529 Mon Sep 17 00:00:00 2001
+From: Yorick Peterse <yorickpeterse@gmail.com>
+Date: Sat, 28 Mar 2015 14:17:27 +0100
+Subject: [PATCH] "this" can not be null
+
+Per clang 3.6 checking if "this" is null or not results in a compiler
+error.
+---
+ vm/oop.hpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/vm/oop.hpp b/vm/oop.hpp
+index 1c55b71..8298f04 100644
+--- a/vm/oop.hpp
++++ b/vm/oop.hpp
+@@ -610,7 +610,7 @@ Object* const cUndef = reinterpret_cast<Object*>(0x22L);
+     }
+ 
+     void validate() const {
+-      assert(this && (!reference_p() || (type_id() > InvalidType && type_id() < LastObjectType)));
++      assert(!reference_p() || (type_id() > InvalidType && type_id() < LastObjectType));
+     }
+ 
+     friend class TypeInfo;
+-- 
+2.3.5
+

--- a/patchsets/rbx/2.5.2/default
+++ b/patchsets/rbx/2.5.2/default
@@ -1,0 +1,2 @@
+clean_bundler_environment_before_running_homebrew
+this_can_not_be_null


### PR DESCRIPTION
This pull request adds two patches to rubinius 2.5.2, rubinius/rubinius@50aa7356 and d4rky-pl/rubinius@bb2f37b1 to allow them to compile on OS X 10.10 clang and homebrew installed.