### PR TITLE
Fixed CentOS Ctrl - C trap issue

### DIFF
--- a/scripts/functions/environment
+++ b/scripts/functions/environment
@@ -212,7 +212,7 @@ __rvm_setup()
     fi
     set +o nounset
 
-    _rvm_old_traps=$( __rvm_grep -E 'EXIT|HUP|INT|QUIT|TERM' <(trap) )
+    _rvm_old_traps=$( trap | __rvm_grep -E 'EXIT|HUP|INT|QUIT|TERM' )
     trap '__rvm_teardown_final ; set +x' EXIT HUP INT QUIT TERM
   fi
 


### PR DESCRIPTION
Fixes #4428 #4422 

Changes proposed in this pull request:
* In CentOS `cat <(trap)` will always get the following result:
  `trap -- '' SIGINT` `trap -- '' SIGQUIT`
* This modification could solve Ctrl - c problems in CentOS