### PR TITLE
Add jruby-9.2 alias

### DIFF
--- a/config/known
+++ b/config/known
@@ -19,6 +19,7 @@ ruby-head
 jruby-1.6[.8]
 jruby-1.7[.27]
 jruby-9.1[.17.0]
+jruby-9.2[.0.0]
 jruby[-9.2.0.0]
 jruby-head
 


### PR DESCRIPTION
Can we have both this and `jruby[-9.2.0.0]` or will they cause conflicts?

(I can add the CHANGELOG entry if you are fine with the change, change was made right in the web UI so sorry for it not being present already.)