### PR TITLE
Support Ruby 2.3 and 2.4 in rvm-prompt

### DIFF
--- a/bin/rvm-prompt
+++ b/bin/rvm-prompt
@@ -127,6 +127,8 @@ then
           (2.0.0)  unicode="➋" ;;
           (2.1.*)  unicode="➋➀" ;;
           (2.2.*)  unicode="➋➁" ;;
+          (2.3.*)  unicode="➋➂" ;;
+          (2.4.*)  unicode="➋➃" ;;
           (*)      unicode="⦿"  ;;
         esac ;;
       (*) unicode="⦿" ;;


### PR DESCRIPTION
When using the unicode flag(†), render numbers for Ruby version 2.3.* and 2.4.* instead of treating these versions as unknown.

Changes proposed in this pull request:
* Added extra output options for the `rvm-prompt` helper script.

(†): `~/.rvm/bin/rvm-prompt unicode`