### PR TITLE
Filtering Travis binaries for OSX for non-travis env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Cannot build rbx-2.5.2 on ArchLinux [\#3497](https://github.com/rvm/rvm/issues/3497)
 * Remove incompatible version of openssl098 [\#3844](https://github.com/rvm/rvm/issues/3844) 
 * Failed to fetch the gpg key from keys.gnupg.net [\#3544](https://github.com/rvm/rvm/issues/3544)
+* Filtering Travis binaries for OSX for non Travis env (they are statically linked and not movable) [\#3690](https://github.com/rvm/rvm/issues/3690) 
 
 ## [1.28.0](https://github.com/rvm/rvm/tag/1.28.0)
 

--- a/scripts/functions/utility_system
+++ b/scripts/functions/utility_system
@@ -116,6 +116,13 @@ __list_remote_all()
   while
     __rvm_db "rvm_remote_server_url${_iterator:-}" rvm_remote_server_url
   do
+    if [[ $rvm_remote_server_url == *"travis"* && $TRAVIS != true && $_system_name_lowercase == "osx" ]]
+    then
+        rvm_debug "Travis binaries for OSX are not movable and can't be used outside of Travis environment. \
+Skip that source."
+        continue
+    fi
+
     __rvm_system_path "" "${_iterator}"
     rvm_debug "__list_remote_all${_iterator:-} $rvm_remote_server_url $rvm_remote_server_path"
     __list_remote_for "${rvm_remote_server_url}" "$rvm_remote_server_path"

--- a/scripts/functions/utility_system
+++ b/scripts/functions/utility_system
@@ -61,13 +61,29 @@ __rvm_ruby_package_file()
   esac
 }
 
+__rvm_include_travis_binaries()
+{
+  if [[ $rvm_remote_server_url == *"travis"* && $TRAVIS != true && $_system_name_lowercase == "osx" ]]
+  then
+      rvm_debug "Travis binaries for OSX are not movable and can't be used outside of Travis environment. \
+Skip that source."
+      return 1
+  fi
+
+  return 0
+}
+
 __rvm_calculate_remote_file()
 {
   rvm_remote_server_url="$( __rvm_db "rvm_remote_server_url${3:-}" )"
+
   [[ -n "$rvm_remote_server_url" ]] || {
     rvm_debug "rvm_remote_server_url${3:-} not found"
     return $1
   }
+
+  __rvm_include_travis_binaries || return $1
+
   __rvm_system_path "" "${3:-}"
   __rvm_ruby_package_file "${4:-}"
   __remote_file="${rvm_remote_server_url}/${rvm_remote_server_path}${rvm_ruby_package_file}"
@@ -113,18 +129,15 @@ __list_remote_all()
 {
   \typeset _iterator rvm_remote_server_url rvm_remote_server_path
   _iterator=""
+
   while
     __rvm_db "rvm_remote_server_url${_iterator:-}" rvm_remote_server_url
   do
-    if [[ $rvm_remote_server_url == *"travis"* && $TRAVIS != true && $_system_name_lowercase == "osx" ]]
-    then
-        rvm_debug "Travis binaries for OSX are not movable and can't be used outside of Travis environment. \
-Skip that source."
-        continue
-    fi
+    __rvm_include_travis_binaries || continue
 
     __rvm_system_path "" "${_iterator}"
     rvm_debug "__list_remote_all${_iterator:-} $rvm_remote_server_url $rvm_remote_server_path"
+
     __list_remote_for "${rvm_remote_server_url}" "$rvm_remote_server_path"
     : $(( _iterator+=1 ))
   done | \command \sort -u | __rvm_version_sort


### PR DESCRIPTION
Filtering Travis binaries for OSX for non-travis env (they are statically linked and not movable)

Fixes #3690, #3582, #3861
