### PR TITLE
Fix macOS openssl requirement gathering with Homebrew

### DIFF
--- a/scripts/functions/requirements/osx_brew
+++ b/scripts/functions/requirements/osx_brew
@@ -340,8 +340,8 @@ requirements_osx_brew_libs_default()
     libyaml readline libksba
   )
 
-  requirements_osx_brew_define_gcc
-  requirements_osx_brew_define_openssl
+  requirements_osx_brew_define_gcc "$1"
+  requirements_osx_brew_define_openssl "$1"
 
   requirements_check "${brew_libs[@]}" "${brew_libs_conf[@]}" || return $?
 }


### PR DESCRIPTION
Fixes a regression added in #4556 (https://github.com/rvm/rvm/pull/4556/commits/f4ee90e6d90faf08ad9c76b4c21e72213bca4fd8). Looks like this was simply over looked.

Changes proposed in this pull request:
* Pass argument all the way through to `requirements_osx_brew_define_openssl()`

Possibly related: #4562 