### PR TITLE
Give clarity to code block installed to dot-files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Simplify and cleanup of `rvm help` output [\#4029](https://github.com/rvm/rvm/pull/4029)
 * Add support for Kali Linux (based on Debian) [\#3958](https://github.com/rvm/rvm/issues/3958) 
 * Railsexpress patches for 2.4.0, 2.4.1 and 2.4-head [\#4050](https://github.com/rvm/rvm/pull/4050)
+* Improve clarity of dotfile edits [\#4053](https://github.com/rvm/rvm/issues/4053)
 
 #### Bug fixes:
 * Use actual executable test instead of mount|grep noexec for robust noexec detection [\#3933](https://github.com/rvm/rvm/pull/3933)

--- a/scripts/functions/installer
+++ b/scripts/functions/installer
@@ -1100,8 +1100,15 @@ setup_user_profile_rc()
     do
       touch "$profile_file"
       printf "%b" "
+###############################################################################
+# At $(date --iso-8601=s), the RVM installer added this block (and also created
+# this file if it did not already exist).
+#########
+#
 # Add RVM to PATH for scripting. Make sure this is the last PATH variable change.
 export PATH=\"\$PATH:$local_rvm_path/bin\"
+#
+###############################################################################
 " >> "$profile_file"
     done
   else

--- a/scripts/functions/installer
+++ b/scripts/functions/installer
@@ -1105,7 +1105,7 @@ setup_user_profile_rc()
 # this file if it did not already exist).
 #########
 #
-# Add RVM to PATH for scripting. Make sure this is the last PATH variable change.
+# Add RVM to PATH for scripting. Ensure this is the last PATH variable change.
 export PATH=\"\$PATH:$local_rvm_path/bin\"
 #
 ###############################################################################


### PR DESCRIPTION
Fixes #4053 .

The RVM installer edits several dot-files (and creates them, if they do not already exist). It can be confusing for a user to find dot-files in their home directory for shells they have never installed (e.g. `.mkshrc`, if they are not a `mksh` user). It can also be hard for a novice user to know which edits to their dot-files were made by what, when, and why.
    
This PR fixes that confusion, by noting, for each edit:
- that the RVM installer made the edit
- when the RVM installer made the edit
- the extent of the edit, using octothorpes as delimiters. Layout loosely inspired by examples such as:
    - https://github.com/syl20bnr/spacemacs/blob/master/core/templates/.spacemacs.template
    - https://github.com/nicksp/dotfiles/blob/master/shell/bash_profile
