### PR TITLE
Better Zsh compinit compatibility

### DIFF
--- a/scripts/initialize
+++ b/scripts/initialize
@@ -42,14 +42,9 @@ export __rvm_env_loaded
 if [[ -z "${rvm_tmp_path:-}" ]] || (( __rvm_env_loaded == 1 ))
 then
 
-  if
-    \typeset -f __rvm_cleanse_variables >/dev/null 2>&1
-  then
-    __rvm_cleanse_variables ||
-    if [[ -n "${ZSH_VERSION:-}" ]]
-    then rvm_error "ZSH Error, run \`rm -f ~/.zcompdump\` and try again."
-    fi
-  fi
+  # Because of compinit in ZSH, this function may not be defined yet
+  # even though it may exist.
+  __rvm_cleanse_variables 2>/dev/null
 
   # Ensure that /etc/rvmrc and $HOME/.rvmrc values take precedence.
   if (( ${rvm_ignore_rvmrc:=0} == 0 ))


### PR DESCRIPTION
@mpapis

In Zsh, compinit creates a `~/.zcompdump` file to cache completions. The
reading of this dump file by the shell creates all the functions in it
as *undefined functions*, which are functions that are actually defined
to be autoloaded when executed (sounds weird, I know). That autoloading
only works if that function can be found in Zsh's `fpath`.

At the first run of RVM in a shell session, `__rvm_cleanse_variables`
will not yet have been defined nor be in an `fpath` somewhere, **but**
it will have been defined as an undefined function if it's in the
`~/.zcompdump` file.

Most users of Zsh will simply run `compinit` somewhere in their
`.zshrc`. Invoking it in that way will *recreate* the `~/.zcompdump`
file from scratch, which means that in that case
`__rvm_cleanse_variables` will not yet have been defined and it's
possible to determine whether to attempt to run it by checking if it's a
function.

*However*, some users of Zsh do not run `compinit` that way. Some run it
manually, others will only run it once a day in a way that recreates the
`~/.zcompdump` file from scratch, simply reusing an existing one for the
rest of the day (using `compinit -C`, see here:
http://carlosbecker.com/posts/speeding-up-zsh/).

This commit simply attempts to run the function whether it has been
defined or not, redirecting `stderr` to `/dev/null`. This way RVM can
play nice with various `compinit` strategies and issues like #1746, #770
and #662 shouldn't happen again.

There might be a slight issue with redirecting `stderr` to `/dev/null`,
as presumably this will redirect all error output (even errors from
functions that `__rvm_cleanse_variables` calls) to `stderr`. If that is
undesirable, perhaps there's a way to determine whether
`__rvm_cleanse_variables` has been defined as an undefined function, or
perhaps whether it's really the first time `initialize` is being run
instead of as a result of `rvm reload` or something.