### PR TITLE
Fix installing Ruby with LibreSSL and MacPorts (Issue #4208)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * `float_warnings` patches for Ruby 2.0.0p64[5 7 8], 2.1.[8 9 10], 2.2.[4 5 6 7 8], 2.3.[0 1 2 3 4 5] and 2.4.[0 1 2] [\#4201](https://github.com/rvm/rvm/pull/4201)
 
 #### Bug fixes:
+* Can't install Ruby with MacPorts and LibreSSL [\#4208](https://github.com/rvm/rvm/issues/4208)
 * ZSH Bad pattern for Gemfile ruby declaration [\#4154](https://github.com/rvm/rvm/issues/4154) [\#4156](https://github.com/rvm/rvm/issues/4156)
 * Add missing `random.c` patch for Ruby 2.3.2 [\#4165](https://github.com/rvm/rvm/issues/4165)
 * Set back IRB history default to HOME [\#4158](https://github.com/rvm/rvm/issues/4158)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@
 * `float_warnings` patches for Ruby 2.0.0p64[5 7 8], 2.1.[8 9 10], 2.2.[4 5 6 7 8], 2.3.[0 1 2 3 4 5] and 2.4.[0 1 2] [\#4201](https://github.com/rvm/rvm/pull/4201)
 
 #### Bug fixes:
-* Can't install Ruby with MacPorts and LibreSSL [\#4208](https://github.com/rvm/rvm/issues/4208)
 * ZSH Bad pattern for Gemfile ruby declaration [\#4154](https://github.com/rvm/rvm/issues/4154) [\#4156](https://github.com/rvm/rvm/issues/4156)
 * Add missing `random.c` patch for Ruby 2.3.2 [\#4165](https://github.com/rvm/rvm/issues/4165)
 * Set back IRB history default to HOME [\#4158](https://github.com/rvm/rvm/issues/4158)
@@ -25,6 +24,7 @@
 * Require make for JRuby 9 [\#4058](https://github.com/rvm/rvm/issues/4058)
 * Fix support for zsh 5.4.1 [bash_zsh_support \#6](https://github.com/mpapis/bash_zsh_support/pull/6)
 * Installing rbx-3.70 fails on PCLinuxOS 64-bit [\#3895](https://github.com/rvm/rvm/issues/3895)  
+* Can't install Ruby with MacPorts and LibreSSL [\#4208](https://github.com/rvm/rvm/issues/4208)
 
 #### Upgraded Ruby interpreters:
 * Add support for Ruby 2.2.8, 2.3.5 and 2.4.2 [\#4159](https://github.com/rvm/rvm/pull/4159)

--- a/scripts/functions/requirements/osx_port
+++ b/scripts/functions/requirements/osx_port
@@ -77,8 +77,15 @@ requirements_osx_port_libs_default()
       fi
       ;;
   esac
+  # LibreSSL is a fork of OpenSSL and is interchangable
+  # If it is installed, then don't worry about OpenSSL
+  if
+    ! requirements_osx_port_lib_installed libressl
+  then
+    port_libs+=( openssl )
+  fi
   port_libs+=(
-    libiconv libyaml libffi readline libksba openssl sqlite3 zlib gdbm
+    libiconv libyaml libffi readline libksba sqlite3 zlib gdbm
   )
   if
     requirements_osx_port_lib_installed ncursesw

--- a/scripts/functions/requirements/osx_port
+++ b/scripts/functions/requirements/osx_port
@@ -58,12 +58,14 @@ requirements_osx_port_before()
 requirements_osx_port_libs_default()
 {
   port_libs=(
-    autoconf automake libtool pkgconfig
+    autoconf automake gdbm libffi libiconv libksba libtool libyaml pkgconfig readline sqlite3 zlib
   )
+  
   case "$1" in
     (*-head) __rvm_which git >/dev/null || port_libs+=( git )
       ;;
   esac
+  
   __rvm_selected_compiler >/dev/null ||
   case "$1" in
     (ruby-1*|ree*)
@@ -77,6 +79,7 @@ requirements_osx_port_libs_default()
       fi
       ;;
   esac
+  
   # LibreSSL is a fork of OpenSSL and is interchangable
   # If it is installed, then don't worry about OpenSSL
   if
@@ -84,9 +87,7 @@ requirements_osx_port_libs_default()
   then
     port_libs+=( openssl )
   fi
-  port_libs+=(
-    libiconv libyaml libffi readline libksba sqlite3 zlib gdbm
-  )
+  
   if
     requirements_osx_port_lib_installed ncursesw
   then
@@ -97,6 +98,7 @@ Error! ncursesw was replaced by ncurses a long time ago, please uninstall 'ncurs
   else
     port_libs+=( ncurses  )
   fi
+  
   requirements_check_fallback curl-ca-bundle certsync || return $?
   requirements_check "${port_libs[@]}" || return $?
 }


### PR DESCRIPTION
Fixes #4208

Changes proposed in this pull request:
* When installing Ruby on OSX with MacPorts, don't try and install OpenSSL if LibreSSL is already installed.