### PR TITLE
zsh 5.4.1 changes how alias expansion during function def works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Infinite loop in `gemset_create` [\#4102](https://github.com/rvm/rvm/issues/4102)
 * Command not found `__rvm_remote_version` error [\#4085](https://github.com/rvm/rvm/pull/4085)
 * Fix path of version script in `environment` [\#4117](https://github.com/rvm/rvm/pull/4117)
+* Define cd(), pushd() and popd() properly when using zsh
 
 #### Upgraded Ruby interpreters:
 * Add support for Rubinius 3.82, 3.83, 3.84

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 * Infinite loop in `gemset_create` [\#4102](https://github.com/rvm/rvm/issues/4102)
 * Command not found `__rvm_remote_version` error [\#4085](https://github.com/rvm/rvm/pull/4085)
 * Fix path of version script in `environment` [\#4117](https://github.com/rvm/rvm/pull/4117)
-* Define cd(), pushd() and popd() properly when using zsh
+* Define cd(), pushd() and popd() properly when using zsh [\#4132](https://github.com/rvm/rvm/pull/4132)
 
 #### Upgraded Ruby interpreters:
 * Add support for Rubinius 3.82, 3.83, 3.84

--- a/scripts/cd
+++ b/scripts/cd
@@ -11,9 +11,9 @@ case "${rvm_project_rvmrc:-1}" in
   [[ -n "${ZSH_VERSION:-}" ]] &&
   __rvm_version_compare "$ZSH_VERSION" -gt  4.3.4 ||
   {
-    cd()    { __zsh_like_cd cd    "$@" ; }
-    popd()  { __zsh_like_cd popd  "$@" ; }
-    pushd() { __zsh_like_cd pushd "$@" ; }
+    function cd()    { __zsh_like_cd cd    "$@" ; }
+    function popd()  { __zsh_like_cd popd  "$@" ; }
+    function pushd() { __zsh_like_cd pushd "$@" ; }
   }
 
   __rvm_after_cd()


### PR DESCRIPTION
This change introduces a backwards compatible fix, r[ecommended by
the zsh maintainers](http://zsh.sourceforge.net/releases.html). Our cd(), pushd() and popd() are now defined
properly.

Changes proposed in this pull request:
* Small update to how shell init happens in zsh, to fix a bug under 5.4.1