### PR TITLE
Require libdb-4.8 for OpenSuSE Tumbleweed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Restore mvn installation for JRuby 1.7 [\#4166](https://github.com/rvm/rvm/issues/4166)
 * ree-1.8.7 requires old version of OpenSSL 1.0.2 [\#4110](https://github.com/rvm/rvm/issues/4110)
 * libreadline6-dev is not a valid Ubuntu 16.10 package [\#4172](https://github.com/rvm/rvm/issues/4172) 
+* libdb version fix for OpenSuSE tumbleweed [\#4178](https://github.com/rvm/rvm/issues/4178)
 
 #### Upgraded Ruby interpreters:
 * Add support for Ruby 2.2.8, 2.3.5 and 2.4.2 [\#4159](https://github.com/rvm/rvm/pull/4159)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 * Restore mvn installation for JRuby 1.7 [\#4166](https://github.com/rvm/rvm/issues/4166)
 * ree-1.8.7 requires old version of OpenSSL 1.0.2 [\#4110](https://github.com/rvm/rvm/issues/4110)
 * libreadline6-dev is not a valid Ubuntu 16.10 package [\#4172](https://github.com/rvm/rvm/issues/4172) 
-* libdb version fix for OpenSuSE tumbleweed [\#4178](https://github.com/rvm/rvm/issues/4178)
+* Require libdb-4.8 for OpenSuSE Tumbleweed [\#4178](https://github.com/rvm/rvm/issues/4178)
 
 #### Upgraded Ruby interpreters:
 * Add support for Ruby 2.2.8, 2.3.5 and 2.4.2 [\#4159](https://github.com/rvm/rvm/pull/4159)

--- a/scripts/functions/requirements/opensuse
+++ b/scripts/functions/requirements/opensuse
@@ -31,17 +31,17 @@ requirements_opensuse_install_custom()
 
 requirements_opensuse_define_default()
 {
-  libdb_minor_version=5
-
-  if [[ "${_system_name}" == *SuSE ]] && __rvm_version_compare "${_system_version}" -ge 12.0
-    then libdb_minor_version=8
+  if 
+    __rvm_version_compare "${_system_version}" -ge 12.0
+    then requirements_check libdb-4_8
+    else requirements_check libdb-4_5
   fi
 
   undesired_check libressl-devel
 
   requirements_check automake binutils bison bzip2 libtool m4 make patch \
     gdbm-devel glibc-devel libffi-devel libopenssl-devel readline-devel \
-    zlib-devel libdb-4_"${libdb_minor_version}" sqlite3-devel "$@"
+    zlib-devel sqlite3-devel "$@"
 
   case ${__type} in
     (suse)

--- a/scripts/functions/requirements/opensuse
+++ b/scripts/functions/requirements/opensuse
@@ -33,7 +33,7 @@ requirements_opensuse_define_default()
 {
   libdb_minor_version=5
 
-  if [[ "${_system_name}" == "SuSE" ]] && __rvm_version_compare "${_system_version}" -ge 12.0
+  if [[ "${_system_name}" == *SuSE ]] && __rvm_version_compare "${_system_version}" -ge 12.0
     then libdb_minor_version=8
   fi
 


### PR DESCRIPTION
Fixes https://github.com/rvm/rvm/issues/4178

Changes proposed in this pull request:
* Use the proper version of libdb in OpenSuSE tumbleweed

Make sure that your pull request includes entry in the [CHANGELOG](CHANGELOG.md).