### PR TITLE
Adding tests for OpenJDK 1.8.0 for Jruby + CentOS/Fedora

### DIFF
--- a/scripts/functions/requirements/centos
+++ b/scripts/functions/requirements/centos
@@ -164,6 +164,7 @@ requirements_centos_define()
         is_head_or_disable_binary "$1"
       then
         requirements_centos_check_binary javac ||
+          requirements_check_fallback java-1.8.0-openjdk-devel java-devel ||
           requirements_check_fallback java-1.7.0-openjdk-devel java-devel
         requirements_check git
         if is_jruby_post17 "$1"
@@ -171,6 +172,7 @@ requirements_centos_define()
         fi
       else
         requirements_centos_check_binary java ||
+          requirements_check_fallback java-1.8.0-openjdk java ||
           requirements_check_fallback java-1.7.0-openjdk java
       fi
       ;;


### PR DESCRIPTION
This impacts Fedora where Fedora 24 ships with OpenJDK 1.8.0 only, 1.7.0 is no longer available as a package. Jruby 9.1.2.0 is happy with 1.8.0 so printing an advisory about 1.7.0, which is very difficult to install manually, is misleading.

Presumably this is good to get in now since RHEL and CentOS will update to this soon if they haven't already.