### PR TITLE
Fix wording (this gems -> these gems)

### DIFF
--- a/scripts/functions/gemset
+++ b/scripts/functions/gemset
@@ -507,7 +507,7 @@ gemset_pristine()
     if
       (( ${#_failed[@]} > 0 ))
     then
-      rvm_error "\n'${_pristine_command[*]} ${_failed[*]}' failed, you need to fix this gems manually."
+      rvm_error "\n'${_pristine_command[*]} ${_failed[*]}' failed, you need to fix these gems manually."
       return 1
     else
       rvm_log "\nfinished."


### PR DESCRIPTION
Tiny wording change. It is unclear at that moment if its one or multiple gems or anything else that made the command fail. The message now is however better than the mix of singular and plural.
