### PR TITLE
Update README to explicitly indicate --64 flag

### DIFF
--- a/README
+++ b/README
@@ -41,6 +41,7 @@ More details here: https://rvm.io/rvm/install/
 --reconfigure     :: Force ./configure on install even if Makefile already exists.
 --skip-gemsets    :: with install, skip the installation of default gemsets.
 --quiet-curl      :: Makes curl silent when fetching data
+--64              :: Option for installing 64-bit Rubies (default behavior)
 --32              :: Option for installing 32-bit Rubies
 
 == Options


### PR DESCRIPTION
This is a change that goes along with https://github.com/rvm/rvm/pull/3526.

Adds the --64-bit flag to the README which is the option for installing 64-bit rubies (although this is also default behavior).