### PR TITLE
$PATH become empty after __rvm_unload executed. 

### DIFF
--- a/scripts/functions/env
+++ b/scripts/functions/env
@@ -92,7 +92,7 @@ __rvm_unset_exports()
 {
   \typeset wrap_name name value
   \typeset -a __variables_list
-  __rvm_read_lines __variables_list <<<"$(
+  __rvm_read_lines __variables_list <<< "$(
     printenv | __rvm_sed '/^rvm_old_.*=/ { s/=.*$//; p; }; d;'
   )"
 
@@ -212,7 +212,7 @@ __rvm_unload()
   fi
 
   # aliases
-  __rvm_unload_action unalias <<<"$(
+  __rvm_unload_action unalias <<< "$(
     if [[ -n "${ZSH_VERSION:-}" ]]
     then alias | __rvm_awk -F"=" '/rvm/ {print $1}'
     else alias | __rvm_awk -F"[= ]" '/rvm/ {print $2}'
@@ -220,16 +220,16 @@ __rvm_unload()
   )"
 
   # variables
-  __rvm_unload_action unset <<<"$(
+  __rvm_unload_action unset <<< "$(
     set |
       __rvm_awk -F"=" 'BEGIN{v=0;} /^[a-zA-Z_][a-zA-Z0-9_]*=/{v=1;} v==1&&$2~/^['\''\$]/{v=2;}
         v==1&&$2~/^\(/{v=3;} v==2&&/'\''$/&&!/'\'\''$/{v=1;} v==3&&/\)$/{v=1;} v{print;} v==1{v=0;}' |
       __rvm_awk -F"=" '/^[^ ]*(RUBY|GEM|IRB|gem|rubies|rvm)[^ ]*=/ {print $1} /^[^ ]*=.*rvm/ {print $1}' |
-      __rvm_grep -vE "^PROMPT|^prompt|^PS|^BASH_SOURCE"
+      __rvm_grep -vE "^PROMPT|^prompt|^PS|^BASH_SOURCE|^PATH"
   )"
 
   # functions
-  __rvm_unload_action __function_unset <<<"$(
+  __rvm_unload_action __function_unset <<< "$(
     \typeset -f | __rvm_awk '$2=="()" {fun=$1} /rvm/{print fun}' | sort -u | __rvm_grep -v __rvm_unload_action
   )"
   if


### PR DESCRIPTION
Plus fixed Sublime Text's highligting.

Unset is called with these envvar names:

```
$     set |
>       __rvm_awk -F"=" 'BEGIN{v=0;} /^[a-zA-Z_][a-zA-Z0-9_]*=/{v=1;} v==1&&$2~/^['\''\$]/{v=2;}
>         v==1&&$2~/^\(/{v=3;} v==2&&/'\''$/&&!/'\'\''$/{v=1;} v==3&&/\)$/{v=1;} v{print;} v==1{v=0;}' |
>       __rvm_awk -F"=" '/^[^ ]*(RUBY|GEM|IRB|gem|rubies|rvm)[^ ]*=/ {print $1} /^[^ ]*=.*rvm/ {print $1}' |
>       __rvm_grep -vE "^PROMPT|^prompt|^PS|^BASH_SOURCE"
GEM_HOME
GEM_HOME
GEM_PATH
GEM_PATH
IRBRC
IRBRC
MY_RUBY_HOME
MY_RUBY_HOME
PATH
RUBY_VERSION
chpwd_functions
file
rvm_bin_path
rvm_bin_path
rvm_ignore_rvmrc
rvm_path
rvm_path
rvm_prefix
rvm_rubygems_path
rvm_rubygems_path
rvm_saved_env
rvm_version
rvmrc
rvmrc

```

So, $PATH was empty after __rvm_unload.
Now it should be fine.