### PR TITLE
Add ruby-version 2.4* on fedora requirement #4247

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Multi-colored log, warning and error messages [\#4044](https://github.com/rvm/rvm/pull/4044)
 
 #### Bug fixes:
+* Add ruby-2.4 on requirement for fedora [\#4247](https://github.com/rvm/rvm/issues/4247)
 * ZSH Bad pattern for Gemfile ruby declaration [\#4154](https://github.com/rvm/rvm/issues/4154) [\#4156](https://github.com/rvm/rvm/issues/4156)
 * Add missing `random.c` patch for Ruby 2.3.2 [\#4165](https://github.com/rvm/rvm/issues/4165)
 * Set back IRB history default to HOME [\#4158](https://github.com/rvm/rvm/issues/4158)

--- a/scripts/functions/requirements/fedora
+++ b/scripts/functions/requirements/fedora
@@ -3,7 +3,7 @@
 requirements_fedora_define_openssl()
 {
   case "$1" in
-    (ruby-2.3*|ruby-2.2*|ruby-2.1*|ruby-2.0*|ruby-1.9*|ruby-1.8*)
+    (ruby-2.4*|ruby-2.3*|ruby-2.2*|ruby-2.1*|ruby-2.0*|ruby-1.9*|ruby-1.8*)
       if
         __rvm_version_compare "${_system_version}" -ge 26
       then


### PR DESCRIPTION


Changes proposed in this pull request:
Add ruby-2.4 in fedora requirement.  #4247

