### PR TITLE
Add missing random.c patch for Ruby 2.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 #### Bug fixes:
 * ZSH Bad pattern for Gemfile ruby declaration [\#4154](https://github.com/rvm/rvm/issues/4154) [\#4156](https://github.com/rvm/rvm/issues/4156)
+* Add missing random.c patch for Ruby 2.3.2
 
 #### Upgraded Ruby interpreters:
 * Add support for Ruby 2.2.8, 2.3.5 and 2.4.2 [\#4159](https://github.com/rvm/rvm/pull/4159)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 #### Bug fixes:
 * ZSH Bad pattern for Gemfile ruby declaration [\#4154](https://github.com/rvm/rvm/issues/4154) [\#4156](https://github.com/rvm/rvm/issues/4156)
-* Add missing random.c patch for Ruby 2.3.2
+* Add missing random.c patch for Ruby 2.3.2 [\#4165](https://github.com/rvm/rvm/issues/4154) [\#4165]
 
 #### Upgraded Ruby interpreters:
 * Add support for Ruby 2.2.8, 2.3.5 and 2.4.2 [\#4159](https://github.com/rvm/rvm/pull/4159)

--- a/patches/ruby/2.3.2/random_c_using_NR_prefix.patch
+++ b/patches/ruby/2.3.2/random_c_using_NR_prefix.patch
@@ -1,0 +1,20 @@
+--- a/random.c
++++ b/random.c
+@@ -521,7 +521,7 @@
+     CryptGenRandom(prov, size, seed);
+     return 0;
+ }
+-#elif defined __linux__ && defined SYS_getrandom
++#elif defined __linux__ && defined __NR_getrandom
+ #include <linux/random.h>
+
+ # ifndef GRND_NONBLOCK
+@@ -538,7 +538,7 @@
+ 	if (!need_secure)
+ 	    flags = GRND_NONBLOCK;
+ 	errno = 0;
+-	ret = syscall(SYS_getrandom, seed, size, flags);
++	ret = syscall(__NR_getrandom, seed, size, flags);
+ 	if (errno == ENOSYS) {
+ 	    ATOMIC_SET(try_syscall, 0);
+ 	    return -1;


### PR DESCRIPTION
Getting the following message when trying to build Ruby 2.3.2:

```
ruby-2.3.2 - #extracting ruby-2.3.2 to /home/rof/.rvm/src/ruby-2.3.2....
ruby-2.3.2 - #applying patch /home/rof/.rvm/patches/ruby/ruby_2_3_gcc7.patch.
Patch 'random_c_using_NR_prefix' not found.
There has been an error applying the specified patches. Halting the installation.
```

It looks like `random_c_using_NR_prefix.patch` was added in #4048, but did not get included for 2.3.2.