### PR TITLE
RailsExpress patchsets for 2.2.10, 2.3.7, 2.4.4 and 2.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@
 * Update README including Table of Contents to help improve documentation readability [\#4277](https://github.com/rvm/rvm/pull/4277)
 * Set default RubyGems to 2.7 [\#4276](https://github.com/rvm/rvm/issues/4276)
 * Add support for installing Ruby <2.4 on Ubuntu 17.10+ [\#4326](https://github.com/rvm/rvm/pull/4326)
-* Add support for installing Rubinius on Redhat/Fedora [\#4329](https://github.com/rvm/rvm/pull/4329)
+* Add support for installing Rubinius on Redhat/Fedora
+  [\#4329](https://github.com/rvm/rvm/pull/4329)
+* RailsExpress patches for 2.2.10, 2.3.7, 2.4.4 and 2.5.1 [\#4344](https://github.com/rvm/rvm/pull/4344)
 
 #### Bug fixes:
 * ZSH Bad pattern for Gemfile ruby declaration [\#4154](https://github.com/rvm/rvm/issues/4154) [\#4156](https://github.com/rvm/rvm/issues/4156)

--- a/patchsets/ruby/2.2.10/railsexpress
+++ b/patchsets/ruby/2.2.10/railsexpress
@@ -1,0 +1,3 @@
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.2.10/railsexpress/01-zero-broken-tests.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.2.10/railsexpress/02-improve-gc-stats.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.2.10/railsexpress/03-display-more-detailed-stack-trace.patch

--- a/patchsets/ruby/2.3.7/railsexpress
+++ b/patchsets/ruby/2.3.7/railsexpress
@@ -1,0 +1,3 @@
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.3.7/railsexpress/01-skip-broken-tests.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.3.7/railsexpress/02-improve-gc-stats.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.3.7/railsexpress/03-display-more-detailed-stack-trace.patch

--- a/patchsets/ruby/2.4.4/railsexpress
+++ b/patchsets/ruby/2.4.4/railsexpress
@@ -1,0 +1,3 @@
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.4.4/railsexpress/01-skip-broken-tests.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.4.4/railsexpress/02-improve-gc-stats.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.4.4/railsexpress/03-display-more-detailed-stack-trace.patch

--- a/patchsets/ruby/2.5.1/railsexpress
+++ b/patchsets/ruby/2.5.1/railsexpress
@@ -1,0 +1,3 @@
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.5.1/railsexpress/01-fix-broken-tests-caused-by-ad.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.5.1/railsexpress/02-improve-gc-stats.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.5.1/railsexpress/03-more-detailed-stacktrace.patch


### PR DESCRIPTION
These are for the security based latest ruby releases.