### PR TITLE
Improve gpg signature verification docs

### DIFF
--- a/docs/gpg.md
+++ b/docs/gpg.md
@@ -37,7 +37,7 @@ run our code - trust our keys.
 
         \curl -sSL https://raw.githubusercontent.com/rvm/rvm/master/binscripts/rvm-installer     -o rvm-installer &&
         \curl -sSL https://raw.githubusercontent.com/rvm/rvm/master/binscripts/rvm-installer.asc -o rvm-installer.asc &&
-        \gpg2 --verify rvm-installer.asc &&
+        \gpg2 --verify rvm-installer.asc rvm-installer &&
         \bash rvm-installer
 
 


### PR DESCRIPTION
`gpg2 --verify rvm-installer.asc` would do the right thing only if the file actually contained a detached signature.

Use explicit and robust `gpg2 --verify rvm-installer.asc rvm-installer` instead.