### PR TITLE
added 'append_system_gemsets' feature for multiuser mode

### DIFF
--- a/help/user.md
+++ b/help/user.md
@@ -8,6 +8,10 @@ To use only gemsets from user home run:
 
     rvm user gemsets
 
+To use mixed gemsets from system and user home run:
+
+    rvm user gemsets --append-system-gemsets
+
 It is also possible to add this settings as default for new user accounts:
 
     sudo rvm user [all|gemsets] --skel

--- a/scripts/functions/environment
+++ b/scripts/functions/environment
@@ -85,7 +85,14 @@ __rvm_ensure_has_environment_files()
   then __path+="${__gem_home}/bin:"
   fi
   __path+="${rvm_ruby_global_gems_path}/bin:${rvm_ruby_home}/bin"
-
+  if (( rvm_append_system_gemsets ))
+  then
+    __path+=":$rvm_ruby_gem_system_home/bin"
+    if [[ -n "$rvm_ruby_global_gems_system_path" ]] && [[ "$rvm_ruby_gem_system_home" != "$rvm_ruby_global_gems_system_path" ]]
+    then
+      __path+=":$rvm_ruby_global_gems_system_path/bin"
+    fi
+  fi
 
   \command \rm -f "$file_name"
   \command \mkdir -p "${__gem_home}/wrappers" "${rvm_environments_path}" "${rvm_wrappers_path}"

--- a/scripts/functions/selector
+++ b/scripts/functions/selector
@@ -181,6 +181,12 @@ __rvm_use_()
     export GEM_HOME GEM_PATH MY_RUBY_HOME RUBY_VERSION IRBRC
     GEM_HOME="$rvm_ruby_gem_home"
     GEM_PATH="$rvm_ruby_gem_path"
+
+    if (( rvm_append_system_gemsets ))
+    then
+      GEM_PATH="$GEM_PATH:$rvm_ruby_gem_system_path"
+    fi
+
     MY_RUBY_HOME="$rvm_ruby_home"
     RUBY_VERSION="$rvm_ruby_string"
     IRBRC="$rvm_ruby_irbrc"
@@ -204,6 +210,16 @@ __rvm_use_()
     then __path_prefix="$GEM_HOME/bin:$rvm_ruby_global_gems_path/bin:${rvm_ruby_binary%/*}:${rvm_bin_path}"
     else __path_prefix="$GEM_HOME/bin:${rvm_ruby_binary%/*}:${rvm_bin_path}"
     fi
+
+    if (( rvm_append_system_gemsets ))
+    then
+      __path_prefix="$__path_prefix:$rvm_ruby_gem_system_home/bin"
+      if [[ -n "$rvm_ruby_global_gems_system_path" ]] && [[ "$rvm_ruby_gem_system_home" != "$rvm_ruby_global_gems_system_path" ]]
+      then
+        __path_prefix="$__path_prefix:$rvm_ruby_global_gems_system_path/bin"
+      fi
+    fi
+
     __path_suffix=""
 }
 

--- a/scripts/functions/selector_gemsets
+++ b/scripts/functions/selector_gemsets
@@ -51,6 +51,7 @@ __rvm_gemset_select_cli_validation()
 
 __rvm_gemset_select_only()
 {
+  rvm_ruby_gem_system_home="$rvm_path/gems/$rvm_ruby_string"
   rvm_ruby_gem_home="${rvm_gems_path:-"$rvm_path/gems"}/$rvm_ruby_string"
 
   : rvm_ignore_gemsets_flag:${rvm_ignore_gemsets_flag:=0}:
@@ -58,9 +59,21 @@ __rvm_gemset_select_only()
   then
     rvm_ruby_global_gems_path="${rvm_ruby_gem_home}"
     rvm_ruby_gem_path="${rvm_ruby_gem_home}"
+
+    if [[ "$rvm_ruby_gem_system_home" != "$rvm_ruby_gem_home" ]]
+    then
+      rvm_ruby_global_gems_system_path="${rvm_ruby_gem_system_home}"
+      rvm_ruby_gem_system_path="${rvm_ruby_gem_system_home}"
+    fi
+
     rvm_gemset_name=""
   else
     rvm_ruby_global_gems_path="${rvm_ruby_gem_home}${rvm_gemset_separator:-"@"}global"
+
+    if [[ "$rvm_ruby_gem_system_home" != "$rvm_ruby_gem_home" ]]
+    then
+      rvm_ruby_global_gems_system_path="${rvm_ruby_gem_system_home}${rvm_gemset_separator:-"@"}global"
+    fi
 
     __rvm_gemset_handle_default
     [[ -z "$rvm_gemset_name" ]] ||
@@ -69,8 +82,18 @@ __rvm_gemset_select_only()
     if [[ "$rvm_gemset_name" == "global" ]]
     then
       rvm_ruby_gem_path="${rvm_ruby_gem_home}"
+
+      if [[ "$rvm_ruby_gem_system_home" != "$rvm_ruby_gem_home" ]]
+      then
+        rvm_ruby_gem_system_path="${rvm_ruby_gem_system_home}"
+      fi
     else
       rvm_ruby_gem_path="${rvm_ruby_gem_home}:${rvm_ruby_global_gems_path}"
+
+      if [[ "$rvm_ruby_gem_system_home" != "$rvm_ruby_gem_home" ]]
+      then
+        rvm_ruby_gem_system_path="${rvm_ruby_gem_system_home}:${rvm_ruby_global_gems_system_path}"
+      fi
     fi
   fi
 

--- a/scripts/tools
+++ b/scripts/tools
@@ -40,7 +40,7 @@ tools_user_usage()
     rvm_error "$msg"
   done
 
-  rvm_error "Usage: rvm user [[gemsets] [rubies] [hooks] [pkgs] [wrappers] [all] [--skel]|none]"
+  rvm_error "Usage: rvm user [[gemsets] [rubies] [hooks] [pkgs] [wrappers] [all] [--skel] [--append-system-gemsets]|none]"
 }
 
 tools_user_setup_path()
@@ -101,6 +101,7 @@ tools_user()
       all)     selection+=( gemsets rubies hooks pkgs wrappers userdb log ) ;;
       gemsets) selection+=( gemsets userdb log ) ;;
       --skel)  rvm_skel_flag=1 ;;
+      --append-system-gemsets)  rvm_append_system_gemsets=1 ;;
       rubies|hooks|pkgs|userdb|log|wrappers)  selection+=( "$item" ) ;;
       (none)
         tools_user_none "${HOME}/.rvmrc"
@@ -155,6 +156,7 @@ tools_user()
           tools_user_setup_path "${target}" $dir
         done
         tools_user_setup "${target}" rvm_create_flag 1
+        tools_user_setup "${target}" rvm_append_system_gemsets "${rvm_append_system_gemsets:-0}"
         ;;
       wrappers|hooks|pkgs|log)
         tools_user_setup_path "${target}" "$item"


### PR DESCRIPTION
Hello.

I've implemented mixing user's and system gemsets for multi-user mode. It allows to use a large set of system-wide gems with a compact user-specific gem sets. Please take a look.

It appends system gems directories (from ruby's primary gem home and '@global') to the GEM_PATH environment variable and the directories of gem's binaries to the PATH, allowing to use user installed gems and system gems together.

The feature adds '--append-system-gemsets' argument to the 'rvm user' command and saves 'rvm_append_system_gemsets' flag in the user's rvmrc file. Than If the flag is on, it appends system gems pathes to GEM_PATH and PATH.