### PR TITLE
rvm-installer: remove hardcoded number of jobs

### DIFF
--- a/binscripts/rvm-installer
+++ b/binscripts/rvm-installer
@@ -887,7 +887,7 @@ rvm_install_ruby_and_gems()
     __rvm_print_headline
 
     for _ruby in ${install_rubies[@]}
-    do command rvm "${forwarded_flags[@]}" install ${_ruby} -j 2
+    do command rvm "${forwarded_flags[@]}" install ${_ruby}
     done
     # set the first one as default, skip rest
     for _ruby in ${install_rubies[@]}


### PR DESCRIPTION
`__rvm_setup_compile_environment_flags_threads()` in scripts/functions/build_config auto-detects the number of threads to use

Changes proposed in this pull request:
* remove the hardcoded number of jobs from rvm-installer so that it will auto detect and build with as many threads as it can

Related: #3856