### PR TITLE
Drop GPG v1 support, as it has trouble with fetching keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@
 * Failing openssl.patch for Ruby 1.9.3 [\#3831](https://github.com/rvm/rvm/issues/3831) 
 * RVM hardcodes number of compile threads [\#3856](https://github.com/rvm/rvm/pull/3856)
 * Cannot build rbx-2.5.2 on ArchLinux [\#3497](https://github.com/rvm/rvm/issues/3497)
-* Remove incompatible version of openssl098 [\#3844](https://github.com/rvm/rvm/issues/3844)  
+* Remove incompatible version of openssl098 [\#3844](https://github.com/rvm/rvm/issues/3844) 
+* Failed to fetch the gpg key from keys.gnupg.net [\#3544](https://github.com/rvm/rvm/issues/3544)
 
 ## [1.28.0](https://github.com/rvm/rvm/tag/1.28.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Failing openssl.patch for Ruby 1.9.3 [\#3831](https://github.com/rvm/rvm/issues/3831) 
 * RVM hardcodes number of compile threads [\#3856](https://github.com/rvm/rvm/pull/3856)
 * Cannot build rbx-2.5.2 on ArchLinux [\#3497](https://github.com/rvm/rvm/issues/3497)
+* Remove incompatible version of openssl098 [\#3844](https://github.com/rvm/rvm/issues/3844)  
 
 ## [1.28.0](https://github.com/rvm/rvm/tag/1.28.0)
 

--- a/binscripts/rvm-installer
+++ b/binscripts/rvm-installer
@@ -390,13 +390,10 @@ rvm_install_gpg_setup()
   {
     rvm_gpg_command="$( \which gpg2 2>/dev/null )" &&
     [[ ${rvm_gpg_command} != "/cygdrive/"* ]]
-  } ||
-  {
-    rvm_gpg_command="$( \which gpg 2>/dev/null )" &&
-    [[ ${rvm_gpg_command} != "/cygdrive/"* ]]
-  } ||
-    rvm_gpg_command=""
+  } || rvm_gpg_command=""
+
   debug "Detected GPG program: '$rvm_gpg_command'"
+
   [[ -n "$rvm_gpg_command" ]] || return $?
 }
 
@@ -410,13 +407,10 @@ verify_package_pgp()
   else
     typeset _ret=$?
     log "\
-Warning, RVM 1.26.0 introduces signed releases and \
-automated check of signatures when GPG software found.
-Assuming you trust Michal Papis import the mpapis public \
-key (downloading the signatures).
+Warning, RVM 1.26.0 introduces signed releases and automated check of signatures when GPG software found. \
+Assuming you trust Michal Papis import the mpapis public key (downloading the signatures).
 
-GPG signature verification failed for '$1' - '$3'!
-try downloading the signatures:
+GPG signature verification failed for '$1' - '$3'! Try to install GPG v2 and then fetch the public key:
 
     ${SUDO_USER:+sudo }${rvm_gpg_command##*/} --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
 
@@ -428,6 +422,9 @@ the key can be compared with:
 
     https://rvm.io/mpapis.asc
     https://keybase.io/mpapis
+
+NOTE: GPG version 2.1.17 have a bug which cause failures during fetching keys from remote server. Please downgrade \
+or upgrade to newer version (if available) or use the second method described above.
 "
     exit $_ret
   fi

--- a/scripts/functions/cli
+++ b/scripts/functions/cli
@@ -204,13 +204,10 @@ rvm_install_gpg_setup()
   {
     rvm_gpg_command="$( \which gpg2 2>/dev/null )" &&
     [[ ${rvm_gpg_command} != "/cygdrive/"* ]]
-  } ||
-  {
-    rvm_gpg_command="$( \which gpg 2>/dev/null )" &&
-    [[ ${rvm_gpg_command} != "/cygdrive/"* ]]
-  } ||
-    rvm_gpg_command=""
+  } || rvm_gpg_command=""
+
   rvm_debug "Detected GPG program: '$rvm_gpg_command'"
+
   [[ -n "$rvm_gpg_command" ]] || return $?
 }
 
@@ -224,13 +221,10 @@ verify_package_pgp()
   else
     \typeset _ret=$?
     rvm_error "\
-Warning, RVM 1.26.0 introduces signed releases and \
-automated check of signatures when GPG software found.
-Assuming you trust Michal Papis import the mpapis public \
-key (downloading the signatures).
+Warning, RVM 1.26.0 introduces signed releases and automated check of signatures when GPG software found. \
+Assuming you trust Michal Papis import the mpapis public key (downloading the signatures).
 
-GPG signature verification failed for '$1' - '$3'!
-try downloading the signatures:
+GPG signature verification failed for '$1' - '$3'! Try to install GPG v2 and then fetch the public key:
 
     ${SUDO_USER:+sudo }${rvm_gpg_command##*/} --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
 
@@ -242,6 +236,9 @@ the key can be compared with:
 
     https://rvm.io/mpapis.asc
     https://keybase.io/mpapis
+
+NOTE: GPG version 2.1.17 have a bug which cause failures during fetching keys from remote server. Please downgrade \
+or upgrade to newer version (if available) or use the second method described above.
 "
     return _ret
   fi

--- a/scripts/functions/requirements/osx_brew
+++ b/scripts/functions/requirements/osx_brew
@@ -49,17 +49,24 @@ requirements_osx_brew_lib_available()
   brew search | __rvm_grep "^${1}$" >/dev/null || return $?
 }
 
+requirements_osx_brew_libs_error()
+{
+    rvm_warn "There were package ${1} errors, make sure to read the log.
+
+Try \`brew tap --repair\` and make sure \`brew doctor\` looks reasonable.
+
+Check Homebrew requirements https://github.com/Homebrew/homebrew/wiki/Installation"
+}
+
 requirements_osx_brew_libs_install()
 {
   brew unlink  "$@" || true # ignore: Error: No such keg: /usr/local/Cellar/automake
   brew install "$@" ||
   {
     \typeset ret=$?
-    rvm_warn "There were package installation errors, make sure to read the log.
 
-Try \`brew tap --repair\` and make sure \`brew doctor\` looks reasonable.
+    requirements_osx_brew_libs_error "installation"
 
-Check Homebrew requirements https://github.com/Homebrew/homebrew/wiki/Installation"
     case "$_system_version" in
       (10.6)
         rvm_warn "
@@ -67,6 +74,19 @@ On OSX 10.6 instead of command line tools install:
     https://github.com/downloads/kennethreitz/osx-gcc-installer/GCC-10.6.pkg"
         ;;
     esac
+    return $ret
+  }
+}
+
+requirements_osx_brew_libs_remove()
+{
+  brew unlink  "$@" || true # ignore: Error: No such keg: /usr/local/Cellar/automake
+  brew remove "$@" ||
+  {
+    \typeset ret=$?
+
+    requirements_osx_brew_libs_error "removal"
+
     return $ret
   }
 }
@@ -289,6 +309,8 @@ requirements_osx_brew_libs_default()
   brew_libs_conf+=( libyaml readline libksba openssl )
 
   requirements_osx_brew_check_custom homebrew/dupes # for: zlib
+
+  undesired_check openssl098
 
   requirements_check "${brew_libs[@]}" "${brew_libs_conf[@]}" || return $?
 }


### PR DESCRIPTION
Drop GPG v1 support, as it has trouble with fetching keys from hkp://keys.gnupg.net.
Added note highlighting issues with GPG 2.1.17

Fixes #3544
