### PR TITLE
Verify GPG signature during Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,15 @@ before_script:
   - git submodule init
   - git submodule update
 script: tf --text rvm-test/fast/* rvm-test-rvm1/*
+matrix:
+  include:
+    - os: linux
+      env: TEST="rvm-installer GPG signature"
+      addons: []
+      before_install: []
+      install: []
+      before_script: []
+      script: gpg --verify binscripts/rvm-installer.asc binscripts/rvm-installer
 notifications:
   irc:
     channels:


### PR DESCRIPTION
This will make sure that we don't merge changes to `rvm-installer` without updating the GPG signature.