### PR TITLE
Fix path of version script in `environment`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 #### Bug fixes:
 * Command not found `__rvm_remote_version` error [\#4085](https://github.com/rvm/rvm/pull/4085)
+* Fix path of version script in `environment` [\#4117](https://github.com/rvm/rvm/pull/4117)
 
 #### Upgraded Ruby interpreters:
 * Add support for Rubinius 3.82, 3.83

--- a/scripts/functions/environment
+++ b/scripts/functions/environment
@@ -350,7 +350,7 @@ __rvm_ensure_is_a_function()
 {
   if [[ ${rvm_reload_flag:=0} == 1 ]] || ! is_a_function rvm
   then
-    for script in version functions/selector cd functions/cli cli override_gem
+    for script in functions/version functions/selector cd functions/cli cli override_gem
     do
       if [[ -f "$rvm_scripts_path/$script" ]]
       then


### PR DESCRIPTION
Fixes #4072 .

Changes proposed in this pull request:
* Source `scripts/functions/version` instead of `scripts/version` at `scripts/environment`

The modification of cc758aa seems to be insufficient.
When run `source "/path/to/.rvm/scripts/rvm"`, the following warning will be output:

```
WARNING:
        Could not source '/path/to/.rvm/scripts/version' as file does not exist.
        RVM will likely not work as expected.
```

The warning will resolved by this patch.
I hope this helps.