### PR TITLE
Include llvm-dev package as a pre-req when installing rbx-head

### DIFF
--- a/scripts/functions/requirements/ubuntu
+++ b/scripts/functions/requirements/ubuntu
@@ -98,7 +98,7 @@ requirements_debian_define()
 
     (rbx*head|rubinius*head)
       requirements_check_fallback git git-core
-      requirements_ubuntu_libs_default clang llvm
+      requirements_ubuntu_libs_default clang llvm llvm-dev
       rvm_configure_flags+=( --cc=clang --cxx=clang++ )
       ;;
 


### PR DESCRIPTION
Fix for https://github.com/rvm/rvm/issues/3320.