### PR TITLE
railsexpress patches for 2.2.8, 2.3.5 and 2.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [Unreleased](https://github.com/rvm/rvm/tree/HEAD)
 [Full Changelog](https://github.com/rvm/rvm/compare/1.29.3...HEAD)
 
+#### New features:
+* Railsexpress patches for 2.2.8, 2.3.5 and 2.4.2 [\#4167](https://github.com/rvm/rvm/pull/4167)
+
 #### Bug fixes:
 * ZSH Bad pattern for Gemfile ruby declaration [\#4154](https://github.com/rvm/rvm/issues/4154) [\#4156](https://github.com/rvm/rvm/issues/4156)
 * Add missing random.c patch for Ruby 2.3.2 [\#4165](https://github.com/rvm/rvm/issues/4165)

--- a/patchsets/ruby/2.2.8/railsexpress
+++ b/patchsets/ruby/2.2.8/railsexpress
@@ -1,0 +1,3 @@
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.2.8/railsexpress/01-zero-broken-tests.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.2.8/railsexpress/02-improve-gc-stats.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.2.8/railsexpress/03-display-more-detailed-stack-trace.patch

--- a/patchsets/ruby/2.3.5/railsexpress
+++ b/patchsets/ruby/2.3.5/railsexpress
@@ -1,0 +1,4 @@
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.3.5/railsexpress/01-skip-broken-tests.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.3.5/railsexpress/02-improve-gc-stats.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.3.5/railsexpress/03-display-more-detailed-stack-trace.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.3.5/railsexpress/04-fix-gmp-compile-issue.patch

--- a/patchsets/ruby/2.4.2/railsexpress
+++ b/patchsets/ruby/2.4.2/railsexpress
@@ -1,0 +1,4 @@
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.4.2/railsexpress/01-skip-broken-tests.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.4.2/railsexpress/02-improve-gc-stats.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.4.2/railsexpress/03-display-more-detailed-stack-trace.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.4.2/railsexpress/04-fix-gmp-compile-issue.patch


### PR DESCRIPTION
Latest railsexpress patches.

Patches also fix the 2.3.5 and 2.4.2 failure to compile and link against libgmp.