### PR TITLE
Extend ruby 798 patch to ruby 2.2 versions that don't have it.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 * Avoid unnecessary install warning [\#4346](https://github.com/rvm/rvm/pull/4346)
 * Unified putput of installation notes [\#4330](https://github.com/rvm/rvm/pull/4330)
 * Skip gemset pristine on mruby reinstall [\#4348](https://github.com/rvm/rvm/pull/4348)
+* Ruby 2.2.5 to 2.2.10 patches for installing bundled gems [\#4358](https://github.com/rvm/rvm/issues/4358)
 
 #### Upgraded Ruby interpreters:
 * Add support for Ruby 2.2.8, 2.3.5 and 2.4.2 [\#4159](https://github.com/rvm/rvm/pull/4159), 2.5.0-preview1 [\#4204](https://github.com/rvm/rvm/pull/4204), 2.2.9, 2.3.6, 2.4.3 and 2.5.0-rc1 [\#4261](https://github.com/rvm/rvm/pull/4261), 2.5.0 [\#4265](https://github.com/rvm/rvm/pull/4265), 2.6.0-preview1 [\#4317](https://github.com/rvm/rvm/pull/4317), 2.2.10, 2.3.7, 2.4.4 and 2.5.1 [\#4340](https://github.com/rvm/rvm/pull/4340)

--- a/patches/ruby/2.2.10/fix_installing_bundled_gems.patch
+++ b/patches/ruby/2.2.10/fix_installing_bundled_gems.patch
@@ -1,0 +1,21 @@
+--- a/tool/rbinstall.rb
++++ b/tool/rbinstall.rb
+@@ -719,15 +719,15 @@ install?(:ext, :comm, :gem) do
+     directories = Gem.ensure_gem_subdirectories(gem_dir, :mode => $dir_mode)
+     prepare "bundle gems", gem_dir, directories
+     Dir.glob(srcdir+'/gems/*.gem').each do |gem|
+-      Gem.install gem, Gem::Requirement.default, :install_dir => with_destdir(Gem.dir), :domain => :local, :ignore_dependencies => true
++      Gem.install gem, Gem::Requirement.default, :install_dir => with_destdir(gem_dir), :domain => :local, :ignore_dependencies => true
+       gemname = Pathname(gem).basename
+       puts "#{" "*30}#{gemname}"
+     end
+     # fix directory permissions
+     # TODO: Gem.install should accept :dir_mode option or something
+-    File.chmod($dir_mode, *Dir.glob(with_destdir(Gem.dir)+"/**/"))
++    File.chmod($dir_mode, *Dir.glob(with_destdir(gem_dir)+"/**/"))
+     # fix .gemspec permissions
+-    File.chmod($data_mode, *Dir.glob(with_destdir(Gem.dir)+"/specifications/*.gemspec"))
++    File.chmod($data_mode, *Dir.glob(with_destdir(gem_dir)+"/specifications/*.gemspec"))
+   else
+     puts "skip installing bundle gems because of lacking zlib"
+   end

--- a/patches/ruby/2.2.5/fix_installing_bundled_gems.patch
+++ b/patches/ruby/2.2.5/fix_installing_bundled_gems.patch
@@ -1,0 +1,21 @@
+--- a/tool/rbinstall.rb
++++ b/tool/rbinstall.rb
+@@ -719,15 +719,15 @@ install?(:ext, :comm, :gem) do
+     directories = Gem.ensure_gem_subdirectories(gem_dir, :mode => $dir_mode)
+     prepare "bundle gems", gem_dir, directories
+     Dir.glob(srcdir+'/gems/*.gem').each do |gem|
+-      Gem.install gem, Gem::Requirement.default, :install_dir => with_destdir(Gem.dir), :domain => :local, :ignore_dependencies => true
++      Gem.install gem, Gem::Requirement.default, :install_dir => with_destdir(gem_dir), :domain => :local, :ignore_dependencies => true
+       gemname = Pathname(gem).basename
+       puts "#{" "*30}#{gemname}"
+     end
+     # fix directory permissions
+     # TODO: Gem.install should accept :dir_mode option or something
+-    File.chmod($dir_mode, *Dir.glob(with_destdir(Gem.dir)+"/**/"))
++    File.chmod($dir_mode, *Dir.glob(with_destdir(gem_dir)+"/**/"))
+     # fix .gemspec permissions
+-    File.chmod($data_mode, *Dir.glob(with_destdir(Gem.dir)+"/specifications/*.gemspec"))
++    File.chmod($data_mode, *Dir.glob(with_destdir(gem_dir)+"/specifications/*.gemspec"))
+   else
+     puts "skip installing bundle gems because of lacking zlib"
+   end

--- a/patches/ruby/2.2.6/fix_installing_bundled_gems.patch
+++ b/patches/ruby/2.2.6/fix_installing_bundled_gems.patch
@@ -1,0 +1,21 @@
+--- a/tool/rbinstall.rb
++++ b/tool/rbinstall.rb
+@@ -719,15 +719,15 @@ install?(:ext, :comm, :gem) do
+     directories = Gem.ensure_gem_subdirectories(gem_dir, :mode => $dir_mode)
+     prepare "bundle gems", gem_dir, directories
+     Dir.glob(srcdir+'/gems/*.gem').each do |gem|
+-      Gem.install gem, Gem::Requirement.default, :install_dir => with_destdir(Gem.dir), :domain => :local, :ignore_dependencies => true
++      Gem.install gem, Gem::Requirement.default, :install_dir => with_destdir(gem_dir), :domain => :local, :ignore_dependencies => true
+       gemname = Pathname(gem).basename
+       puts "#{" "*30}#{gemname}"
+     end
+     # fix directory permissions
+     # TODO: Gem.install should accept :dir_mode option or something
+-    File.chmod($dir_mode, *Dir.glob(with_destdir(Gem.dir)+"/**/"))
++    File.chmod($dir_mode, *Dir.glob(with_destdir(gem_dir)+"/**/"))
+     # fix .gemspec permissions
+-    File.chmod($data_mode, *Dir.glob(with_destdir(Gem.dir)+"/specifications/*.gemspec"))
++    File.chmod($data_mode, *Dir.glob(with_destdir(gem_dir)+"/specifications/*.gemspec"))
+   else
+     puts "skip installing bundle gems because of lacking zlib"
+   end

--- a/patches/ruby/2.2.7/fix_installing_bundled_gems.patch
+++ b/patches/ruby/2.2.7/fix_installing_bundled_gems.patch
@@ -1,0 +1,21 @@
+--- a/tool/rbinstall.rb
++++ b/tool/rbinstall.rb
+@@ -719,15 +719,15 @@ install?(:ext, :comm, :gem) do
+     directories = Gem.ensure_gem_subdirectories(gem_dir, :mode => $dir_mode)
+     prepare "bundle gems", gem_dir, directories
+     Dir.glob(srcdir+'/gems/*.gem').each do |gem|
+-      Gem.install gem, Gem::Requirement.default, :install_dir => with_destdir(Gem.dir), :domain => :local, :ignore_dependencies => true
++      Gem.install gem, Gem::Requirement.default, :install_dir => with_destdir(gem_dir), :domain => :local, :ignore_dependencies => true
+       gemname = Pathname(gem).basename
+       puts "#{" "*30}#{gemname}"
+     end
+     # fix directory permissions
+     # TODO: Gem.install should accept :dir_mode option or something
+-    File.chmod($dir_mode, *Dir.glob(with_destdir(Gem.dir)+"/**/"))
++    File.chmod($dir_mode, *Dir.glob(with_destdir(gem_dir)+"/**/"))
+     # fix .gemspec permissions
+-    File.chmod($data_mode, *Dir.glob(with_destdir(Gem.dir)+"/specifications/*.gemspec"))
++    File.chmod($data_mode, *Dir.glob(with_destdir(gem_dir)+"/specifications/*.gemspec"))
+   else
+     puts "skip installing bundle gems because of lacking zlib"
+   end

--- a/patches/ruby/2.2.8/fix_installing_bundled_gems.patch
+++ b/patches/ruby/2.2.8/fix_installing_bundled_gems.patch
@@ -1,0 +1,21 @@
+--- a/tool/rbinstall.rb
++++ b/tool/rbinstall.rb
+@@ -719,15 +719,15 @@ install?(:ext, :comm, :gem) do
+     directories = Gem.ensure_gem_subdirectories(gem_dir, :mode => $dir_mode)
+     prepare "bundle gems", gem_dir, directories
+     Dir.glob(srcdir+'/gems/*.gem').each do |gem|
+-      Gem.install gem, Gem::Requirement.default, :install_dir => with_destdir(Gem.dir), :domain => :local, :ignore_dependencies => true
++      Gem.install gem, Gem::Requirement.default, :install_dir => with_destdir(gem_dir), :domain => :local, :ignore_dependencies => true
+       gemname = Pathname(gem).basename
+       puts "#{" "*30}#{gemname}"
+     end
+     # fix directory permissions
+     # TODO: Gem.install should accept :dir_mode option or something
+-    File.chmod($dir_mode, *Dir.glob(with_destdir(Gem.dir)+"/**/"))
++    File.chmod($dir_mode, *Dir.glob(with_destdir(gem_dir)+"/**/"))
+     # fix .gemspec permissions
+-    File.chmod($data_mode, *Dir.glob(with_destdir(Gem.dir)+"/specifications/*.gemspec"))
++    File.chmod($data_mode, *Dir.glob(with_destdir(gem_dir)+"/specifications/*.gemspec"))
+   else
+     puts "skip installing bundle gems because of lacking zlib"
+   end

--- a/patches/ruby/2.2.9/fix_installing_bundled_gems.patch
+++ b/patches/ruby/2.2.9/fix_installing_bundled_gems.patch
@@ -1,0 +1,21 @@
+--- a/tool/rbinstall.rb
++++ b/tool/rbinstall.rb
+@@ -719,15 +719,15 @@ install?(:ext, :comm, :gem) do
+     directories = Gem.ensure_gem_subdirectories(gem_dir, :mode => $dir_mode)
+     prepare "bundle gems", gem_dir, directories
+     Dir.glob(srcdir+'/gems/*.gem').each do |gem|
+-      Gem.install gem, Gem::Requirement.default, :install_dir => with_destdir(Gem.dir), :domain => :local, :ignore_dependencies => true
++      Gem.install gem, Gem::Requirement.default, :install_dir => with_destdir(gem_dir), :domain => :local, :ignore_dependencies => true
+       gemname = Pathname(gem).basename
+       puts "#{" "*30}#{gemname}"
+     end
+     # fix directory permissions
+     # TODO: Gem.install should accept :dir_mode option or something
+-    File.chmod($dir_mode, *Dir.glob(with_destdir(Gem.dir)+"/**/"))
++    File.chmod($dir_mode, *Dir.glob(with_destdir(gem_dir)+"/**/"))
+     # fix .gemspec permissions
+-    File.chmod($data_mode, *Dir.glob(with_destdir(Gem.dir)+"/specifications/*.gemspec"))
++    File.chmod($data_mode, *Dir.glob(with_destdir(gem_dir)+"/specifications/*.gemspec"))
+   else
+     puts "skip installing bundle gems because of lacking zlib"
+   end

--- a/patchsets/ruby/2.2.10/default
+++ b/patchsets/ruby/2.2.10/default
@@ -1,2 +1,1 @@
 fix_installing_bundled_gems
-openssl3

--- a/patchsets/ruby/2.2.6/default
+++ b/patchsets/ruby/2.2.6/default
@@ -1,2 +1,1 @@
 fix_installing_bundled_gems
-openssl3

--- a/patchsets/ruby/2.2.7/default
+++ b/patchsets/ruby/2.2.7/default
@@ -1,2 +1,1 @@
 fix_installing_bundled_gems
-openssl3

--- a/patchsets/ruby/2.2.8/default
+++ b/patchsets/ruby/2.2.8/default
@@ -1,2 +1,1 @@
 fix_installing_bundled_gems
-openssl3

--- a/patchsets/ruby/2.2.9/default
+++ b/patchsets/ruby/2.2.9/default
@@ -1,2 +1,1 @@
 fix_installing_bundled_gems
-openssl3


### PR DESCRIPTION
Copied the ruby-2.2.4 patch to ruby-2.2.5 to ruby-2.2.10.

Fixes #4358.