### PR TITLE
Allow specifying of system name through --with-system-name

### DIFF
--- a/scripts/functions/detect_system
+++ b/scripts/functions/detect_system
@@ -186,6 +186,21 @@ __rvm_detect_system()
       return 1
       ;;
   esac
+
+  if
+    [[ " ${rvm_configure_flags[*]}" == *" --with-system-type="* ]]
+  then
+    \typeset __system_type
+    for __system_type in "${rvm_configure_flags[@]}"
+    do
+      case "$__system_type" in
+        (--with-system-type=*)
+          _system_type="${__system_type#--with-system-type=}"
+          ;;
+      esac
+    done
+  fi
+
   _system_type="${_system_type//[ \/]/_}"
   _system_name="${_system_name//[ \/]/_}"
   _system_name_lowercase="$(echo ${_system_name} | \command \tr '[A-Z]' '[a-z]')"


### PR DESCRIPTION
This patch adds operating system name specification to the configuration options in system_detect, in the event that the proper operating system is not detected

example:
```
$ rvm install 2.0
	Checking requirements for redhat.
	# install fails on centos

$ rvm install 2.0 -C --with-system-name=centos
	Checking requirements for centos.
	# install succeeds
```

The implementation is based on [--with-gcc](https://github.com/rvm/rvm/blob/363c6eed834a51fca234a2c43570a0bbcf88b31c/scripts/functions/build#L19-L30)

I think this is an important option to have in cases such as either improperly configured operating systems (such as if /etc/*-release has been removed) or in unique cases where a manual system name specification would be preferred. In the former, a non-privileged user may not be able to modify /etc meaning no rubies for them!