### PR TITLE
Update rvm-test and test installing TruffleRuby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ script:
 env:
   - TEST=rvm-test/fast/* rvm-test-rvm1/*
   - TEST=rvm-test/long/named_ruby_and_gemsets_comment_test.sh
+  - TEST=rvm-test/long/truffleruby_comment_test.sh
 matrix:
   include:
     - os: linux


### PR DESCRIPTION
Runs the test added in https://github.com/rvm/rvm-test/pull/26 in rvm/rvm's CI.
Relates to #4297 and https://github.com/rvm/rvm/pull/4456#issuecomment-432487811.

cc @mpapis @pkuczynski @havenwood 