### PR TITLE
Capturing grep for #ruby= in variable to handle error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * Allow building static ruby with --disbale-shared [\#4091](https://github.com/rvm/rvm/issues/4091)
 * Restore detection of `gpg` command for veryfication of signatures [\#4059](https://github.com/rvm/rvm/issues/4059)
 * Update gem-wrappers to 1.3.2: Avoid nested chdir warnings [gem-wrappers \#11](https://github.com/rvm/gem-wrappers/pull/11)
+* Cleanup found project file reject reasons [\4314](https://github.com/rvm/rvm/pull/4314)
 
 #### Upgraded Ruby interpreters:
 * Add support for Rubinius 3.82, 3.83, 3.84

--- a/scripts/functions/rvmrc_project
+++ b/scripts/functions/rvmrc_project
@@ -202,22 +202,17 @@ __rvm_project_dir_check()
   __rvm_find_first_file _found_file "${_valid_files[@]}" || true
 
   if
-    [[ "${_found_file##*/}" == "Gemfile" ]]
+    [[ ! -s "$_found_file" ||
+      "${_found_file}" == "$HOME/.rvmrc"
+    ]]
   then
-     if
-      [[ -s "$_found_file" ]] && {
-        _did_find=$(__rvm_grep    "^#ruby="  "$_found_file" ||
-        __rvm_grep -E "^\s*ruby" "$_found_file") || true;         
-      }
-    then
-     if [[ "$_did_find" != "" ]]; then true;
-    else
-      _found_file="";
-    fi
+    _found_file=""
   elif
-    [[ "${_found_file}" == "$HOME/.rvmrc" ]]
+    [[ "${_found_file##*/}" == "Gemfile" ]] &&
+    ! __rvm_grep    "^#ruby="  "$_found_file" >/dev/null &&
+    ! __rvm_grep -E "^\s*ruby" "$_found_file" >/dev/null
   then
-    _found_file="";
+    _found_file=""
   fi
 
   if [[ -n "$variable" ]]

--- a/scripts/functions/rvmrc_project
+++ b/scripts/functions/rvmrc_project
@@ -204,20 +204,20 @@ __rvm_project_dir_check()
   if
     [[ "${_found_file##*/}" == "Gemfile" ]]
   then
-    if
+     if
       [[ -s "$_found_file" ]] && {
-        __rvm_grep    "^#ruby="  "$_found_file" >/dev/null ||
-        __rvm_grep -E "^\s*ruby" "$_found_file" >/dev/null
+        _did_find=$(__rvm_grep    "^#ruby="  "$_found_file" ||
+        __rvm_grep -E "^\s*ruby" "$_found_file") || true;         
       }
     then
-      true
+     if [[ "$_did_find" != "" ]]; then true;
     else
-      _found_file=""
+      _found_file="";
     fi
   elif
     [[ "${_found_file}" == "$HOME/.rvmrc" ]]
   then
-    _found_file=""
+    _found_file="";
   fi
 
   if [[ -n "$variable" ]]


### PR DESCRIPTION
Capturing the return from __rmv_grep in a variable, and checking that, rather than letting it return a non-zero exit code.  The previous way would fail a bash script if set -e was enabled.   This way, we continue on failure with a non-zero exit code, but still check if we find a file with the #ruby in it.