### PR TITLE
UPDATE signals handling

### DIFF
--- a/scripts/functions/environment
+++ b/scripts/functions/environment
@@ -212,9 +212,7 @@ __rvm_setup()
     fi
     set +o nounset
 
-    trap >/dev/null
     _rvm_old_traps=$( trap | __rvm_grep -E 'EXIT|HUP|INT|QUIT|TERM' )
-    trap >/dev/null
     trap '__rvm_teardown_final ; set +x' EXIT HUP INT QUIT TERM
   fi
 

--- a/scripts/functions/environment
+++ b/scripts/functions/environment
@@ -212,7 +212,9 @@ __rvm_setup()
     fi
     set +o nounset
 
-    _rvm_old_traps=$( __rvm_grep -E 'EXIT|HUP|INT|QUIT|TERM' <(trap) )
+    trap >/dev/null
+    _rvm_old_traps=$( trap | __rvm_grep -E 'EXIT|HUP|INT|QUIT|TERM' )
+    trap >/dev/null
     trap '__rvm_teardown_final ; set +x' EXIT HUP INT QUIT TERM
   fi
 
@@ -257,7 +259,7 @@ __rvm_teardown()
     [[ -n "${BASH_VERSION:-}" ]]
   then
     trap - EXIT HUP INT QUIT TERM # Clear all traps, we do not want to go into an loop.
-    if 
+    if
       [[ -n "${_rvm_old_traps:-}" ]]
     then
       eval "${_rvm_old_traps}"


### PR DESCRIPTION
Fixes #4422 on Amazon Linux 2018.03

Per @charlietag comment at https://github.com/rvm/rvm/commit/3d9b93b3ce1a0651c3c7cc23193957f619f65fd9#r29693653:

> Please try modify this line as following:
> ````
> trap >/dev/null
> _rvm_old_traps=$( trap | __rvm_grep -E 'EXIT|HUP|INT|QUIT|TERM' )
> trap >/dev/null
> ````
> Otherwise (trap) will always get the following result:
> trap -- '' SIGINT
> trap -- '' SIGQUIT
> This means.... INT QUIT (__rvm_grep) will always be trapped.
> This means... My ctrl+c will always be blocked....