### PR TITLE
Fix parse error in cd script

### DIFF
--- a/scripts/cd
+++ b/scripts/cd
@@ -11,9 +11,9 @@ case "${rvm_project_rvmrc:-1}" in
   [[ -n "${ZSH_VERSION:-}" ]] &&
   __rvm_version_compare "$ZSH_VERSION" -gt  4.3.4 ||
   {
-    cd()    { __zsh_like_cd cd    "$@" ; }
-    popd()  { __zsh_like_cd popd  "$@" ; }
-    pushd() { __zsh_like_cd pushd "$@" ; }
+    function cd()    { __zsh_like_cd cd    "$@" ; }
+    function popd()  { __zsh_like_cd popd  "$@" ; }
+    function pushd() { __zsh_like_cd pushd "$@" ; }
   }
 
   __rvm_after_cd()


### PR DESCRIPTION
When I open a new terminal I get the following message:
/home/emersonmx/.rvm/scripts/cd:14: defining function based on alias `cd'
/home/emersonmx/.rvm/scripts/cd:14: parse error near `()'

I don't know why this happen now, because last week everything was working.
Anyway, everything is fine now with this :)

Changes proposed in this pull request:
* Remove parse error message when open a new terminal