### PR TITLE
Fix Ruby 2.5.0 and 2.5.1 build with LibreSSL 2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,16 @@
 [Full Changelog](https://github.com/rvm/rvm/compare/1.29.4...HEAD)
 
 #### New features:
-* Switch to new maven-based JRuby download URLs.
+* Switch to new maven-based JRuby download URLs
 * RailsExpress patches for 2.3.8, 2.4.5 and 2.5.3 [\#4476](https://github.com/rvm/rvm/pull/4476)
 
 #### Bug fixes:
-* Allow HTTP 2.0 servers to be used for downloads.
+* Allow HTTP 2.0 servers to be used for downloads
 * Remove too restrictive check for LLVM with TruffleRuby [\#4427](https://github.com/rvm/rvm/pull/4427)
 * Fix trap restoration on Amazon Linux [\#4428](https://github.com/rvm/rvm/pull/4428)
 * Fix Amazon Linux 2 detection [\#4435](https://github.com/rvm/rvm/pull/4435)
 * Fix libssl dependency for Elementary 5.0 Juno [\#4448](https://github.com/rvm/rvm/pull/4448)
+* Fix Ruby 2.5.0 and 2.5.1 build with LibreSSL 2.7.0 [\#4483](https://github.com/rvm/rvm/pull/4483)
 
 #### Upgraded Ruby interpreters:
 * Add support for TruffleRuby 1.0.0-rc3 [\#4419](https://github.com/rvm/rvm/pull/4419), 1.0.0-rc5 [\#4440](https://github.com/rvm/rvm/pull/4440), 1.0.0-rc6 [\#4452](https://github.com/rvm/rvm/pull/4452), and 1.0.0-rc7 [\#4466](https://github.com/rvm/rvm/pull/4466).

--- a/patches/ruby/2.5.0/libressl_2_7.patch
+++ b/patches/ruby/2.5.0/libressl_2_7.patch
@@ -1,0 +1,15 @@
+--- a/ext/openssl/extconf.rb
++++ b/ext/openssl/extconf.rb
+@@ -122,8 +122,11 @@
+ have_func("SSL_is_server")
+
+ # added in 1.1.0
++if !have_struct_member("SSL", "ctx", "openssl/ssl.h") ||
++    try_static_assert("LIBRESSL_VERSION_NUMBER >= 0x2070000fL", "openssl/opensslv.h")
++  $defs.push("-DHAVE_OPAQUE_OPENSSL")
++end
+ have_func("CRYPTO_lock") || $defs.push("-DHAVE_OPENSSL_110_THREADING_API")
+-have_struct_member("SSL", "ctx", "openssl/ssl.h") || $defs.push("-DHAVE_OPAQUE_OPENSSL")
+ have_func("BN_GENCB_new")
+ have_func("BN_GENCB_free")
+ have_func("BN_GENCB_get_arg")

--- a/patches/ruby/2.5.1/libressl_2_7.patch
+++ b/patches/ruby/2.5.1/libressl_2_7.patch
@@ -1,0 +1,15 @@
+--- a/ext/openssl/extconf.rb
++++ b/ext/openssl/extconf.rb
+@@ -122,8 +122,11 @@
+ have_func("SSL_is_server")
+
+ # added in 1.1.0
++if !have_struct_member("SSL", "ctx", "openssl/ssl.h") ||
++    try_static_assert("LIBRESSL_VERSION_NUMBER >= 0x2070000fL", "openssl/opensslv.h")
++  $defs.push("-DHAVE_OPAQUE_OPENSSL")
++end
+ have_func("CRYPTO_lock") || $defs.push("-DHAVE_OPENSSL_110_THREADING_API")
+-have_struct_member("SSL", "ctx", "openssl/ssl.h") || $defs.push("-DHAVE_OPAQUE_OPENSSL")
+ have_func("BN_GENCB_new")
+ have_func("BN_GENCB_free")
+ have_func("BN_GENCB_get_arg")

--- a/patchsets/ruby/2.5.0/default
+++ b/patchsets/ruby/2.5.0/default
@@ -1,1 +1,2 @@
 prelude_gcc_diagnostic
+libressl_2_7

--- a/patchsets/ruby/2.5.1/default
+++ b/patchsets/ruby/2.5.1/default
@@ -1,0 +1,1 @@
+libressl_2_7


### PR DESCRIPTION
Based on https://github.com/ruby/openssl/issues/192