### PR TITLE
Reorder PROMPT_COMMAND hook to prevent error on Mac OS

### DIFF
--- a/scripts/cd
+++ b/scripts/cd
@@ -78,7 +78,7 @@ case "${rvm_project_rvmrc:-1}" in
   then
     precmd_functions+=(__rvm_do_with_env_before __rvm_project_rvmrc __rvm_do_with_env_after)
   else
-    PROMPT_COMMAND="${PROMPT_COMMAND:-}${PROMPT_COMMAND:+; }__rvm_do_with_env_before; __rvm_project_rvmrc; __rvm_do_with_env_after"
+    PROMPT_COMMAND="__rvm_do_with_env_before; __rvm_project_rvmrc; __rvm_do_with_env_after;${PROMPT_COMMAND:-}"
   fi
   ;;
 esac

--- a/scripts/cd
+++ b/scripts/cd
@@ -78,7 +78,9 @@ case "${rvm_project_rvmrc:-1}" in
   then
     precmd_functions+=(__rvm_do_with_env_before __rvm_project_rvmrc __rvm_do_with_env_after)
   else
-    PROMPT_COMMAND="__rvm_do_with_env_before; __rvm_project_rvmrc; __rvm_do_with_env_after;${PROMPT_COMMAND:-}"
+    PROMPT_COMMAND="${PROMPT_COMMAND%% }"
+    PROMPT_COMMAND="${PROMPT_COMMAND%%;}"
+    PROMPT_COMMAND="${PROMPT_COMMAND:-}${PROMPT_COMMAND:+; }__rvm_do_with_env_before; __rvm_project_rvmrc; __rvm_do_with_env_after"
   fi
   ;;
 esac


### PR DESCRIPTION
On Macs, in the default terminal, PROMPT_COMMAND is set to
'update_terminal_cwd;' with the included trailing semi-colon. This is legal
syntax, and currently, the cd script does not handle it gracefully. Reordering
the hooks fixes the problem.