### PR TITLE
Select an appropriate dependency fallback version for installation

### DIFF
--- a/scripts/functions/build_requirements_helpers
+++ b/scripts/functions/build_requirements_helpers
@@ -117,7 +117,7 @@ requirements_check_fallback()
   __available_dependencies=()
   \typeset __package
   requirements_fallback_lib_available "$@"
-  requirements_fallback_lib_installed "${__available_dependencies[@]}" || requirements_check "$1"
+  requirements_fallback_lib_installed "${__available_dependencies[@]}" || requirements_check "${__available_dependencies[0]}"
 }
 
 requirements_detect_installed()


### PR DESCRIPTION
Fix requirements_fallback_lib_installed to select a dependency version
from the generated list of those available, rather than the first
possible version.

We have this nice list of what is and isn't available on the system for a
given list of fallbacks - surely we should use one of those instead of
forcing the first dependency option (which may or may not be available)?