### PR TITLE
Container-based travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: c
 os: [linux, osx]
 osx_image: mavericks
+sudo: false
+addons:
+  apt:
+    packages:
+    - gawk
 before_install:
   - "sed -i'' -e '/rvm_project_rvmrc/d ; /rvm_silence_path_mismatch_check_flag/d' ~/.rvmrc || true"
   - "head -n 100 /etc/rvmrc ~/.rvmrc || true"
@@ -9,8 +14,7 @@ before_install:
   - "env | grep '^rvm' || true"
 install: gem install tf -v '>=0.4.1'
 before_script:
-  - "sudo chown -R $USER: $rvm_path"
-  - "if which apt-get ; then sudo apt-get install gawk -y ; fi"
+  - "chown -R $USER: $rvm_path"
   - "echo ruby_1.8.7_rubygems_version=1.8.25 > $rvm_path/user/db"
   - "if [[ -f ~/.rvmrc ]] ; then sed -i'' -r -e '/rvm_silence_path_mismatch_check_flag|rvm_project_rvmrc/ d' ~/.rvmrc ; fi"
   - unset rvm_silence_path_mismatch_check_flag rvm_project_rvmrc


### PR DESCRIPTION
The container-based builds should be faster than the VM-based builds.

http://docs.travis-ci.com/user/migrating-from-legacy/#Why-migrate-to-container-based-infrastructure%3F