### PR TITLE
Add script to automatically register a new TruffleRuby release in RVM

### DIFF
--- a/update-truffleruby.rb
+++ b/update-truffleruby.rb
@@ -1,8 +1,8 @@
 require "digest"
 
-raise "Usage: #{$0} VERSION" unless ARGV.size == 1
+raise "Usage: #{$0} VERSION RELEASE_DIRECTORY" unless ARGV.size == 2
 
-version = ARGV[0]
+version, release_directory = ARGV
 
 def replace_line(file, pattern, replacement)
   lines = File.readlines(file)
@@ -26,7 +26,7 @@ insert_after "config/known_strings", /^truffleruby/, ["truffleruby-#{version}\n"
 %w[md5 sha512].each { |algorithm|
   digests = %w[linux-amd64 macos-amd64].map { |platform|
     basename = "truffleruby-#{version}-#{platform}.tar.gz"
-    archive = File.expand_path("../ruby-versions/pkg/#{basename}")
+    archive = "#{release_directory}/#{basename}"
     digest = Digest(algorithm.upcase).file(archive).hexdigest
     "#{basename}=#{digest}\n"
   }

--- a/update-truffleruby.rb
+++ b/update-truffleruby.rb
@@ -1,0 +1,34 @@
+require "digest"
+
+raise "Usage: #{$0} VERSION" unless ARGV.size == 1
+
+version = ARGV[0]
+
+def replace_line(file, pattern, replacement)
+  lines = File.readlines(file)
+  i = lines.index { |line| pattern =~ line }
+  lines[i] = replacement
+  File.write(file, lines.join)
+end
+
+def insert_after(file, pattern, new_lines)
+  lines = File.readlines(file)
+  i = lines.rindex { |line| pattern =~ line }
+  lines.insert(i+1, *new_lines)
+  File.write(file, lines.join)
+end
+
+replace_line "config/db", /truffleruby_version=/, "truffleruby_version=#{version}\n"
+replace_line "config/known", /truffleruby\[/, "truffleruby[-#{version}]\n"
+
+insert_after "config/known_strings", /^truffleruby/, ["truffleruby-#{version}\n"]
+
+%w[md5 sha512].each { |algorithm|
+  digests = %w[linux-amd64 macos-amd64].map { |platform|
+    basename = "truffleruby-#{version}-#{platform}.tar.gz"
+    archive = File.expand_path("../ruby-versions/pkg/#{basename}")
+    digest = Digest(algorithm.upcase).file(archive).hexdigest
+    "#{basename}=#{digest}\n"
+  }
+  insert_after "config/#{algorithm}", /^truffleruby/, digests
+}


### PR DESCRIPTION
This automates adding a new TruffleRuby version in RVM, and avoids copy-paste errors.

Where should I place the script?
For now, I added it at the root of the repo like e.g., `update-remote.sh`.

cc @pkuczynski @havenwood @nirvdrum 