### PR TITLE
Avoid unnecessary install warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 * Fix installing rubygems master [\#3734](https://github.com/rvm/rvm/issues/3734)
 * Correctly look for rvm group in /etc/group [\#4300](https://github.com/rvm/rvm/issues/4300)
 * Drop homebrew/versions and upgrade gcc to 6.0 [\#4304](https://github.com/rvm/rvm/pull/4304)
+* Avoid unnecessary install warning [\4346](https://github.com/rvm/rvm/pull/4346)
 
 #### Upgraded Ruby interpreters:
 * Add support for Ruby 2.2.8, 2.3.5 and 2.4.2 [\#4159](https://github.com/rvm/rvm/pull/4159), 2.5.0-preview1 [\#4204](https://github.com/rvm/rvm/pull/4204), 2.2.9, 2.3.6, 2.4.3 and 2.5.0-rc1 [\#4261](https://github.com/rvm/rvm/pull/4261), 2.5.0 [\#4265](https://github.com/rvm/rvm/pull/4265), 2.6.0-preview1 [\#4317](https://github.com/rvm/rvm/pull/4317), 2.2.10, 2.3.7, 2.4.4 and 2.5.1 [\#4340](https://github.com/rvm/rvm/pull/4340)

--- a/scripts/functions/installer
+++ b/scripts/functions/installer
@@ -1303,6 +1303,7 @@ migrate_environments_and_wrappers()
 
 create_gems_aliases()
 {
+  [[ -s "$rvm_path/config/alias" ]] || return 0
   \typeset __alias __ruby
   \typeset -a __aliases
   __rvm_read_lines __aliases "$rvm_path/config/alias"


### PR DESCRIPTION
Aliases cleanup was issuing unnecessary warning about missing config/alias
Added check for file existence to avoid the warning