### PR TITLE
Making alias's error message reflect actual usage.

### DIFF
--- a/scripts/alias
+++ b/scripts/alias
@@ -46,7 +46,7 @@ alias_create()
   if
     [[ -z "${rvm_environment_identifier:-""}" || -z "$rvm_ruby_string" || -z "$alias_name" ]]
   then
-    rvm_error "usage: 'rvm alias [alias_name] [ruby_string]'"
+    rvm_error "usage: 'rvm alias [action] [alias_name] [ruby_string]'"
     return 1
   elif
     [[ ! -L "$rvm_rubies_path/$alias_name" && -d "$rvm_rubies_path/$alias_name" ]]


### PR DESCRIPTION
Alias was giving an improper syntax in it's error message, it only indicated 2 argument, but it requires 3.