### PR TITLE
Fixes broken links to VERSION and CHANGELOG.md in release-procedure.md

### DIFF
--- a/docs/release-procedure.md
+++ b/docs/release-procedure.md
@@ -10,8 +10,8 @@ git pull
 git merge master
 ```
 
-2. Increase [VERSION](VERSION) number and remove `-next`
-3. Update [CHANGELOG](CHANGELOG.md) with release date and links to changes (do not add new `Next` section yet)
+2. Increase [VERSION](https://github.com/rvm/rvm/blob/master/VERSION) number and remove `-next`
+3. Update [CHANGELOG](https://github.com/rvm/rvm/blob/master/CHANGELOG.md) with release date and links to changes (do not add new `Next` section yet)
 4. Tag stable with version
 
 ```bash
@@ -45,8 +45,8 @@ bash ./sign-releases.sh
 9. Publish blog entry on http://rvm.io
 10. Publish info on twitter
 11. Prepare for the next release on `master` branch
-    * add `-next` to the [VERSION](VERSION)
-    * add new `Next` section to [CHANGELOG](CHANGELOG.md)
+    * add `-next` to the [VERSION](https://github.com/rvm/rvm/blob/master/VERSION)
+    * add new `Next` section to [CHANGELOG](https://github.com/rvm/rvm/blob/master/CHANGELOG.md)
 
 ## Preconditions
 

--- a/docs/release-procedure.md
+++ b/docs/release-procedure.md
@@ -10,8 +10,8 @@ git pull
 git merge master
 ```
 
-2. Increase [VERSION](https://github.com/rvm/rvm/blob/master/VERSION) number and remove `-next`
-3. Update [CHANGELOG](https://github.com/rvm/rvm/blob/master/CHANGELOG.md) with release date and links to changes (do not add new `Next` section yet)
+2. Increase [VERSION](../VERSION) number and remove `-next`
+3. Update [CHANGELOG](../CHANGELOG.md) with release date and links to changes (do not add new `Next` section yet)
 4. Tag stable with version
 
 ```bash
@@ -45,8 +45,8 @@ bash ./sign-releases.sh
 9. Publish blog entry on http://rvm.io
 10. Publish info on twitter
 11. Prepare for the next release on `master` branch
-    * add `-next` to the [VERSION](https://github.com/rvm/rvm/blob/master/VERSION)
-    * add new `Next` section to [CHANGELOG](https://github.com/rvm/rvm/blob/master/CHANGELOG.md)
+    * add `-next` to the [VERSION](../VERSION)
+    * add new `Next` section to [CHANGELOG](../CHANGELOG.md)
 
 ## Preconditions
 


### PR DESCRIPTION
This tiny PR fixes a few broken links in the release procedure documentation.  Currently the links take you to GitHub's 404 page.