### PR TITLE
Install libssl1.0-dev for version 1.8 of Ruby on Ubuntu linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Improve detection of Amazon Linux 2 [\#4568](https://github.com/rvm/rvm/pull/4568)
 * Fix macOS openssl requirement gathering with Homebrew [\#4583](https://github.com/rvm/rvm/pull/4583)
 * Don't spoil environment with '_system_*' variables [\#4584](https://github.com/rvm/rvm/pull/4584)
+* Install libssl1.0-dev for version 1.8 of Ruby on Ubuntu linux
 
 #### Changes
 * 

--- a/scripts/functions/requirements/ubuntu
+++ b/scripts/functions/requirements/ubuntu
@@ -24,7 +24,7 @@ requirements_ubuntu_define_libssl()
   # starting from Ubuntu 17.10 (Artful Aardvark)
 
   case "$1" in
-    (ruby-2.3*|ruby-2.2*|ruby-2.1*|ruby-2.0*|ruby-1.9*)
+    (ruby-2.3*|ruby-2.2*|ruby-2.1*|ruby-2.0*|ruby-1.9*|ruby-1.8*)
       if
         __rvm_version_compare ${_system_version} -ge 17.10
       then


### PR DESCRIPTION
Changes proposed in this pull request:
* Install libssl1.0-dev for version 1.8 of Ruby on Ubuntu linux

