### PR TITLE
Remove kernel-libc-devel dependency on Solus

### DIFF
--- a/scripts/functions/requirements/solus
+++ b/scripts/functions/requirements/solus
@@ -63,8 +63,7 @@ requirements_solus_define()
       fi
       requirements_check autoconf gcc g++ glibc-devel patch readline readline-devel \
         zlib zlib-devel libffi-devel openssl-devel make bzip2 automake libtool \
-        bison sqlite3-devel yaml-devel gmp-devel pkg-config ncurses-devel binutils \
-        kernel-libc-devel
+        bison sqlite3-devel yaml-devel gmp-devel pkg-config ncurses-devel binutils
       ;;
   esac
 }


### PR DESCRIPTION
Small fix for Solus. The package kernel-libc-devel package has been renamed to kernel-headers and causes rvm install to fail because kernel-libc-devel cannot be found by the package manager. The package is also not required and can be removed

Changes proposed in this pull request:
* Remove kernel-libc-devel dependency on Solus
