### PR TITLE
Fix endless loop on macOS when listing remotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 *
 
 #### Bug fixes
+* Fix endless loop on macOS when listing remotes
 *
 
 #### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 *
 
 #### Bug fixes
-* Fix endless loop on macOS when listing remotes
+* Fix endless loop on macOS when listing remotes [\#4703](https://github.com/rvm/rvm/pull/4603), 2.5.4 and 2.6.2 [\#4703]
 *
 
 #### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 *
 
 #### Bug fixes
-* Fix endless loop on macOS when listing remotes [\#4703](https://github.com/rvm/rvm/pull/4603), 2.5.4 and 2.6.2 [\#4703]
+* Fix endless loop on macOS when listing remotes [\#4703](https://github.com/rvm/rvm/pull/4703)
 *
 
 #### Changes

--- a/scripts/functions/utility_system
+++ b/scripts/functions/utility_system
@@ -146,12 +146,14 @@ __list_remote_all()
   while
     __rvm_db "rvm_remote_server_url${_iterator:-}" rvm_remote_server_url
   do
-    __rvm_include_travis_binaries || continue
+    if
+      __rvm_include_travis_binaries
+    then
+      __rvm_system_path "" "${_iterator}"
+      rvm_debug "__list_remote_all${_iterator:-} $rvm_remote_server_url $rvm_remote_server_path"
 
-    __rvm_system_path "" "${_iterator}"
-    rvm_debug "__list_remote_all${_iterator:-} $rvm_remote_server_url $rvm_remote_server_path"
-
-    __list_remote_for "${rvm_remote_server_url}" "$rvm_remote_server_path"
+      __list_remote_for "${rvm_remote_server_url}" "$rvm_remote_server_path"
+    fi
     : $(( _iterator+=1 ))
   done | \command \sort -u | __rvm_version_sort
 }


### PR DESCRIPTION
If the check for Travis CI binaries returned false – as is always the case outside of Travis CI – the code could go into an endless loop, because is was continued before the iterator was incremented.
