### PR TITLE
improves warning message for when PATH= is set without $PATH

### DIFF
--- a/scripts/notes
+++ b/scripts/notes
@@ -262,7 +262,7 @@ $notes_type Notes:
     important_message "
   * WARNING: ${__file} contains \`PATH=\` with no \`\$PATH\` inside, this can break RVM,
     for details check https://github.com/rvm/rvm/issues/1351#issuecomment-10939525
-    to avoid this warning append #PATH.
+    to avoid this warning prepend \`\$PATH\`.
 "
   fi | important_redirect
 


### PR DESCRIPTION
references #1351. I just ran into this issue and think the solution could be more clear as shown in the issue $PATH needs to prepended, but the message says that #PATH  needs to be appended

* changes #PATH to $PATH to be more clear what needs to be done
* changes append to prepend since $PATH needs to be prepended