### PR TITLE
Use JRuby's ./mvnw to build JRuby 9k+

### DIFF
--- a/scripts/functions/manage/jruby
+++ b/scripts/functions/manage/jruby
@@ -46,12 +46,14 @@ about not returning non zero status in case of errors."
 
 jruby_install_post17()
 {
-  __rvm_log_command "mvn" "$rvm_ruby_string - #mvn" mvn || return $?
+  \typeset mvnw="${rvm_src_path}/$rvm_ruby_string/mvnw"
+
+  __rvm_log_command "mvnw" "$rvm_ruby_string - #$mvnw" "$mvnw" || return $?
   if
     (( ${#rvm_configure_flags[@]} ))
   then
-    __rvm_log_command "mvn_flags" "$rvm_ruby_string - #mvn ${rvm_configure_flags[*]}" \
-      mvn "${rvm_configure_flags[@]}" ||
+    __rvm_log_command "mvn_flags" "$rvm_ruby_string - #$mvnw ${rvm_configure_flags[*]}" \
+      $mvnw "${rvm_configure_flags[@]}" ||
       return $?
   fi
 }


### PR DESCRIPTION
See #3457. This handles the case where Maven is installed but it's a version prior to Maven 3.3.1 by using the mvnw wrapper JRuby provides. Closes #3470 and #3499.