### PR TITLE
Changed eval to source for fish v2.5.0 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Expose `autolibs` setting in `rvm info` output [\#3892](https://github.com/rvm/rvm/pull/3892)
 
 #### Bug fixes:
+* Changed `eval` to `source` for fish 2.5.0 compatibility [fish-shell\#3809](https://github.com/fish-shell/fish-shell/issues/3809)
 * $PATH become empty after __rvm_unload executed [\#3847](https://github.com/rvm/rvm/pull/3847)
 * RVM incorrectly tries to install llvm 3.5 when trying to install Rubinius 3 [\#3848](https://github.com/rvm/rvm/pull/3848)
 * Failing openssl.patch for Ruby 1.9.3 [\#3831](https://github.com/rvm/rvm/issues/3831)

--- a/scripts/extras/rvm.fish
+++ b/scripts/extras/rvm.fish
@@ -1,7 +1,7 @@
 #!/usr/bin/env fish
 
 function load_env_file
-  eval (sed -e "s/export\(.*\);\(.*\)=/set -x \1 /" -e "s/export\(.*\)=/set -x \1 /" -e 's/unset/set -e /' -e "/ PATH / s/[\"':]/ /g" -e 's/$/; /' < $argv)
+  sed -e "s/export\(.*\);\(.*\)=/set -x \1 /" -e "s/export\(.*\)=/set -x \1 /" -e 's/unset/set -e /' -e "/ PATH / s/[\"':]/ /g" -e 's/$/; /' < $argv | source
 end
 
 load_env_file ~/.rvm/environments/default


### PR DESCRIPTION
Fix related to [fish-shell\#3809](https://github.com/fish-shell/fish-shell/issues/3809) .

Changes proposed in this pull request:
* changed `eval` to `source` to make `rvm.fish` compatible with Fish v2.5.0

More details about mentioned issue in following discussions:
* syl20bnr/spacemacs/issues/4755 (the issue i've initially ran into) 
* purcell/exec-path-from-shell/issues/56
* fish-shell/fish-shell/issues/3809 (the solution implemented was proposed in this thread)

Similar PR submited to oh-my-fish/plugin-rvm: oh-my-fish/plugin-rvm/pull/10