### PR TITLE
libreadline6-dev is not a valid Ubuntu 16.10 package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Set back IRB history default to HOME [\#4158](https://github.com/rvm/rvm/issues/4158)
 * Do not require libyaml-devel on Redhat/Centos when it's not needed [\#2998](https://github.com/rvm/rvm/issues/2998)
 * Restore mvn installation for JRuby 1.7 [\#4166](https://github.com/rvm/rvm/issues/4166)
+* libreadline6-dev is not a valid Ubuntu 16.10 package [\#4172](https://github.com/rvm/rvm/issues/4172) 
 
 #### Upgraded Ruby interpreters:
 * Add support for Ruby 2.2.8, 2.3.5 and 2.4.2 [\#4159](https://github.com/rvm/rvm/pull/4159)

--- a/scripts/functions/requirements/ubuntu
+++ b/scripts/functions/requirements/ubuntu
@@ -9,7 +9,13 @@ requirements_ubuntu_define_libgmp()
 
 requirements_ubuntu_define_libreadline()
 {
-  requirements_check libreadline6-dev
+  if
+    __rvm_version_compare ${_system_version} -ge 16.10
+  then
+    requirements_check libreadline-dev
+  else
+    requirements_check libreadline6-dev
+  fi
 }
 
 requirements_ubuntu_define_libssl()


### PR DESCRIPTION
Starting from Ubuntu 16.10 the correct package name is `libreadline-dev`

Fixes #4172