### PR TITLE
Fix Travis build on GPG keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ matrix:
           packages:
             - gnupg2
       script:
+        - gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
         - gpg2 --verify binscripts/rvm-installer.asc binscripts/rvm-installer
 notifications:
   email:


### PR DESCRIPTION
For some reason Travis is unable to verify rvm-installer due to missing key. This should fix our failsafe build job to make sure we don't break rvm-installer.

See https://travis-ci.org/rvm/rvm/jobs/468465092