### PR TITLE
Set recommended MRI version to 2.5.0

### DIFF
--- a/config/db
+++ b/config/db
@@ -77,7 +77,7 @@ ruby_unmaintained_date=2017-04-01
 ruby_unmaintained_version=2.1.0
 ruby_url=https://cache.ruby-lang.org/pub/ruby
 ruby_url_fallback_1=https://ftp.ruby-lang.org/pub/ruby
-ruby_version=2.4.3
+ruby_version=2.5.0
 #
 # REE
 #


### PR DESCRIPTION
Follow-up from #4265.

This will make RVM install Ruby 2.5.0 when user do `rvm install ruby`.