### PR TITLE
Fix invalid `libgmp3-dev` requirement for Debian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Installing rbx-3.70 fails on PCLinuxOS 64-bit [\#3895](https://github.com/rvm/rvm/issues/3895)  
 * Can't install Ruby with MacPorts and LibreSSL [\#4208](https://github.com/rvm/rvm/issues/4208)
 * Fix invalid Ruby binary for CentOS 7 ruby-2.4.2 [\#4222](https://github.com/rvm/rvm/issues/4222)
+* Fix invalid `libgmp3-dev` requirement for Debian [\#4238](https://github.com/rvm/rvm/pull/4238)
 
 #### Upgraded Ruby interpreters:
 * Add support for Ruby 2.2.8, 2.3.5 and 2.4.2 [\#4159](https://github.com/rvm/rvm/pull/4159)

--- a/scripts/functions/requirements/debian
+++ b/scripts/functions/requirements/debian
@@ -117,7 +117,7 @@ requirements_debian_define_base()
   requirements_check "$@" \
     make libc6-dev patch openssl ca-certificates \
     curl zlib1g zlib1g-dev libyaml-dev \
-    libsqlite3-dev sqlite3 autoconf libgmp-dev \
+    libsqlite3-dev sqlite3 autoconf \
     libgdbm-dev libncurses5-dev automake libtool bison pkg-config libffi-dev
 
   requirements_${_system_name_lowercase}_define_libgmp


### PR DESCRIPTION
Fixes #3675
See https://github.com/rvm/rvm/issues/3675#issuecomment-344501157