### PR TITLE
Fix macOS CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ before_script:
   - ./install
   - git submodule init
   - git submodule update
+  - rvm reload
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rvm autolibs read-only; fi
 script:
   - tf --text $TEST
 env:
@@ -55,13 +57,6 @@ matrix:
         - ruby -v
         - rake --version
         - ruby -ropen-uri -e 'puts open("https://rubygems.org/") { |f| f.read(1024) }'
-  allow_failures:
-    - os: osx
-      env: TEST=rvm-test/fast/* rvm-test-rvm1/*
-    - os: osx
-      env: TEST=rvm-test/long/named_ruby_and_gemsets_comment_test.sh
-    - os: osx
-      env: TEST=rvm-test/long/truffleruby_comment_test.sh
 notifications:
   email:
     recipients:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ before_install:
   - "rvm use ruby-2.4 --fuzzy || rvm use ruby-2.3 --fuzzy"
   - "[[ -n \"${LANG:-}\" ]] || export LANG=en_US.UTF-8"
   - "env | grep '^rvm' || true"
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
 install:
   - gem install tf -v '>=0.4.1'
 before_script:


### PR DESCRIPTION
Fixes #4579.

This PR makes the macOS CI on TravisCI green.

For that, it removes very slow (5min/job vs 20-40min) and unreliable calls to Homebrew by using `rvm autolibs read-only`. Without that, RVM would call to Homebrew and update many packages, which would take a very long time and lead to build failures (#4579).
In practice, it is clear TravisCI macOS machines already have all the necessary dependencies to test RVM and install the tested Ruby versions.

I think we should merge this because it's more valuable to test the rest of the logic (everything except `autolibs`) on macOS, than having a failing CI and issues potentially piling up.

cc @pkuczynski @havenwood 