### PR TITLE
Remove unused function __rvm_get_user_shell

### DIFF
--- a/scripts/functions/utility_system
+++ b/scripts/functions/utility_system
@@ -230,30 +230,3 @@ __list_remote_for_s3()
   __rvm_awk "{ print "'"'$1/'"'"\$1 }"
   rm "${__tmp_name}"*
 }
-
-__rvm_get_user_shell()
-{
-  case "${_system_type}:${_system_name}" in
-    (Linux:*|SunOS:*|BSD:*|*:Cygwin)
-      __shell="$( getent passwd $USER )" ||
-      {
-        rvm_error "Error checking user shell via getent ... something went wrong, report a bug."
-        return 2
-      }
-      echo "${__shell##*:}"
-      ;;
-    (Darwin:*)
-      \typeset __version
-      __version="$(dscl localhost -read "/Search/Users/$USER" UserShell)" ||
-      {
-        rvm_error "Error checking user shell via dscl ... something went wrong, report a bug."
-        return 3
-      }
-      echo ${__version#*: }
-      ;;
-    (*)
-      rvm_error "Do not know how to check user shell on '$(command uname)'."
-      return 1
-      ;;
-  esac
-}


### PR DESCRIPTION
This function has been moved to `warning_zsh` and is used only there, so we should get rid of it I think...