### PR TITLE
Allow $rvm_path to contain a space

### DIFF
--- a/binscripts/rvm-installer
+++ b/binscripts/rvm-installer
@@ -535,7 +535,7 @@ rvm_install_default_settings()
     fi
   fi
   if [[ -z "${rvm_prefix}" ]]
-  then rvm_prefix=$( dirname $rvm_path )
+  then rvm_prefix=$( dirname "$rvm_path" )
   fi
 
   # duplication marker kkdfkgnjfndgjkndfjkgnkfjdgn


### PR DESCRIPTION
An rvm_path which contains a space is currently causing an error.
