### PR TITLE
Fix error message about ignoring all Gemfiles

### DIFF
--- a/scripts/functions/rvmrc_warning
+++ b/scripts/functions/rvmrc_warning
@@ -159,7 +159,7 @@ __rvmrc_warning_display_for_Gemfile()
   then
     rvm_log "RVM used your Gemfile for selecting Ruby, it is all fine - Heroku does that too,
 you can ignore these warnings with 'rvm rvmrc warning ignore $1'.
-To ignore the warning for all files run 'rvm rvmrc warning ignore all Gemfiles'.
+To ignore the warning for all files run 'rvm rvmrc warning ignore allGemfiles'.
 " >&2
   fi
 }


### PR DESCRIPTION
It looks like be6f83626c67c11aea920d522b114a15f9e2b786 introduced an error, as the option is `allGemfiles`, not `all Gemfiles`.  

Source: https://github.com/rvm/rvm/blob/9be6aeb257c3cc68589ae01b7364a6b704acc428/scripts/functions/rvmrc_warning#L30

Error message I encountered:
![allgemfiles](https://cloud.githubusercontent.com/assets/22501/18802950/6399c9e4-81a9-11e6-951a-8d01f2083747.png)

