### PR TITLE
railsexpress: heap dump support and backported fixes for 2.2.2

### DIFF
--- a/patchsets/ruby/2.1.6/railsexpress
+++ b/patchsets/ruby/2.1.6/railsexpress
@@ -6,3 +6,4 @@ https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.1.6/
 https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.1.6/railsexpress/06-funny-falcon-stc-pool-allocation.patch
 https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.1.6/railsexpress/07-aman-opt-aset-aref-str.patch
 https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.1.6/railsexpress/08-funny-falcon-method-cache.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.1.6/railsexpress/09-heap-dump-support.patch

--- a/patchsets/ruby/2.1/head/railsexpress
+++ b/patchsets/ruby/2.1/head/railsexpress
@@ -6,3 +6,4 @@ https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.1/he
 https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.1/head/railsexpress/06-funny-falcon-stc-pool-allocation.patch
 https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.1/head/railsexpress/07-aman-opt-aset-aref-str.patch
 https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.1/head/railsexpress/08-funny-falcon-method-cache.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.1/head/railsexpress/09-heap-dump-support.patch

--- a/patchsets/ruby/2.2.2/railsexpress
+++ b/patchsets/ruby/2.2.2/railsexpress
@@ -1,3 +1,4 @@
 https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.2.2/railsexpress/01-zero-broken-tests.patch
 https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.2.2/railsexpress/02-improve-gc-stats.patch
 https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.2.2/railsexpress/03-display-more-detailed-stack-trace.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.2.2/railsexpress/04-backported-bugfixes-222.patch


### PR DESCRIPTION
There are a lot of fixes scheduled for 2.2.3. This patch adds those to railsexpress 2.2.2.