### PR TITLE
Remove slash from curl command of install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Make sure you have following required packages installed:
 
 And then run:
 
-`\curl -sSL https://get.rvm.io | bash -s stable`
+`curl -sSL https://get.rvm.io | bash -s stable`
 
 ### Additional installation options
 


### PR DESCRIPTION
It doesn't seem that it's needed?