### PR TITLE
Require os-specific functions during install only when they exist

### DIFF
--- a/scripts/functions/manage/base_install
+++ b/scripts/functions/manage/base_install
@@ -2,7 +2,7 @@
 
 __rvm_install_source()
 {
-  source "$rvm_scripts_path/functions/manage/install/$_system_name_lowercase"
+  __rvm_require "$rvm_scripts_path/functions/manage/install/$_system_name_lowercase"
 
   true ${rvm_ruby_selected_flag:=0}
 

--- a/scripts/functions/utility
+++ b/scripts/functions/utility
@@ -325,6 +325,7 @@ file_exists_at_url()
     return 1
   fi
 )
+
 __rvm_try_sudo()
 (
   \typeset -a command_to_run
@@ -393,4 +394,9 @@ __rvm_calculate_space_used()
 {
   __used_space="$( \command \du -msc "$@" | __rvm_awk 'END {print $1}' )"
   __used_space="${__used_space%M}"
+}
+
+__rvm_require()
+{
+  [[ -f "$1" ]] && source "$1"
 }


### PR DESCRIPTION
Fixes #4582
Fixes #4588
