### PR TITLE
Ensure compat-openssl10-devel is not installed for Fedora 26+ and Ruby 2.4+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Installing rbx-3.70 fails on PCLinuxOS 64-bit [\#3895](https://github.com/rvm/rvm/issues/3895)  
 * Can't install Ruby with MacPorts and LibreSSL [\#4208](https://github.com/rvm/rvm/issues/4208)
 * Fix invalid `libgmp3-dev` requirement for Debian [\#4238](https://github.com/rvm/rvm/pull/4238)
+* Ensure compat-openssl10-devel is not installed for Fedora 26+ and Ruby 2.4+
 
 #### Upgraded Ruby interpreters:
 * Add support for Ruby 2.2.8, 2.3.5 and 2.4.2 [\#4159](https://github.com/rvm/rvm/pull/4159)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 * Installing rbx-3.70 fails on PCLinuxOS 64-bit [\#3895](https://github.com/rvm/rvm/issues/3895)  
 * Can't install Ruby with MacPorts and LibreSSL [\#4208](https://github.com/rvm/rvm/issues/4208)
 * Fix invalid `libgmp3-dev` requirement for Debian [\#4238](https://github.com/rvm/rvm/pull/4238)
-* Ensure compat-openssl10-devel is not installed for Fedora 26+ and Ruby 2.4+
+* Ensure compat-openssl10-devel is not installed for Fedora 26+ and Ruby 2.4+ [\#4249](https://github.com/rvm/rvm/pull/4249)
 
 #### Upgraded Ruby interpreters:
 * Add support for Ruby 2.2.8, 2.3.5 and 2.4.2 [\#4159](https://github.com/rvm/rvm/pull/4159)

--- a/scripts/functions/requirements/fedora
+++ b/scripts/functions/requirements/fedora
@@ -7,13 +7,16 @@ requirements_fedora_define_openssl()
       if
         __rvm_version_compare "${_system_version}" -ge 26
       then
+        undesired_check openssl-devel
         requirements_check compat-openssl10-devel
       else
+        undesired_check compat-openssl10-devel
         requirements_check openssl-devel
       fi
       ;;
 
     (*)
+      undesired_check compat-openssl10-devel
       requirements_check openssl-devel
       ;;
   esac


### PR DESCRIPTION
Fixes #4247
Fixes #4248