### PR TITLE
Fix Command Line Tools version detection on MacOS 10.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 #### Bug fixes
 * Install libssl1.0.2 for old versions of Ruby on Kali linux [\#4522](https://github.com/rvm/rvm/pull/4522)
 * Fix Linux Mint 19 dependencies [\#4524](https://github.com/rvm/rvm/pull/4524)
+* Fix Mojave Command Line Tools version detection [\#4404](https://github.com/rvm/rvm/pull/4404)
 
 #### Ruby interpreters
 * Add support for Ruby 2.6.0-rc2 [\#4526](https://github.com/rvm/rvm/pull/4526)

--- a/scripts/functions/requirements/osx_brew
+++ b/scripts/functions/requirements/osx_brew
@@ -398,7 +398,10 @@ __CLT_version_at_least()
   \typeset __version="$(
     pkgutil --pkg-info com.apple.pkg.DeveloperToolsCLI 2>/dev/null | __rvm_awk '$1~/version:/{print $2}'
   )"
-  [[ -n "${__version}" ]] || return $?
+  [[ -n "${__version}" ]] || __version="$(
+    pkgutil --pkg-info com.apple.pkg.CLTools_Executables 2>/dev/null | __rvm_awk '$1~/version:/{print $2}'
+  )"
+  [[ -n "${__version}" ]] ||return $?
   __rvm_version_compare "${__version}" -ge "$1" || return $?
 }
 


### PR DESCRIPTION
Improves #4402

Changes proposed in this pull request:
* Add check for CommandLineTools that uses newer package name:
pkgutil --pkg-info com.apple.pkg.CLTools_Executables

When XCode is not installed, the __rvm_detect_xcode_version_at_least
check from osx_brew falls back to __CLT_version_at_least 4.6.0 that
tries to detect the version of command line tools. The command it uses:
pkgutil --pkg-info com.apple.pkg.DeveloperToolsCLI is outdated.
That package doesn't exist in Mojave and this change adds another
fallback that uses the new package name.

Before the change any commands that required building ruby was failing
with:
rvm install 2.5.3
...
Xcode version older than 4.6.2 installed, download and install newer version from:
...

Verified that this solved the issue by successfully executing:
rvm install 2.5.3.
