### PR TITLE
Disable nounset for rvm run, fix #4013

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Allow comments after ruby directive in Gemfile [\#4056](https://github.com/rvm/rvm/issues/4056)
 * Ruby 2.3/4 compilation fix for GCC 7 [\#4080](https://github.com/rvm/rvm/issues/4080) [\#4115](https://github.com/rvm/rvm/issues/4115)
 * Add warning for sudo users [\#4009](https://github.com/rvm/rvm/issues/4009)
+* Allows running RVM shell function in Bash with `set -o nounset` [\#4013](https://github.com/rvm/rvm/issues/4013)
 
 #### Upgraded Ruby interpreters:
 * Add support for Rubinius 3.82, 3.83, 3.84

--- a/scripts/base
+++ b/scripts/base
@@ -6,17 +6,17 @@
 __rvm_has_opt()
 {
   if # pre-gnu
-   [[ -n "${ZSH_VERSION}"  ]]
+   [[ -n "${ZSH_VERSION:-}"  ]]
   then
-    setopt | GREP_OPTIONS="" \command \grep "^${1}$" >/dev/null 2>&1 || return $?
+    setopt | GREP_OPTIONS="" \command \grep "^${1:-}$" >/dev/null 2>&1 || return $?
   elif # mksh
-    [[ -n "${KSH_VERSION}"  ]]
+    [[ -n "${KSH_VERSION:-}"  ]]
   then
-    set +o | GREP_OPTIONS="" \command \grep "-o ${1}$" >/dev/null 2>&1 || return $?
+    set +o | GREP_OPTIONS="" \command \grep "-o ${1:-}$" >/dev/null 2>&1 || return $?
   elif # bash
-    [[ -n "${BASH_VERSION}" ]]
+    [[ -n "${BASH_VERSION:-}" ]]
   then
-    [[ ":$SHELLOPTS:" == *":${1}:"* ]] || return $?
+    [[ ":${SHELLOPTS:-}:" == *":${1:-}:"* ]] || return $?
   else # what is this?!
     return 1
   fi

--- a/scripts/functions/environment
+++ b/scripts/functions/environment
@@ -202,8 +202,16 @@ __rvm_setup()
   then return 0
   fi
 
-  if [[ -n "${BASH_VERSION:-}" ]] && ! __function_on_stack cd pushd popd
+  if
+    [[ -n "${BASH_VERSION:-}" ]] && ! __function_on_stack cd pushd popd
   then
+    export rvm_shell_nounset
+    if __rvm_has_opt "nounset"
+    then rvm_bash_nounset=1
+    else rvm_bash_nounset=0
+    fi
+    set +o nounset
+
     trap '__rvm_teardown_final ; set +x' EXIT HUP INT QUIT TERM
   fi
 
@@ -253,6 +261,9 @@ __rvm_teardown()
     then
       trap 'shell_session_update' EXIT
     fi
+
+    (( rvm_bash_nounset == 1 )) && set -o nounset
+    unset rvm_bash_nounset
   fi
 
   if

--- a/scripts/functions/support
+++ b/scripts/functions/support
@@ -8,7 +8,7 @@ is_a_function()
 # Functions RVM is built on
 # __rvm_string_match <value> <string|glob>
 if
-  [[ -n "$ZSH_VERSION" ]]
+  [[ -n "${ZSH_VERSION:-}" ]]
 then
   __rvm_string_match()
   {

--- a/scripts/rvm
+++ b/scripts/rvm
@@ -26,17 +26,17 @@ fi
 __rvm_has_opt()
 {
   if # pre-gnu
-   [[ -n "${ZSH_VERSION}"  ]]
+   [[ -n "${ZSH_VERSION:-}"  ]]
   then
-    setopt | GREP_OPTIONS="" \command \grep "^${1}$" >/dev/null 2>&1 || return $?
+    setopt | GREP_OPTIONS="" \command \grep "^${1:-}$" >/dev/null 2>&1 || return $?
   elif # mksh
-    [[ -n "${KSH_VERSION}"  ]]
+    [[ -n "${KSH_VERSION:-}"  ]]
   then
-    set +o | GREP_OPTIONS="" \command \grep "-o ${1}$" >/dev/null 2>&1 || return $?
+    set +o | GREP_OPTIONS="" \command \grep "-o ${1:-}$" >/dev/null 2>&1 || return $?
   elif # bash
-    [[ -n "${BASH_VERSION}" ]]
+    [[ -n "${BASH_VERSION:-}" ]]
   then
-    [[ ":$SHELLOPTS:" == *":${1}:"* ]] || return $?
+    [[ ":${SHELLOPTS:-}:" == *":${1:-}:"* ]] || return $?
   else # what is this?!
     return 1
   fi


### PR DESCRIPTION
Fixes #4013.

Allows running RVM shell function in Bash with `set -o nounset`
