### PR TITLE
Add libgmp-dev as an Ubuntu requirement

### DIFF
--- a/scripts/functions/requirements/ubuntu
+++ b/scripts/functions/requirements/ubuntu
@@ -124,7 +124,7 @@ requirements_ubuntu_libs_default()
   requirements_check "$@" \
     make libc6-dev patch openssl ca-certificates libreadline6 \
     libreadline6-dev curl zlib1g zlib1g-dev libssl-dev libyaml-dev \
-    libsqlite3-dev sqlite3 autoconf \
+    libsqlite3-dev sqlite3 autoconf libgmp-dev \
     libgdbm-dev libncurses5-dev automake libtool bison pkg-config libffi-dev
 }
 


### PR DESCRIPTION
RVM uses the binaries from Travis CI for its installations.
The binaries for Ubuntu from Travis CI are compiled against libgmp which
means that `-lgmp` is part of the `RbConfig::CONFIG["LIBS"]` and is used
in the compilation of ever C extention in ruby.

If libgmp is not installed, then any installation of any C extension rubygem
will fail when rubygems attempts to make sure that the compiler works.
This is evident by errors such as:

```
vagrant@vagrant-ubuntu-trusty-64:~$ gem install hitimes
Fetching: hitimes-1.2.3.gem (100%)
Building native extensions.  This could take a while...
ERROR:  Error installing hitimes:
        ERROR: Failed to build gem native extension.

    /home/vagrant/.rvm/rubies/ruby-2.2.3/bin/ruby -r ./siteconf20151119-7016-spbnuj.rb extconf.rb
checking for clock_gettime() in -lrt... *** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
        --with-opt-dir
        --without-opt-dir
        --with-opt-include
        --without-opt-include=${opt-dir}/include
        --with-opt-lib
        --without-opt-lib=${opt-dir}/lib
        --with-make-prog
        --without-make-prog
        --srcdir=.
        --curdir
        --ruby=/home/vagrant/.rvm/rubies/ruby-2.2.3/bin/$(RUBY_BASE_NAME)
        --with-rtlib
        --without-rtlib
/home/vagrant/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/mkmf.rb:456:in `try_do': The compiler failed to generate an executable file. (RuntimeError)
You have to install development tools first.
        from /home/vagrant/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/mkmf.rb:541:in `try_link0'
        from /home/vagrant/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/mkmf.rb:556:in `try_link'
        from /home/vagrant/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/mkmf.rb:735:in `try_func'
        from /home/vagrant/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/mkmf.rb:966:in `block in have_library'
        from /home/vagrant/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/mkmf.rb:911:in `block in checking_for'
        from /home/vagrant/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/mkmf.rb:351:in `block (2 levels) in postpone'
        from /home/vagrant/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/mkmf.rb:321:in `open'
        from /home/vagrant/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/mkmf.rb:351:in `block in postpone'
        from /home/vagrant/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/mkmf.rb:321:in `open'
        from /home/vagrant/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/mkmf.rb:347:in `postpone'
        from /home/vagrant/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/mkmf.rb:910:in `checking_for'
        from /home/vagrant/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/mkmf.rb:961:in `have_library'
        from extconf.rb:10:in `<main>'

extconf failed, exit code 1

Gem files will remain installed in /home/vagrant/.rvm/gems/ruby-2.2.3/gems/hitimes-1.2.3 for inspection.
Results logged to /home/vagrant/.rvm/gems/ruby-2.2.3/extensions/x86_64-linux/2.2.0/hitimes-1.2.3/gem_make.out
```

In order to fix this, if RVM is going to use pre-built binaries, RVM
must ensure that the system libraries on a machine match the libraries
that ruby tiself is compiled against.