### PR TITLE
Detect `.` as an alternative to `source` in bash profile warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * Use actual executable test instead of mount|grep noexec for robust noexec detection [\#3933](https://github.com/rvm/rvm/pull/3933)
 * "Unknown ruby string (do not know how to handle)" when specifying Ruby version w/a gemset [\#3292](https://github.com/rvm/rvm/issue/3292)
 * Fix the required openssl version for ruby 1.8 on OSX [\#3955](https://github.com/rvm/rvm/issue/3955)
-* Fix spurious warning about not sourcing `.profile` from bash startup files when it is being sourced using the `.` syntax [\#3960](https://github.com/rvm/rvm/issues/3960)
+* Detect `.` as an alternative to `source` in bash profile warning [\#3960](https://github.com/rvm/rvm/issues/3960)
 
 #### Upgraded Ruby interpreters:
 * Add support for Rubinius 3.72 [\#3934](https://github.com/rvm/rvm/pull/3934)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Use actual executable test instead of mount|grep noexec for robust noexec detection [\#3933](https://github.com/rvm/rvm/pull/3933)
 * "Unknown ruby string (do not know how to handle)" when specifying Ruby version w/a gemset [\#3292](https://github.com/rvm/rvm/issue/3292)
 * Fix the required openssl version for ruby 1.8 on OSX [\#3955](https://github.com/rvm/rvm/issue/3955)
+* Fix spurious warning about not sourcing `.profile` from bash startup files when it is being sourced using the `.` syntax [\#3960](https://github.com/rvm/rvm/issues/3960)
 
 #### Upgraded Ruby interpreters:
 * Add support for Rubinius 3.72 [\#3934](https://github.com/rvm/rvm/pull/3934)

--- a/scripts/notes
+++ b/scripts/notes
@@ -204,8 +204,7 @@ $notes_type Notes:
         __rvm_grep -E '(source|\.).+profile' "${__var}" >/dev/null 2>&1 ||
         {
           important_message "
-  * WARNING: You have a '~/.profile' file, you might want to load it.
-    To do that add the following line to '${__var}':
+  * WARNING: '~/.profile' file found. To load it into your shell, add the following line to '${__var}':
 
       source ~/.profile
 "

--- a/scripts/notes
+++ b/scripts/notes
@@ -201,7 +201,7 @@ $notes_type Notes:
       if
         [[ -f "${__var}" ]]
       then
-        __rvm_grep 'source.*profile' "${__var}" >/dev/null 2>&1 ||
+        __rvm_grep -E '(source|\.).+profile' "${__var}" >/dev/null 2>&1 ||
         {
           important_message "
   * WARNING: You have '~/.profile' file, you might want to load it,

--- a/scripts/notes
+++ b/scripts/notes
@@ -204,8 +204,8 @@ $notes_type Notes:
         __rvm_grep -E '(source|\.).+profile' "${__var}" >/dev/null 2>&1 ||
         {
           important_message "
-  * WARNING: You have '~/.profile' file, you might want to load it,
-    to do that add the following line to '${__var}':
+  * WARNING: You have a '~/.profile' file, you might want to load it.
+    To do that add the following line to '${__var}':
 
       source ~/.profile
 "


### PR DESCRIPTION
Add a check for the `.`  source syntax in the bash startup files before warning about `.profile` not being sourced. 

Fixes #3960

Changes proposed in this pull request:
* Use a regular expression that also detects the use of `.` as well as `source`
* Improved the wording of the warning a little