### PR TITLE
Use Ruby's bundled libyaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * ZSH Bad pattern for Gemfile ruby declaration [\#4154](https://github.com/rvm/rvm/issues/4154) [\#4156](https://github.com/rvm/rvm/issues/4156)
 * Add missing random.c patch for Ruby 2.3.2 [\#4165](https://github.com/rvm/rvm/issues/4165)
 * Set back IRB history default to HOME [\#4158](https://github.com/rvm/rvm/issues/4158)
+* Do not require libyaml-devel on Redhat/Centos when it's not needed [\#2998](https://github.com/rvm/rvm/issues/2998)
 
 #### Upgraded Ruby interpreters:
 * Add support for Ruby 2.2.8, 2.3.5 and 2.4.2 [\#4159](https://github.com/rvm/rvm/pull/4159)

--- a/scripts/functions/requirements/centos
+++ b/scripts/functions/requirements/centos
@@ -141,7 +141,11 @@ requirements_centos_before_update_check_repos()
 
 requirements_centos_before_update()
 {
-  requirements_centos_before_update_check_repos || return $?
+  case "$1" in
+    (ruby-1*)
+      requirements_centos_before_update_check_repos || return $?
+      ;;
+  esac
 }
 
 requirements_centos_check_binary()
@@ -160,7 +164,9 @@ requirements_centos_define_glibc()
 
 requirements_centos_define_libyaml()
 {
-  requirements_check libyaml-devel
+  case "$1" in
+    (ruby-1*) requirements_check libyaml-devel ;;
+  esac
 }
 
 requirements_centos_define_openssl()

--- a/scripts/functions/requirements/redhat
+++ b/scripts/functions/requirements/redhat
@@ -9,7 +9,9 @@ requirements_redhat_define_glibc()
 
 requirements_redhat_define_libyaml()
 {
-  requirements_check libyaml-devel
+  case "$1" in
+    (ruby-1*) requirements_check libyaml-devel ;;
+  esac
 }
 
 requirements_redhat_define_openssl()


### PR DESCRIPTION
Ruby supports embedded libyaml since 2.0.0, no need to require superfluous and buggy instructions to add it.
This can pose security risk for not updated libyaml - but it should be Ruby's responsibility to inform users about it!

Fixes #2998
Update #3194
Deprecate/fix #3191
Deprecate/fix #3207
Partially fixes #3304 
