### PR TITLE
Do not use rubygems-bundler on TruffleRuby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 * Skip gemset pristine on mruby reinstall [\#4348](https://github.com/rvm/rvm/pull/4348)
 * Ruby 2.2.5 to 2.2.10 patches for installing bundled gems [\#4358](https://github.com/rvm/rvm/issues/4358)
 * Update RBX dependencies for OpenSUSE [\#4382](https://github.com/rvm/rvm/pull/4382)
+* Do not use rubygems-bundler on TruffleRuby [\#4409](https://github.com/rvm/rvm/pull/4409)
 
 #### Upgraded Ruby interpreters:
 * Add support for Ruby 2.2.8, 2.3.5 and 2.4.2 [\#4159](https://github.com/rvm/rvm/pull/4159), 2.5.0-preview1 [\#4204](https://github.com/rvm/rvm/pull/4204), 2.2.9, 2.3.6, 2.4.3 and 2.5.0-rc1 [\#4261](https://github.com/rvm/rvm/pull/4261), 2.5.0 [\#4265](https://github.com/rvm/rvm/pull/4265), 2.6.0-preview1 [\#4317](https://github.com/rvm/rvm/pull/4317), 2.2.10, 2.3.7, 2.4.4, 2.5.1 [\#4340](https://github.com/rvm/rvm/pull/4340) and 2.6.0-preview2[\#4395](https://github.com/rvm/rvm/pull/4395)

--- a/gemsets/truffleruby/global.gems
+++ b/gemsets/truffleruby/global.gems
@@ -1,0 +1,2 @@
+gem-wrappers
+rvm


### PR DESCRIPTION
* Fixes #4408.
* Avoid changing the behavior of standard Ruby executables.
* No need to install rake, it is part of the standard library.

This seems the most straightforward solution to #4408.
`rubygems-bundler` and its dependencies `executable-hooks` and `bundler-unload` are no longer installed by RVM for TruffleRuby.

This seems saner to me, as `rake`, `ri`, `rdoc`, etc behave like they do outside of RVM and are not changed to load Bundler or have a broken shebang.
This means as TruffleRuby developers we can support these executables and rely on less magic for users (no special RVM-specific behavior).
That said, I'm open to other solutions, but we need to fix this quickly.

As a side note, `gem-wrappers` itself is fine as it just generates some extra files outside of `PATH`, so I kept that gem as it seems mostly harmless (and it's anyway installed in `run_gem_wrappers()`).

Relates to #4297.

cc @mpapis @havenwood 