### PR TITLE
Link version script to functions #4134

### DIFF
--- a/scripts/version
+++ b/scripts/version
@@ -1,0 +1,1 @@
+functions/version


### PR DESCRIPTION
Fixes issue with `\curl -sSL https://get.rvm.io | bash -s stable --ruby` introduced by #4134

Changes proposed in this pull request:
* link version script to functions directory