### PR TITLE
Don't hard code number of compile threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 #### Bug fixes:
 * $PATH become empty after __rvm_unload executed [\#3847](https://github.com/rvm/rvm/pull/3847)
 * RVM incorrectly tries to install llvm 3.5 when trying to install Rubinius 3  [\#3848](https://github.com/rvm/rvm/pull/3848), 
+* RVM hardcodes number of compile threads [\#3856](https://github.com/rvm/rvm/pull/3856)
 
 ## [1.28.0](https://github.com/rvm/rvm/tag/1.28.0)
 

--- a/scripts/functions/build_config
+++ b/scripts/functions/build_config
@@ -129,7 +129,6 @@ __rvm_setup_compile_environment_movable()
       ;;
   esac
   rvm_configure_flags+=( --sysconfdir=/etc )
-  rvm_make_flags+=( -j3 )
 }
 
 __rvm_setup_compile_environment_bison()


### PR DESCRIPTION
RVM can automatically detect number of available threads.

Changes proposed in this pull request:
* remove hardcoded `-j3` 
