### PR TITLE
uname -p in Solaris does not detect correctly the version of the kern…

### DIFF
--- a/scripts/functions/detect_system
+++ b/scripts/functions/detect_system
@@ -119,7 +119,7 @@ __rvm_detect_system()
       _system_type="SunOS"
       _system_name="Solaris"
       _system_version="$(command uname -v)"
-      _system_arch="$(command uname -p)"
+      _system_arch="$(command isainfo -b)"
       if
         [[ "${_system_version}" == joyent* ]]
       then

--- a/scripts/functions/detect_system
+++ b/scripts/functions/detect_system
@@ -119,7 +119,7 @@ __rvm_detect_system()
       _system_type="SunOS"
       _system_name="Solaris"
       _system_version="$(command uname -v)"
-      _system_arch="$(command isainfo -b)"
+      _system_arch="$(command isainfo -k)"
       if
         [[ "${_system_version}" == joyent* ]]
       then


### PR DESCRIPTION
…el as Solaris has simplified the OS installation. Isainfo is more appropriate