### PR TITLE
Test TruffleRuby in TravisCI in RVM's .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,17 @@ matrix:
       script:
         - gpg2 --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
         - gpg2 --verify binscripts/rvm-installer.asc binscripts/rvm-installer
+    - language: ruby
+      os: linux
+      env: TEST="Test TruffleRuby in TravisCI"
+      rvm: truffleruby
+      before_install: true
+      install: true
+      before_script: true
+      script:
+        - ruby -v
+        - rake --version
+        - ruby -ropen-uri -e 'puts open("https://rubygems.org/") { |f| f.read(1024) }'
 notifications:
   email:
     recipients:


### PR DESCRIPTION
As seen in https://github.com/rvm/rvm/issues/4561#issuecomment-450678661, it happens that the CI of RVM passes, yet `rvm: truffleruby` doesn't work in TravisCI.

So this PR adds a test using `rvm: truffleruby` in RVM's `.travis.yml`.
This is exactly what people testing their Ruby library on TravisCI will use, and so tests one important use-case where RVM is used.

cc @pkuczynski 