### PR TITLE
avoid infinite loop

### DIFF
--- a/scripts/functions/rvmrc_project
+++ b/scripts/functions/rvmrc_project
@@ -20,7 +20,7 @@ __rvm_project_rvmrc()
   while :
   do
     if
-      [[ -z "$working_dir" || "$HOME" == "$working_dir" || "${rvm_prefix:-}" == "$working_dir" ]]
+      [[ -z "$working_dir" || "$HOME" == "$working_dir" || "${rvm_prefix:-}" == "$working_dir" || "$working_dir" == "." ]]
     then
       if (( ${rvm_project_rvmrc_default:-0} >= 1 ))
       then rvm_previous_environment=default


### PR DESCRIPTION
I'm using zsh + tmux

when the working dir is removed, the $working_dir is going to be "."
which causes the infinite loop while calling __rvm_project_dir_check below.
you can reproduce it easily by using tmux.

### How to reproduce:
1. Let's add an line `echo "loop!!"` to `scripts/functions/rvmrc_project:36`
2. create a dir `/tmp/a`
3. **`cd /tmp/a`**, then run `tmux new-session -s test`
4. use the shortcut to `detach-client`
5. `..; rm -rf a`
6. use the shortcut to `split-window`
7. Now you got an infinite loop

![loop](https://cloud.githubusercontent.com/assets/6406875/14101287/1cffe6ea-f5c6-11e5-9ffa-0bbe842ff510.gif)
