### PR TITLE
Fix the rvm version checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 *
 
 #### Bug fixes
-* Fix rvm version version validation per project [\#4692](https://github.com/rvm/rvm/pull/4692)
+* Fix rvm version validation per project [\#4692](https://github.com/rvm/rvm/pull/4692)
 
 #### Changes
 *

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 *
 
 #### Bug fixes
-*
+* Fix rvm version version validation per project [\#4692](https://github.com/rvm/rvm/pull/4692)
 
 #### Changes
 *

--- a/scripts/functions/rvmrc_set
+++ b/scripts/functions/rvmrc_set
@@ -93,9 +93,9 @@ environment_id=\"$identifier\"
 
 # Uncomment the following lines if you want to verify rvm version per project
 # rvmrc_rvm_version=\"${rvm_version}\" # 1.10.1 seems like a safe start
-# eval \"\$(echo \${rvm_version}.\${rvmrc_rvm_version} | __rvm_awk -F. '{print \"[[ \"\$1*65536+\$2*256+\$3\" -ge \"\$4*65536+\$5*256+\$6\" ]]\"}' )\" || {
+# eval \"\$(echo \${rvm_version}.\${rvmrc_rvm_version} | awk -F. '{print \"[[ \"\$1*65536+\$2*256+\$3\" -ge \"\$4*65536+\$5*256+\$6\" ]]\"}' )\" || {
 #   echo \"This .rvmrc file requires at least RVM \${rvmrc_rvm_version}, aborting loading.\"
-#   return 1
+#   exit 1
 # }
 " >> .rvmrc
     if __rvm_string_match "$identifier" "jruby*"


### PR DESCRIPTION
This pull request fixes the rvm version validation.

Steps to reproduce:
1) install the latest version of rvm 1.29.8
2) Generate the .rvmrc  using "rvm rvmrc create" in an empty directory
3) Uncomment the part where it says "Uncomment the following lines if you want to verify rvm version per project" and run it and you will get an error message like this 

$ bash .rvmrc
.rvmrc: line 13: __rvm_awk: command not found

After fixing removing the extra  __rvm_ before awk and setting 
rvmrc_rvm_version="1.30.8 (latest)
then I got this 

$ bash  .rvmrc
This .rvmrc file requires at least RVM 1.30.8 (latest), aborting loading.
.rvmrc: line 16: return: can only `return' from a function or sourced script

After this fix, this is the output

$ bash  .rvmrc
This .rvmrc file requires at least RVM 1.30.8 (latest), aborting loading.


