### PR TITLE
Update jruby alias to JRuby 9.1.16.0

### DIFF
--- a/config/known
+++ b/config/known
@@ -17,7 +17,7 @@ ruby-head
 # JRuby
 jruby-1.6[.8]
 jruby-1.7[.27]
-jruby[-9.1.15.0]
+jruby[-9.1.16.0]
 jruby-head
 
 # Rubinius


### PR DESCRIPTION
Here are the release notes: http://jruby.org/2018/02/21/jruby-9-1-16-0.html
