### PR TITLE
Use actual executable test instead of mount|grep noexec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 [Full Changelog](https://github.com/rvm/rvm/compare/1.29.1...HEAD)
 
 #### Bug fixes:
-* Use actual executable test instead of mount|grep noexec for robust noexec detection [\#3832](https://github.com/rvm/rvm/issues/3832)
+* Use actual executable test instead of mount|grep noexec for robust noexec detection [\#3933](https://github.com/rvm/rvm/pull/3933)
 
 ## [1.29.1](https://github.com/rvm/rvm/tag/1.29.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 [Full Changelog](https://github.com/rvm/rvm/compare/1.29.1...HEAD)
 
+#### Bug fixes:
+* Use actual executable test instead of mount|grep noexec for robust noexec detection [\#3832](https://github.com/rvm/rvm/issues/3832)
 
 ## [1.29.1](https://github.com/rvm/rvm/tag/1.29.1)
 

--- a/binscripts/rvm-installer
+++ b/binscripts/rvm-installer
@@ -783,7 +783,7 @@ follow this link for details how to fix:
 
 rvm_install_validate_volume_mount_mode()
 {
-  \typeset path partition
+  \typeset path partition test_exec
 
   path=$rvm_path
 
@@ -793,10 +793,14 @@ rvm_install_validate_volume_mount_mode()
   do
       if [[ -d $path ]]
       then
+        test_exec=$(mktemp $path/rvm-exec-test.XXXXXX)
+        echo '#!/bin/sh' > "$test_exec"
+        chmod +x "$test_exec"
         partition=`df -P $path | awk 'END{print $1}'`
 
-        if mount | grep "$partition .*noexec.*" >/dev/null 2>&1
+        if ! "$test_exec"
         then
+          rm -f "$test_exec"
           printf "%b" "
 It looks that partition holding RVM destination location ${rvm_path}
 is mounted in *noexec* mode, which prevents RVM from working correctly.
@@ -804,6 +808,7 @@ Please re-mount partition ${partition} without the noexec option."
           exit 2
         fi
 
+        rm -f "$test_exec"
         break
       fi
 

--- a/binscripts/rvm-installer
+++ b/binscripts/rvm-installer
@@ -787,24 +787,25 @@ rvm_install_validate_volume_mount_mode()
 
   path=$rvm_path
 
-  # $rvm_path might not exists at this point so we need to traverse the directory tree upwards
-  # to find the name of the partition and then check if it has not been mount with noexec mode
+  # Directory $rvm_path might not exists at this point so we need to traverse the tree upwards
   while [[ -n "$path" ]]
   do
       if [[ -d $path ]]
       then
+        partition=`df -P $path | awk 'END{print $1}'`
+
         test_exec=$(mktemp $path/rvm-exec-test.XXXXXX)
         echo '#!/bin/sh' > "$test_exec"
         chmod +x "$test_exec"
-        partition=`df -P $path | awk 'END{print $1}'`
 
         if ! "$test_exec"
         then
           rm -f "$test_exec"
           printf "%b" "
-It looks that partition holding RVM destination location ${rvm_path}
-is mounted in *noexec* mode, which prevents RVM from working correctly.
-Please re-mount partition ${partition} without the noexec option."
+It looks that scripts located in ${path}, which would be RVM destination ${rvm_path},
+are not executable. One of the reasons might be that partition ${partition} holding this location
+is mounted in *noexec* mode, which prevents RVM from working correctly. Please verify your setup 
+and re-mount partition ${partition} without the noexec option."
           exit 2
         fi
 


### PR DESCRIPTION
Fixes #3832.

Changes proposed in this pull request:
* Don't try to parse mounted filesystem table to detect partitions mounted `noexec`
* Create a temporary script and try to execute it to actually test if scripts are runnable from the target location