### PR TITLE
Call __rvm_setup_compile_environment() for TruffleRuby

### DIFF
--- a/scripts/functions/manage/truffleruby
+++ b/scripts/functions/manage/truffleruby
@@ -13,6 +13,7 @@ https://github.com/oracle/truffleruby/blob/master/doc/user/installing-llvm.md"
 
 truffleruby_install()
 {
+  __rvm_setup_compile_environment "${rvm_ruby_string}" || return $?
   truffleruby_install_check_llvm || return $?
 
   __rvm_cd "${rvm_src_path}"


### PR DESCRIPTION
* So necessary packages get installed and the per-distribution logic gets triggered.

I missed the fact `__rvm_setup_compile_environment()` is the function triggering the per-distribution logic to install packages in https://github.com/rvm/rvm/pull/4406.

cc @mpapis @havenwood 

Relates to #4297.