### PR TITLE
Add system ruby as dependency for CentOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * 
 
 #### Bug fixes
-* 
+* Add system ruby as dependency for CentOS
 
 #### Changes
 * 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * 
 
 #### Bug fixes
-* Add system ruby as dependency for CentOS
+* Add system ruby as dependency for CentOS [\#4567](https://github.com/rvm/rvm/pull/4567)
 
 #### Changes
 * 

--- a/scripts/functions/requirements/centos
+++ b/scripts/functions/requirements/centos
@@ -231,7 +231,7 @@ requirements_centos_define()
       fi
 
       requirements_check autoconf automake bison bzip2 gcc-c++ libffi-devel libtool make patch readline \
-                         readline-devel sqlite-devel zlib zlib-devel
+                         readline-devel ruby sqlite-devel zlib zlib-devel
 
       requirements_${_system_name_lowercase}_define_glibc $1
       requirements_${_system_name_lowercase}_define_libyaml $1


### PR DESCRIPTION
Seems that CentOS needs some version of ruby to be installed to compile new ruby. This PR adds `ruby` dependency.

Fixes issue: `executable host ruby is required. use --with-baseruby option.`

Fixes #4529 