### PR TITLE
Remove early check for LLVM with TruffleRuby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 #### Bug fixes:
 * Allow HTTP 2.0 servers to be used for downloads.
+* Remove too restrictive check for LLVM with TruffleRuby [\#4427](https://github.com/rvm/rvm/pull/4427)
 
 #### Upgraded Ruby interpreters:
 * Add support for TruffleRuby 1.0.0-rc3 [\#4419](https://github.com/rvm/rvm/pull/4419)

--- a/scripts/functions/manage/truffleruby
+++ b/scripts/functions/manage/truffleruby
@@ -1,20 +1,8 @@
 #!/usr/bin/env bash
 
-truffleruby_install_check_llvm()
-{
-  builtin command -v opt > /dev/null ||
-  {
-    rvm_error "TruffleRuby requires LLVM to be installed to run native extensions.
-For more details and for setup instructions for your system, please see:
-https://github.com/oracle/truffleruby/blob/master/doc/user/installing-llvm.md"
-    return 1
-  }
-}
-
 truffleruby_install()
 {
   __rvm_setup_compile_environment "${rvm_ruby_string}" || return $?
-  truffleruby_install_check_llvm || return $?
 
   __rvm_cd "${rvm_src_path}"
 


### PR DESCRIPTION
* TruffleRuby already checks later and looks up more paths to find the LLVM executables clang and opt.
  (TruffleRuby also looks up in Homebrew and MacPorts directories on macOS).
* See https://github.com/oracle/truffleruby/issues/1386 for details.

So this logic is redundant because per-platform checks for installing LLVM are already in RVM and TruffleRuby itself checks if `clang` & `opt` are available when it needs to compile C extensions.
It's also needlessly restrictive for Homebrew and MacPorts (forcing the LLVM executables to be in `PATH`), so it needs to be removed.

cc @havenwood 