### PR TITLE
Bump JRuby to 1.7.25

### DIFF
--- a/config/known
+++ b/config/known
@@ -15,7 +15,7 @@ ruby-head
 
 # JRuby
 jruby-1.6[.8]
-jruby-1.7[.23]
+jruby-1.7[.25]
 jruby[-9.0.5.0]
 jruby-head
 

--- a/config/known_strings
+++ b/config/known_strings
@@ -1,7 +1,7 @@
 # this strings are matched only when partial version was provided
 jruby-1.5.6
 jruby-1.6.8
-jruby-1.7.23
+jruby-1.7.25
 jruby-9.0.5.0
 rbx-1.3.3
 rbx-1.4.3

--- a/config/md5
+++ b/config/md5
@@ -1078,6 +1078,7 @@ https://s3.amazonaws.com/jruby.org/downloads/1.7.20/jruby-bin-1.7.20.tar.gz=0c2a
 https://s3.amazonaws.com/jruby.org/downloads/1.7.21/jruby-bin-1.7.21.tar.gz=bc91594072032023d146f330764d3274
 https://s3.amazonaws.com/jruby.org/downloads/1.7.22/jruby-bin-1.7.22.tar.gz=1da904bf41d362d0d0b366d9e781168f
 https://s3.amazonaws.com/jruby.org/downloads/1.7.23/jruby-bin-1.7.23.tar.gz=41e3f45c28c94a275f9eeb22721da35d
+https://s3.amazonaws.com/jruby.org/downloads/1.7.25/jruby-bin-1.7.25.tar.gz=fc43ead73f657f5261428923974fd605
 https://s3.amazonaws.com/jruby.org/downloads/1.7.3/jruby-bin-1.7.3.tar.gz=f0adf8ccee6f6777f7ab8e5e1d7a1f47
 https://s3.amazonaws.com/jruby.org/downloads/1.7.4/jruby-bin-1.7.4.tar.gz=c6a56eae78db28dddba911ccd0848c32
 https://s3.amazonaws.com/jruby.org/downloads/1.7.5/jruby-bin-1.7.5.tar.gz=c2a28c43c8095127d4a4aee0cf9b1439

--- a/config/sha512
+++ b/config/sha512
@@ -1056,6 +1056,7 @@ https://s3.amazonaws.com/jruby.org/downloads/1.7.20/jruby-bin-1.7.20.tar.gz=7713
 https://s3.amazonaws.com/jruby.org/downloads/1.7.21/jruby-bin-1.7.21.tar.gz=111883df12a60d06e9924d33057ba72094fcffd44f7e3954d6c6d2190f8e6442804e739cc525a9e75159251a8dc1cc487570792b1b4f5773f4d0082f0eb360d0
 https://s3.amazonaws.com/jruby.org/downloads/1.7.22/jruby-bin-1.7.22.tar.gz=6ed6cbe7b81a8aee60906fdf965bc217b3db794698e2cb37559f36ac119a0cd2a1ae1a7a766535ab491d647e8b4e6b2f63e62011714b757f8691455831ef365c
 https://s3.amazonaws.com/jruby.org/downloads/1.7.23/jruby-bin-1.7.23.tar.gz=6f4b97c4e08274f96195deb176e3126e8d047c981cb655cded9665624033fb905d60d5586704a3f91b2ca06d7e78918d9d31131c93e4c90c75a38182e309ac9c
+https://s3.amazonaws.com/jruby.org/downloads/1.7.25/jruby-bin-1.7.25.tar.gz=a89ab8d539bff346ad56d345b6a205f74890b9aafe82a2c82e7c19cfc30b77fefde1003e8bd7ed15f141151bc0fd21946203219691383a64f2234fa586e1905b
 https://s3.amazonaws.com/jruby.org/downloads/1.7.3/jruby-bin-1.7.3.tar.gz=1d19be25bf4a7dbb0edad71008704377893d3967aa4204a0d59d6883aa04462ef6798c64d0c0fdd3f5129c16ccb42e8507f3fef38ed56054bf6e689de745935a
 https://s3.amazonaws.com/jruby.org/downloads/1.7.4/jruby-bin-1.7.4.tar.gz=d7c0ee0316c50ae5413757e956c18ca68e9d99a25cf85be978da0787c13b8978d4ff2712a3effa564cfdf07144be4a56a0cb8acc794a01f43264fe8baeb125e5
 https://s3.amazonaws.com/jruby.org/downloads/1.7.5/jruby-bin-1.7.5.tar.gz=a4984591a3809330b93f4ce79fd1b9c24360f89d88a03bbc76351be623893c4bfc6441375bbea452ba4f24ca8b9357e03ac938fd6c065b3e2348c0f896b22a1b


### PR DESCRIPTION
1.7.25 was released a week ago: http://jruby.org/2016/04/14/jruby-1-7-25.html