### PR TITLE
Use fuzzy version match for `rvm remove`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Add support for elementary OS [\#3935](https://github.com/rvm/rvm/issues/3935)
 * Add support for Deepin (based on Debian) [\#3999](https://github.com/rvm/rvm/issues/3999) 
 * Simplified OS detection mechanism [\#3938](https://github.com/rvm/rvm/pull/3938)
-* Use fuzzy version match for `rvm remove`
+* Use fuzzy version match for `rvm remove` [\#4028](https://github.com/rvm/rvm/pull/4028)
 
 #### Bug fixes:
 * Use actual executable test instead of mount|grep noexec for robust noexec detection [\#3933](https://github.com/rvm/rvm/pull/3933)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add support for elementary OS [\#3935](https://github.com/rvm/rvm/issues/3935)
 * Add support for Deepin (based on Debian) [\#3999](https://github.com/rvm/rvm/issues/3999) 
 * Simplified OS detection mechanism [\#3938](https://github.com/rvm/rvm/pull/3938)
+* Use fuzzy version match for `rvm remove`
 
 #### Bug fixes:
 * Use actual executable test instead of mount|grep noexec for robust noexec detection [\#3933](https://github.com/rvm/rvm/pull/3933)

--- a/scripts/functions/manage/base_remove
+++ b/scripts/functions/manage/base_remove
@@ -27,6 +27,7 @@ __rvm_remove_ruby()
       return 1
       ;;
   esac
+  rvm_fuzzy_flag=1
   (( ${rvm_ruby_selected_flag:=0} )) || __rvm_select
   [[ -n "${rvm_ruby_string:-}"    ]] ||
   {


### PR DESCRIPTION
**Preconditions:**

```
$ rvm install jruby-1.7.27
```

**Steps to reproduce:**

```
$ rvm remove jruby
```

**Expected result:**

```
jruby-1.7.26 - #removing rubies/jruby-1.7.26..
...
```

**Actual result:**

```
jruby-9.1.8.0 - #already gone
```

**Temporary solution:**

```
$ rvm remove jruby --fuzzy
```

**Final solution implemented in this PR:**

No need to use `--fuzzy` switch.
