### PR TITLE
Limit s3 lookup of rbx to correct versions (fixes #4311)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 * Add support for installing Rubinius on Redhat/Fedora [\#4329](https://github.com/rvm/rvm/pull/4329)
 * Installing Rubinius on Ubuntu 17.x [\#4213](https://github.com/rvm/rvm/pull/4213)
 * RailsExpress patches for 2.2.10, 2.3.7, 2.4.4 and 2.5.1 [\#4344](https://github.com/rvm/rvm/pull/4344)
-* Whitelist Rubinius versions hosted on s3, use git for all others [\#4311](https://github.com/rvm/rvm/pull/4349)
+* Whitelist Rubinius versions hosted on s3, use git for all others; fixes [\#4311](https://github.com/rvm/rvm/issues/4311) [\#4349](https://github.com/rvm/rvm/pull/4349)
 
 #### Bug fixes:
 * ZSH Bad pattern for Gemfile ruby declaration [\#4154](https://github.com/rvm/rvm/issues/4154) [\#4156](https://github.com/rvm/rvm/issues/4156)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Add support for installing Rubinius on Redhat/Fedora [\#4329](https://github.com/rvm/rvm/pull/4329)
 * Installing Rubinius on Ubuntu 17.x [\#4213](https://github.com/rvm/rvm/pull/4213)
 * RailsExpress patches for 2.2.10, 2.3.7, 2.4.4 and 2.5.1 [\#4344](https://github.com/rvm/rvm/pull/4344)
+* Whitelist Rubinius versions hosted on s3, use git for all others [\#4311]()
 
 #### Bug fixes:
 * ZSH Bad pattern for Gemfile ruby declaration [\#4154](https://github.com/rvm/rvm/issues/4154) [\#4156](https://github.com/rvm/rvm/issues/4156)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 * Add support for installing Rubinius on Redhat/Fedora [\#4329](https://github.com/rvm/rvm/pull/4329)
 * Installing Rubinius on Ubuntu 17.x [\#4213](https://github.com/rvm/rvm/pull/4213)
 * RailsExpress patches for 2.2.10, 2.3.7, 2.4.4 and 2.5.1 [\#4344](https://github.com/rvm/rvm/pull/4344)
-* Whitelist Rubinius versions hosted on s3, use git for all others [\#4311]()
+* Whitelist Rubinius versions hosted on s3, use git for all others [\#4311](https://github.com/rvm/rvm/pull/4349)
 
 #### Bug fixes:
 * ZSH Bad pattern for Gemfile ruby declaration [\#4154](https://github.com/rvm/rvm/issues/4154) [\#4156](https://github.com/rvm/rvm/issues/4156)

--- a/config/db
+++ b/config/db
@@ -105,6 +105,7 @@ rbx_1.2.2_patch_level=20110222
 rbx_1.2.3_patch_level=20110315
 rbx_1.2.4_patch_level=20110705
 rbx_repo_url=https://github.com/rubinius/rubinius.git
+rbx_s3_versions="0.12 0.13.0 1.0.0 1.0.1 1.1.0 1.1.1 1.2.0 1.2.1 1.2.2 1.2.3 1.2.4 2.0.0.n199 2.0.0.rc1 2.0.0dev"
 rbx_url=https://s3.amazonaws.com/asset.rubini.us
 rbx_url_2.0_and_newer=https://rubinius-releases-rubinius-com.s3.amazonaws.com
 rbx_version=3.100

--- a/scripts/functions/selector_interpreters
+++ b/scripts/functions/selector_interpreters
@@ -74,7 +74,10 @@ __rvm_select_interpreter_rbx()
 
   __rvm_select_rbx_compatibility_branch
 
+  rbx_s3_versions=${rbx_s3_versions:-$(__rvm_db "rbx_s3_versions")}
+  
   if
+    [[ -z "${rbx_s3_versions##*$rvm_ruby_version*}" ]] &&
     (( ${rvm_head_flag:=1} == 0 )) &&
     [[ -z "${rvm_ruby_repo_branch:-}" ]] &&
     [[ "${rvm_ruby_version}" != "head" ]]


### PR DESCRIPTION
Fixes #4311.

Changes proposed in this pull request: 
* add whitelist of s3-hosted versions of rbx
* check against whitelist, use git for all other rbx versions