### PR TITLE
Correctly look for rvm group in /etc/group.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
 * Fix installing rubygems 2.7 [\#4287](https://github.com/rvm/rvm/pull/4287)
 * Add prelude_gcc_diagnostic patch for Ruby 2.5.0 to correct compilation failures with GCC < 5
 * Fix installing rubygems master [\#3734](https://github.com/rvm/rvm/issues/3734)
-* Correctly look for rvm group in /etc/group
+* Correctly look for rvm group in /etc/group [\#4300](https://github.com/rvm/rvm/issues/4300)
 
 #### Upgraded Ruby interpreters:
 * Add support for Ruby 2.2.8, 2.3.5 and 2.4.2 [\#4159](https://github.com/rvm/rvm/pull/4159), 2.5.0-preview1 [\#4204](https://github.com/rvm/rvm/pull/4204), 2.2.9, 2.3.6, 2.4.3 and 2.5.0-rc1 [\#4261](https://github.com/rvm/rvm/pull/4261), 2.5.0 [\#4265](https://github.com/rvm/rvm/pull/4265)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * Fix installing rubygems 2.7 [\#4287](https://github.com/rvm/rvm/pull/4287)
 * Add prelude_gcc_diagnostic patch for Ruby 2.5.0 to correct compilation failures with GCC < 5
 * Fix installing rubygems master [\#3734](https://github.com/rvm/rvm/issues/3734)
+* Correctly look for rvm group in /etc/group
 
 #### Upgraded Ruby interpreters:
 * Add support for Ruby 2.2.8, 2.3.5 and 2.4.2 [\#4159](https://github.com/rvm/rvm/pull/4159), 2.5.0-preview1 [\#4204](https://github.com/rvm/rvm/pull/4204), 2.2.9, 2.3.6, 2.4.3 and 2.5.0-rc1 [\#4261](https://github.com/rvm/rvm/pull/4261), 2.5.0 [\#4265](https://github.com/rvm/rvm/pull/4265)

--- a/scripts/functions/group
+++ b/scripts/functions/group
@@ -55,7 +55,7 @@ __rvm_group_exists()
       dscl . -read "/Groups/$1" 1>/dev/null 2>&1 || return $?
       ;;
     (*)
-      __rvm_grep "$1" /etc/group >/dev/null 2>&1
+      __rvm_grep "^$1:" /etc/group >/dev/null 2>&1
       ;;
   esac
 }


### PR DESCRIPTION
Fixes #4296 .

Changes proposed in this pull request:
* Use an improved regular expression to avoid matching group names that contain the string `rvm`
