### PR TITLE
Save/restore bash traps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 * Skip gemset pristine on mruby reinstall [\#4348](https://github.com/rvm/rvm/pull/4348)
 * Ruby 2.2.5 to 2.2.10 patches for installing bundled gems [\#4358](https://github.com/rvm/rvm/issues/4358)
 * Update RBX dependencies for OpenSUSE [\#4382](https://github.com/rvm/rvm/pull/4382)
+* RVM removes traps in bash [\#4416](https://github.com/rvm/rvm/issues/4416)
 
 #### Upgraded Ruby interpreters:
 * Add support for Ruby 2.2.8, 2.3.5 and 2.4.2 [\#4159](https://github.com/rvm/rvm/pull/4159), 2.5.0-preview1 [\#4204](https://github.com/rvm/rvm/pull/4204), 2.2.9, 2.3.6, 2.4.3 and 2.5.0-rc1 [\#4261](https://github.com/rvm/rvm/pull/4261), 2.5.0 [\#4265](https://github.com/rvm/rvm/pull/4265), 2.6.0-preview1 [\#4317](https://github.com/rvm/rvm/pull/4317), 2.2.10, 2.3.7, 2.4.4, 2.5.1 [\#4340](https://github.com/rvm/rvm/pull/4340) and 2.6.0-preview2[\#4395](https://github.com/rvm/rvm/pull/4395)

--- a/scripts/functions/environment
+++ b/scripts/functions/environment
@@ -212,6 +212,7 @@ __rvm_setup()
     fi
     set +o nounset
 
+    _rvm_old_traps=$( __rvm_grep -E 'EXIT|HUP|INT|QUIT|TERM' <(trap) )
     trap '__rvm_teardown_final ; set +x' EXIT HUP INT QUIT TERM
   fi
 
@@ -256,10 +257,10 @@ __rvm_teardown()
     [[ -n "${BASH_VERSION:-}" ]]
   then
     trap - EXIT HUP INT QUIT TERM # Clear all traps, we do not want to go into an loop.
-    if
-      is_a_function shell_session_update
+    if 
+      [[ -n "${_rvm_old_traps:-}" ]]
     then
-      trap 'shell_session_update' EXIT
+      eval "${_rvm_old_traps}"
     fi
 
     (( rvm_bash_nounset == 1 )) && set -o nounset


### PR DESCRIPTION
RVM replaces traps set on EXIT, HUP, INT, QUIT, TERM signals
This fix saves traps for affected signals before setting rvm's traps
and restores traps after clearing rvm's traps.
Fixes https://github.com/rvm/rvm/issues/4416