### PR TITLE
Updates and fixes to switch to new JRuby binary URL.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@
 [Full Changelog](https://github.com/rvm/rvm/compare/1.29.4...HEAD)
 
 #### New features:
+* Switch to new maven-based JRuby download URLs.
 
 #### Bug fixes:
+* Allow HTTP 2.0 servers to be used for downloads.
 
 #### Upgraded Ruby interpreters:
 

--- a/config/db
+++ b/config/db
@@ -5,8 +5,8 @@ niceness=0
 #
 # RVM
 #
-rvm_remote_server_path1=downloads
-rvm_remote_server_url1=https://s3.amazonaws.com/jruby.org
+rvm_remote_server_path1=maven2/org/jruby/jruby-dist
+rvm_remote_server_url1=https://repo1.maven.org
 rvm_remote_server_url2=https://rubies.travis-ci.org
 rvm_remote_server_url=https://rvm_io.global.ssl.fastly.net/binaries
 #

--- a/scripts/functions/utility
+++ b/scripts/functions/utility
@@ -322,7 +322,7 @@ file_exists_at_url_command()
 {
   __rvm_curl --silent --insecure --location --list-only \
     --max-time ${rvm_max_time_flag:-5} --head "$@" 2>&1 |
-    __rvm_grep -E 'HTTP/[0-9\.]+ 200 OK' >/dev/null 2>&1 ||
+    __rvm_grep -E 'HTTP/[0-9\.]+ 200' >/dev/null 2>&1 ||
     {
       \typeset __ret=$?
       case ${__ret} in

--- a/scripts/functions/utility_system
+++ b/scripts/functions/utility_system
@@ -47,7 +47,7 @@ __rvm_ruby_package_file()
         rvm_remote_flag=0 __rvm_ruby_string
         echo "$rvm_ruby_version"
       )"
-      rvm_ruby_package_file="/${__version}/jruby-bin-${__version}.$(__rvm_remote_extension "$1" -)"
+      rvm_ruby_package_file="/${__version}/jruby-dist-${__version}-bin.$(__rvm_remote_extension "$1" -)"
       ;;
     "")
       rvm_ruby_package_file=""


### PR DESCRIPTION
Changes proposed in this pull request:
* Switch download URL to Maven address.
* Fix structure of tarball filename.
* Allow "HTTP/2 200" format in curl results.

Fixes #4223.