### PR TITLE
Detect an absence of grep

### DIFF
--- a/binscripts/rvm-installer
+++ b/binscripts/rvm-installer
@@ -31,6 +31,7 @@ fail() { log "\nERROR: $*\n" ; exit 1 ; }
 rvm_install_commands_setup()
 {
   \which which >/dev/null 2>&1 || fail "Could not find 'which' command, make sure it's available first before continuing installation."
+  \which grep >/dev/null 2>&1 || fail "Could not find 'grep' command, make sure it's available first before continuing installation."
   if
     [[ -z "${rvm_tar_command:-}" ]] && builtin command -v gtar >/dev/null
   then


### PR DESCRIPTION
When grep is not installed, RVM installer script misdetects that tar is not installed even if tar is installed.
