### PR TITLE
Update openssl-devel to libssl-devel for Cygwin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * Update rbx dependencies for macOS [\#4643](https://github.com/rvm/rvm/pull/4643)
 * Fix version selected for TruffleRuby binary install [\#4662](https://github.com/rvm/rvm/pull/4662)
 * Remove hardcoded number of jobs in installer [\#4674](https://github.com/rvm/rvm/pull/4674)
+* Updated obsoleted package openssl-devel to libssl-devel cygwin requirements
 
 #### Changes
 *

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@
 * Update rbx dependencies for macOS [\#4643](https://github.com/rvm/rvm/pull/4643)
 * Fix version selected for TruffleRuby binary install [\#4662](https://github.com/rvm/rvm/pull/4662)
 * Remove hardcoded number of jobs in installer [\#4674](https://github.com/rvm/rvm/pull/4674)
-* Updated obsoleted package openssl-devel to libssl-devel cygwin requirements
+* Updated obsoleted package openssl-devel to libssl-devel cygwin requirements [\#4685](https://github.com/rvm/rvm/pull/4685)
 
 #### Changes
 *

--- a/scripts/functions/requirements/cygwin
+++ b/scripts/functions/requirements/cygwin
@@ -75,7 +75,7 @@ requirements_cygwin_define()
       requirements_check make autoconf automake bison m4 libtool \
         gcc gcc-core mingw64-i686-gcc-core mingw64-x86_64-gcc-core \
         libiconv zlib zlib-devel \
-        openssl openssl-devel \
+        openssl libssl-devel \
         libcrypt-devel libcrypt0 \
         libyaml-devel libyaml0_2 \
         libffi-devel \


### PR DESCRIPTION
Fixes #4684

Changes proposed in this pull request:
updated openssl-devel requirement for Cygwin to libssl-devel

