### PR TITLE
Use Standard `command` instead of `which`

### DIFF
--- a/binscripts/rvm-installer
+++ b/binscripts/rvm-installer
@@ -30,8 +30,7 @@ fail() { log "\nERROR: $*\n" ; exit 1 ; }
 
 rvm_install_commands_setup()
 {
-  \which which >/dev/null 2>&1 || fail "Could not find 'which' command, make sure it's available first before continuing installation."
-  \which grep >/dev/null 2>&1 || fail "Could not find 'grep' command, make sure it's available first before continuing installation."
+  __rvm_which grep > /dev/null || fail "Could not find 'grep' command, make sure it's available first before continuing installation."
   if
     [[ -z "${rvm_tar_command:-}" ]] && builtin command -v gtar >/dev/null
   then
@@ -59,9 +58,9 @@ rvm_install_commands_setup()
             log "Trying to install GNU version of tar, might require sudo password"
             if (( UID ))
             then
-              if \which sudo >/dev/null 2>&1
+              if __rvm_which sudo >/dev/null
               then sudo_10=sudo
-              elif \which /opt/csw/bin/sudo >/dev/null 2>&1
+              elif __rvm_which /opt/csw/bin/sudo >/dev/null
               then sudo_10=/opt/csw/bin/sudo
               else fail "sudo is required but not found. You may install sudo from OpenCSW repository (https://www.opencsw.org/about)"
               fi
@@ -219,7 +218,7 @@ __rvm_curl()
 )
 
 rvm_error()  { printf "ERROR: %b\n" "$*"; }
-__rvm_which(){   which "$@" || return $?; true; }
+__rvm_which(){ command -v "$@" 2>/dev/null; }
 __rvm_debug_command()
 {
   debug "Running($#): $*"
@@ -388,10 +387,10 @@ rvm_install_gpg_setup()
 {
   export rvm_gpg_command
   {
-    rvm_gpg_command="$( \which gpg2 2>/dev/null )" &&
+    rvm_gpg_command="$( __rvm_which gpg2 2>/dev/null )" &&
     [[ ${rvm_gpg_command} != "/cygdrive/"* ]]
   } ||
-    rvm_gpg_command="$( \which gpg 2>/dev/null )" ||
+    rvm_gpg_command="$( __rvm_which gpg 2>/dev/null )" ||
     rvm_gpg_command=""
   debug "Detected GPG program: '$rvm_gpg_command'"
   [[ -n "$rvm_gpg_command" ]] || return $?

--- a/hooks/after_use_textmate
+++ b/hooks/after_use_textmate
@@ -14,7 +14,7 @@ function set_textmate_wrapper()
   __current_ruby=${RUBY_VERSION:-${GEM_HOME##*/}}
 
   if
-    __textmate_ruby="$( \which textmate_ruby 2>/dev/null )" &&
+    __textmate_ruby="$( command -v textmate_ruby 2>/dev/null )" &&
     [[ -n "${__textmate_ruby:-}" ]]
   then
     __textmate_ruby="$( readlink "${__textmate_ruby:-}" )"

--- a/scripts/functions/build
+++ b/scripts/functions/build
@@ -40,9 +40,9 @@ __rvm_selected_compiler()
 
 __rvm_found_compiler()
 {
-  __rvm_selected_compiler  ||
-  __rvm_which gcc   2>/dev/null ||
-  __rvm_which clang 2>/dev/null
+  __rvm_selected_compiler ||
+  __rvm_which gcc ||
+  __rvm_which clang
 }
 
 __rvm_fix_rbconfig()
@@ -70,7 +70,7 @@ __rvm_fix_gcc_path()
   \typeset __cc_value __cc_new
   __rvm_which $(
     "$1/bin/ruby" -rrbconfig -e 'puts RbConfig::CONFIG["CC"]||"true"' 2>/dev/null
-  ) >/dev/null 2>/dev/null ||
+  ) >/dev/null ||
   {
     __cc_value="$( "$1/bin/ruby" -rrbconfig -e 'puts RbConfig::CONFIG["CC"]' 2>/dev/null )" &&
     if
@@ -91,13 +91,13 @@ __rvm_fix_install_path()
   \typeset __install_value __install_new
   __rvm_which $(
     "$1/bin/ruby" -rrbconfig -e 'puts RbConfig::CONFIG["INSTALL"]||"true"' 2>/dev/null
-  ) >/dev/null 2>/dev/null ||
+  ) >/dev/null ||
   {
     __install_value="$( "$1/bin/ruby" -rrbconfig -e 'puts RbConfig::CONFIG["INSTALL"]' 2>/dev/null )"
     if
       __rvm_grep "CONFIG\[\"INSTALL\"\]" "${__config_file}" >/dev/null
     then
-      __install_new="$( \command \which install )"
+      __install_new="$( __rvm_which install )"
       rvm_debug "Fixing ruby installer from '${__install_value}' to '${__install_new}'."
       __rvm_sed_i "${__config_file}" \
         -e "s#CONFIG\[\"INSTALL\"\].*\$#CONFIG[\"INSTALL\"] = \"${__install_new}\"#"

--- a/scripts/functions/cli
+++ b/scripts/functions/cli
@@ -202,10 +202,10 @@ You can enable  auto-update  with:    echo rvm_autoupdate_flag=2 >> ~/.rvmrc
 rvm_install_gpg_setup()
 {
   {
-    rvm_gpg_command="$( \which gpg2 2>/dev/null )" &&
+    rvm_gpg_command="$( __rvm_which gpg2 )" &&
     [[ ${rvm_gpg_command} != "/cygdrive/"* ]]
   } ||
-    rvm_gpg_command="$( \which gpg 2>/dev/null )" ||
+    rvm_gpg_command="$( __rvm_which gpg )" ||
     rvm_gpg_command=""
   rvm_debug "Detected GPG program: '$rvm_gpg_command'"
   [[ -n "$rvm_gpg_command" ]] || return $?

--- a/scripts/functions/support
+++ b/scripts/functions/support
@@ -210,12 +210,7 @@ __rvm_setup_utils_functions_Solaris()
   else gnu_missing+=( ${gnu_prefix}stat )
   fi
 
-  if [[ "${_system_name}" == "SmartOS" ]]
-  then __rvm_which() { \command \which "$@" || return $?; }
-  elif [[ -x $gnu_tools_path/${gnu_prefix}which ]]
-  then eval "__rvm_which() { $gnu_tools_path/${gnu_prefix}which \"\$@\" || return \$?; }"
-  else gnu_missing+=( ${gnu_prefix}which )
-  fi
+  __rvm_which() { command -v "$@" 2>/dev/null; }
 
   for gnu_util in "${gnu_utils[@]}"
   do
@@ -259,19 +254,7 @@ __rvm_setup_utils_functions_common()
 {
   __rvm_grep() { GREP_OPTIONS="" \command \grep "$@" || return $?; }
 
-  if \command \which --skip-alias --skip-functions which >/dev/null 2>&1
-  then __rvm_which() { \command \which --skip-alias --skip-functions "$@" || return $?; }
-  elif \command \which whence >/dev/null 2>&1 && \command \whence whence >/dev/null 2>&1
-  then __rvm_which() { \command \whence -p "$@" || return $?; }
-  elif \command \which which >/dev/null 2>&1
-  then __rvm_which() { \command \which "$@" || return $?; }
-  elif \which which >/dev/null 2>&1
-  then __rvm_which() { \which "$@" || return $?; }
-  else
-    \typeset __result=$?
-    rvm_error "ERROR: Missing proper 'which' command. Make sure it is installed before using RVM!"
-    return ${__result}
-  fi
+  __rvm_which() { command -v "$@" 2>/dev/null; }
 
   for gnu_util in "${gnu_utils[@]}"
   do eval "__rvm_$gnu_util() { \\$gnu_util \"\$@\" || return \$?; }"
@@ -350,7 +333,7 @@ __rvm_setup_sudo_function_Solaris()
 __rvm_setup_sudo_function_Other()
 {
   if
-    __rvm_which sudo >/dev/null 2>&1
+    __rvm_which sudo >/dev/null
   then
     __rvm_sudo()
     {
@@ -419,13 +402,13 @@ __rvm_curl()
   \typeset curl_path
   if
     [[ "${_system_name} ${_system_version}" == "Solaris 10" ]] &&
-    ! __rvm_which curl >/dev/null 2>&1
+    ! __rvm_which curl >/dev/null
   then
     curl_path=/opt/csw/bin/
   else
     curl_path=""
   fi
-  __rvm_which ${curl_path}curl >/dev/null 2>&1 ||
+  __rvm_which ${curl_path}curl >/dev/null ||
   {
     rvm_error "RVM requires 'curl'. Install 'curl' first and try again."
     return 200


### PR DESCRIPTION
If a system is able to run these scripts, it is guaranteed to have the `command` builtin. It is not guaranteed to have the `which` command. If it does, the `which` command is not guaranteed to behave consistently.

Despite Herculean effort to avoid shell aliases from altering the behavior, shell functions can still have a significant impact. The below is what brought this to my attention:

```
Downloading https://github.com/rvm/rvm/archive/1.27.0.tar.gz
Downloading https://github.com/rvm/rvm/releases/download/1.27.0/1.27.0.tar.gz.asc
rvm-installer: line 404: gpg2 is /usr/local/bin/gpg2: No such file or directory
Warning, RVM 1.26.0 introduces signed releases and automated check of signatures when GPG software found.
```

because

```
$ which which
which is a function
which ()
{
    type -a $1
}
which is /usr/bin/which
```
