### PR TITLE
use CentOS binaries for RHEL

### DIFF
--- a/scripts/functions/detect_system
+++ b/scripts/functions/detect_system
@@ -108,7 +108,7 @@ __rvm_detect_system()
         _system_name="$(
           GREP_OPTIONS="" \command \grep -Eo 'CentOS|ClearOS|Mageia|PCLinuxOS|Scientific|ROSA Desktop|OpenMandriva' /etc/redhat-release 2>/dev/null | \command \head -n 1 | \command \sed "s/ //"
         )"
-        _system_name="${_system_name:-RedHat}"
+        _system_name="${_system_name:-CentOS}"
         _system_version="$(GREP_OPTIONS="" \command \grep -Eo '[0-9\.]+' /etc/redhat-release  | \command \awk -F. 'NR==1{print $1}' | head -n 1)"
       elif
         [[ -f /etc/centos-release ]]


### PR DESCRIPTION
Binaries built for CentOS should be compatible to run on Red Hat Enterprise Linux of the same version. I see no benefit to build them again.

It would be nice if rvm adds RHEL to the build chain. But using CentOS binaries is IMO also a good approach.

This pull would partially fix #3735