### PR TITLE
Remove requirement to build against OpenSSL 0.9.8

### DIFF
--- a/scripts/functions/requirements/osx_brew
+++ b/scripts/functions/requirements/osx_brew
@@ -172,17 +172,9 @@ requirements_osx_brew_after()
 
 requirements_osx_brew_after_update_certs_openssl()
 {
-  \typeset brew_lib_prefix openssl_name
-  case "$1" in
-    (ruby-1.8*|ree*)
-      openssl_name=openssl098
-      ;;
-    (*)
-      openssl_name=openssl
-      ;;
-  esac
+  \typeset brew_lib_prefix
   if
-    requirements_osx_brew_lib_installed_prefix_check "${openssl_name}" &&
+    requirements_osx_brew_lib_installed_prefix_check openssl &&
     [[ -x "${brew_lib_prefix}/bin/openssl" ]]
   then
     requirements_osx_update_openssl_cert "${brew_lib_prefix}/bin/openssl" || return $?
@@ -294,16 +286,7 @@ requirements_osx_brew_libs_default()
       rvm_debug "No code to ensure that selected compiler: '${selected_compiler}' exists"
       ;;
   esac
-  brew_libs_conf+=( libyaml readline libksba )
-  case "$1" in
-    (ruby-1.8*|ree*)
-      requirements_osx_brew_check_custom homebrew/versions
-      brew_libs_conf+=( openssl098 )
-      ;;
-    (*)
-      brew_libs_conf+=( openssl )
-      ;;
-  esac
+  brew_libs_conf+=( libyaml readline libksba openssl )
   requirements_check "${brew_libs[@]}" "${brew_libs_conf[@]}" || return $?
 }
 


### PR DESCRIPTION
It's deprecated and not supported by our package manager, and 1.8.7-head (I've not tested REE) builds and runs cleanly on modern OS X with OpenSSL 1.0.2f (Homebrew's latest).