### PR TITLE
Don't trap with a non-existent command

### DIFF
--- a/scripts/functions/environment
+++ b/scripts/functions/environment
@@ -278,7 +278,7 @@ __rvm_teardown()
 
   if
     [[ "${_system_name}" == "OSX" ]] && __rvm_version_compare "${_system_version}" -ge 10.11 &&
-    [[ -n "$BASH" ]] && [[ ! -f "${HOME}/.bash_sessions_disable" ]]
+    [[ -n "$BASH" ]] && [[ ! -f "${HOME}/.bash_sessions_disable" ]] && is_a_function shell_session_update
   then trap 'shell_session_update' EXIT
   fi
 


### PR DESCRIPTION
This fixes #3655 by avoiding the call to `shell_session_update` if it's not a function.