### PR TITLE
Add support for installing Ruby <2.4 on Ubuntu 17.10+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * RailsExpress patches for 2.5.0 [\#4268](https://github.com/rvm/rvm/pull/4268)
 * Update README including Table of Contents to help improve documentation readability [\#4277](https://github.com/rvm/rvm/pull/4277)
 * Set default RubyGems to 2.7 [\#4276](https://github.com/rvm/rvm/issues/4276)
+* Add support for installing Ruby <2.4 on Ubuntu 17.10+
 
 #### Bug fixes:
 * ZSH Bad pattern for Gemfile ruby declaration [\#4154](https://github.com/rvm/rvm/issues/4154) [\#4156](https://github.com/rvm/rvm/issues/4156)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 * RailsExpress patches for 2.5.0 [\#4268](https://github.com/rvm/rvm/pull/4268)
 * Update README including Table of Contents to help improve documentation readability [\#4277](https://github.com/rvm/rvm/pull/4277)
 * Set default RubyGems to 2.7 [\#4276](https://github.com/rvm/rvm/issues/4276)
-* Add support for installing Ruby <2.4 on Ubuntu 17.10+
+* Add support for installing Ruby <2.4 on Ubuntu 17.10+ [\#4326](https://github.com/rvm/rvm/pull/4326)
 
 #### Bug fixes:
 * ZSH Bad pattern for Gemfile ruby declaration [\#4154](https://github.com/rvm/rvm/issues/4154) [\#4156](https://github.com/rvm/rvm/issues/4156)

--- a/scripts/functions/requirements/debian
+++ b/scripts/functions/requirements/debian
@@ -92,13 +92,14 @@ requirements_debian_define_libreadline()
 
 requirements_debian_define_libssl()
 {
+  # Legacy libssl-dev required by older version of ruby has been renamed to libssl1.0-dev
+  # starting from Debian 9 (Stretch)
+
   case "$1" in
     (ruby-2.3*|ruby-2.2*|ruby-2.1*|ruby-2.0*|ruby-1.9*)
       if
         __rvm_version_compare ${_system_version} -ge 9
       then
-        # legacy libssl-dev required by older version of ruby has been renamed to libssl1.0-dev
-        # starting from Debian 9 (Stretch)
         undesired_check libssl-dev
         requirements_check libssl1.0-dev
       else

--- a/scripts/functions/requirements/ubuntu
+++ b/scripts/functions/requirements/ubuntu
@@ -20,7 +20,25 @@ requirements_ubuntu_define_libreadline()
 
 requirements_ubuntu_define_libssl()
 {
-  requirements_check libssl-dev
+  # Legacy libssl-dev required by older version of ruby has been renamed to libssl1.0-dev
+  # starting from Ubuntu 17.10 (Artful Aardvark)
+
+  case "$1" in
+    (ruby-2.3*|ruby-2.2*|ruby-2.1*|ruby-2.0*|ruby-1.9*)
+      if
+        __rvm_version_compare ${_system_version} -ge 17.10
+      then
+        undesired_check libssl-dev
+        requirements_check libssl1.0-dev
+      else
+        requirements_check libssl-dev
+      fi
+      ;;
+
+    (*)
+      requirements_check libssl-dev
+      ;;
+  esac
 }
 
 requirements_ubuntu_define()


### PR DESCRIPTION
Refs #3862
