### PR TITLE
Reuse the logic for MRI/Rubinius for TruffleRuby for requirements on macOS

### DIFF
--- a/scripts/functions/requirements/osx_brew
+++ b/scripts/functions/requirements/osx_brew
@@ -301,6 +301,9 @@ requirements_osx_brew_libs_default()
         (rbx*head|rubinius*head)
             brew_libs_conf+=( llvm )
             ;;
+        (truffleruby*)
+            brew_libs_conf+=( llvm@4 )
+            ;;
         (*)
           __ruby_clang_ok "$1" ||
           requirements_osx_brew_libs_default_check_gcc ||
@@ -325,6 +328,10 @@ requirements_osx_brew_libs_default()
       ;;
 
     (ruby-2.3*|ruby-2.2*|ruby-2.1*|ruby-2.0*|ruby-1.9*|ruby-1.8*)
+      brew_openssl_package="openssl"
+      ;;
+
+    (truffleruby*)
       brew_openssl_package="openssl"
       ;;
 
@@ -369,7 +376,7 @@ requirements_osx_brew_define()
       ;;
 
     (truffleruby*)
-      requirements_check openssl llvm@4
+      requirements_osx_brew_libs_default "$1"
       ;;
 
     (ruby*head)


### PR DESCRIPTION
* requirements_osx_brew_after() expects some global variables to be set,
  notably $brew_libs, $brew_libs_conf and $brew_openssl_package.

@havenwood told me the logic on macOS for TruffleRuby wasn't quite working as expected.
Now TruffleRuby uses the same logic as MRI/Rubinius, as there are complex dependencies between functions due to global variables used within `requirements_osx_brew_after()`.
This installs a few more packages than needed (`autoconf`, `automake`), but for now this seems the safer and simpler fix.

Relates to #4297.