### PR TITLE
Allow failures on macOS until the CI is fixed on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,13 @@ matrix:
         - ruby -v
         - rake --version
         - ruby -ropen-uri -e 'puts open("https://rubygems.org/") { |f| f.read(1024) }'
+  allow_failures:
+    - os: osx
+      env: TEST=rvm-test/fast/* rvm-test-rvm1/*
+    - os: osx
+      env: TEST=rvm-test/long/named_ruby_and_gemsets_comment_test.sh
+    - os: osx
+      env: TEST=rvm-test/long/truffleruby_comment_test.sh
 notifications:
   email:
     recipients:


### PR DESCRIPTION
* See https://github.com/rvm/rvm/issues/4579

I'd like the build to be green, to avoid regressions (e.g., #4609).

Another option is completely removing tests on macOS, but many tests pass:
https://github.com/rvm/rvm/issues/4579#issuecomment-462966466

cc @pkuczynski 