### PR TITLE
Fix nailgun detection on JRuby 9+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 * Skip gemset pristine on mruby reinstall [\#4348](https://github.com/rvm/rvm/pull/4348)
 * Ruby 2.2.5 to 2.2.10 patches for installing bundled gems [\#4358](https://github.com/rvm/rvm/issues/4358)
 * Update RBX dependencies for OpenSUSE [\#4382](https://github.com/rvm/rvm/pull/4382)
+* Fix nailgun detection on JRuby 9+ [\#4089](https://github.com/rvm/rvm/issues/4089)
 
 #### Upgraded Ruby interpreters:
 * Add support for Ruby 2.2.8, 2.3.5 and 2.4.2 [\#4159](https://github.com/rvm/rvm/pull/4159), 2.5.0-preview1 [\#4204](https://github.com/rvm/rvm/pull/4204), 2.2.9, 2.3.6, 2.4.3 and 2.5.0-rc1 [\#4261](https://github.com/rvm/rvm/pull/4261), 2.5.0 [\#4265](https://github.com/rvm/rvm/pull/4265), 2.6.0-preview1 [\#4317](https://github.com/rvm/rvm/pull/4317), 2.2.10, 2.3.7, 2.4.4, 2.5.1 [\#4340](https://github.com/rvm/rvm/pull/4340) and 2.6.0-preview2[\#4395](https://github.com/rvm/rvm/pull/4395)

--- a/scripts/functions/hooks/jruby
+++ b/scripts/functions/hooks/jruby
@@ -4,7 +4,7 @@ export JRUBY_OPTS
 
 jruby_ngserver_is_running()
 {
-  \command \ps auxww | __rvm_grep '[c]om.martiansoftware.nailgun.NGServer' >/dev/null
+  \command \ps auxww | __rvm_grep -e '[o]rg.jruby.main.NailServerMain' -e '[c]om.martiansoftware.nailgun.NGServer' >/dev/null
 }
 
 jruby_ngserver_start()


### PR DESCRIPTION
JRuby 9+ runs nailgun with an org.jruby.main.NailServerMain wrapper.
JRuby 1.7.x calls com.martiansoftware.nailgun.NGServer directly.
Check for both when attempting to see if nailgun is running.

Fixes #4089.