### PR TITLE
Command not found `__rvm_remote_version` error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 #### New features:
 * Add RVM commands missing in bash shell completion [\#4078](https://github.com/rvm/rvm/pull/4078)
 
+#### Bug fixes:
+* Fix an error message displayed on some commands [\#4085](https://github.com/rvm/rvm/pull/4085)
+
 
 [1.29.2](https://github.com/rvm/rvm/tag/1.29.2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Add RVM commands missing in bash shell completion [\#4078](https://github.com/rvm/rvm/pull/4078)
 
 #### Bug fixes:
-* Fix an error message displayed on some commands [\#4085](https://github.com/rvm/rvm/pull/4085)
+* Command not found `__rvm_remote_version` error [\#4085](https://github.com/rvm/rvm/pull/4085)
 
 
 [1.29.2](https://github.com/rvm/rvm/tag/1.29.2)

--- a/scripts/functions/cli
+++ b/scripts/functions/cli
@@ -180,7 +180,7 @@ Please do one of the following:
 
 __rvm_cli_autoupdate_version_old()
 {
-  online_version="$( __rvm_remote_version )"
+  online_version="$( __rvm_version_remote )"
   version_release="$(\command \cat "$rvm_path/RELEASE" 2>/dev/null)"
   : version_release:"${version_release:=master}"
   [[ -s "$rvm_path/VERSION" && -n "${online_version:-}" && "${rvm_version%% *}" != "${online_version:-}" ]] || return $?


### PR DESCRIPTION
some commands (like `rvm list known`) display error messages like `command not found: __rvm_remote_version` or `__rvm_cli_autoupdate_version_old:2: command not found: __rvm_remote_version`

Looking into code, the actual function name is `__rvm_version_remote`, so this commit fixes that reference.  I only found the bad reference in a single location.

It doesn't seem to cause any significant harm, but fixing this will clean up an error message that appears in the terminal when some commands are run.

I didn't find an existing github issue for this.

Changes proposed in this pull request:
* Fix a function reference to eliminate an error message

Make sure that your pull request includes entry in the [CHANGELOG](CHANGELOG.md).