### PR TITLE
Add forcing 3.5 version of both clang and llvm in Archlinux

### DIFF
--- a/scripts/functions/requirements/arch
+++ b/scripts/functions/requirements/arch
@@ -64,10 +64,10 @@ requirements_arch_define()
       requirements_check nodejs
       ;;
     (rbx*head|rubinius*head)
-      requirements_check clang llvm llvm-libs patch curl zlib readline autoconf automake diffutils make libtool bison git
+      requirements_check clang35 llvm35 llvm35-libs patch curl zlib readline autoconf automake diffutils make libtool bison git
       ;;
     (rbx*|rubinius*)
-      requirements_check clang llvm llvm-libs patch curl zlib readline autoconf automake diffutils make libtool bison
+      requirements_check clang35 llvm35 llvm35-libs patch curl zlib readline autoconf automake diffutils make libtool bison
       ;;
     (*-head)
       requirements_check gcc patch curl zlib readline autoconf automake diffutils make libtool bison sqlite git


### PR DESCRIPTION
Fixes #3353