### PR TITLE
Respect RAILS_ENV in unicorn service setup. Default to development

### DIFF
--- a/contrib/unicorn_init.sh
+++ b/contrib/unicorn_init.sh
@@ -95,9 +95,9 @@ setup ()
 
   export PID=$RAILS_ROOT/tmp/pids/unicorn.pid
   export OLD_PID="$PID.oldbin"
-  export RAILS_ENV=production
+  export RAILS_ENV=${RAILS_ENV-development}
 
-  CMD=( "$UNICORN" -c "${RAILS_ROOT}/config/unicorn.rb" -D )
+  CMD=( "$UNICORN" -E "${RAILS_ENV}" -c "${RAILS_ROOT}/config/unicorn.rb" -D )
 
   typeset __owner="$(stat -c "%U" "${RAILS_ROOT}")"
   if


### PR DESCRIPTION
Even when I have specified "RAILS_ENV=production" in my /etc/unicorn/my-app.conf, the previous unicorn_init.sh when deployed in /etc/init.d/ as a service always runs my rails server in development mode.

It turns out that the RAILS_ENV in the /etc/unicorn/my-app.conf was not passed to the unicorn command. This commit fixes that problem.

This commit also set the default environment for the unicorn service is set to development, following rails convention.

This is the second time that I have opened this pull request, as the last pull request failed the CI job for an unrelated reason. I made a tiny improvement, though, for the very rare cases when somebody's rails environment has a space in it such as `RAILS_ENV="with space"`.