### PR TITLE
Change to automake1.14 since 1.13 is no longer available

### DIFF
--- a/scripts/functions/requirements/osx_fink
+++ b/scripts/functions/requirements/osx_fink
@@ -95,7 +95,7 @@ requirements_osx_fink_gcc_version_detect()
 
 requirements_osx_fink_libs_default_tools()
 {
-  fink_libs+=( autoconf2.6 automake1.13 pkgconfig )
+  fink_libs+=( autoconf2.6 automake1.14 pkgconfig )
 
   if
     __rvm_version_compare "${_system_version}" -le 10.6


### PR DESCRIPTION
Without this change, getrvm utterly fails on OS-X 10.10.5