### PR TITLE
Allow sudo in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: c
 os: [osx, linux]
 osx_image: xcode9.3
-sudo: false
+sudo: true
 addons:
   apt:
     packages:


### PR DESCRIPTION
* So we can test installing packages with rvm autolibs.
* Containers are being deprecated in TravisCI:
  https://docs.travis-ci.com/user/reference/overview/#deprecated-virtualization-environments

cc @pkuczynski 