### PR TITLE
Add libgmp-dev dependency

### DIFF
--- a/scripts/functions/requirements/ubuntu
+++ b/scripts/functions/requirements/ubuntu
@@ -125,7 +125,8 @@ requirements_ubuntu_libs_default()
     make libc6-dev patch openssl ca-certificates libreadline6 \
     libreadline6-dev curl zlib1g zlib1g-dev libssl-dev libyaml-dev \
     libsqlite3-dev sqlite3 autoconf \
-    libgdbm-dev libncurses5-dev automake libtool bison pkg-config libffi-dev
+    libgdbm-dev libncurses5-dev automake libtool bison pkg-config libffi-dev \
+    libgmp-dev
 }
 
 requirements_ubuntu_define()


### PR DESCRIPTION
libgmp-dev need for latest nokogiri gem installation on Ubuntu 14.04.3.