### PR TITLE
Enforce usage of gpg coming from Cygwin on Windows

### DIFF
--- a/binscripts/rvm-installer
+++ b/binscripts/rvm-installer
@@ -391,7 +391,10 @@ rvm_install_gpg_setup()
     rvm_gpg_command="$( \which gpg2 2>/dev/null )" &&
     [[ ${rvm_gpg_command} != "/cygdrive/"* ]]
   } ||
-    rvm_gpg_command="$( \which gpg 2>/dev/null )" ||
+  {
+    rvm_gpg_command="$( \which gpg 2>/dev/null )" &&
+    [[ ${rvm_gpg_command} != "/cygdrive/"* ]]
+  } ||
     rvm_gpg_command=""
   debug "Detected GPG program: '$rvm_gpg_command'"
   [[ -n "$rvm_gpg_command" ]] || return $?

--- a/scripts/functions/cli
+++ b/scripts/functions/cli
@@ -205,7 +205,10 @@ rvm_install_gpg_setup()
     rvm_gpg_command="$( \which gpg2 2>/dev/null )" &&
     [[ ${rvm_gpg_command} != "/cygdrive/"* ]]
   } ||
-    rvm_gpg_command="$( \which gpg 2>/dev/null )" ||
+  {
+    rvm_gpg_command="$( \which gpg 2>/dev/null )" &&
+    [[ ${rvm_gpg_command} != "/cygdrive/"* ]]
+  } ||
     rvm_gpg_command=""
   rvm_debug "Detected GPG program: '$rvm_gpg_command'"
   [[ -n "$rvm_gpg_command" ]] || return $?

--- a/scripts/functions/requirements/cygwin
+++ b/scripts/functions/requirements/cygwin
@@ -35,7 +35,7 @@ requirements_cygwin_define()
 {
   case "$1" in
     (rvm)
-      requirements_check bash curl patch
+      requirements_check bash curl patch gnupg
       ;;
     (jruby*)
       if
@@ -69,7 +69,8 @@ requirements_cygwin_define()
         libyaml-devel libyaml0_2 \
         libffi-devel \
         sqlite3 \
-        patch
+        patch \
+        gnupg
       if [[ "${_system_arch}" == "x86_64" ]]
       then requirements_check readline
       else requirements_check cygwin32-readline


### PR DESCRIPTION
Other versions installed outside of Cygwin do not understand Cygwin paths and fail on verifying downloaded files.

Fixes #3623