### PR TITLE
Install missing dirmngr for GPG signature test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ matrix:
       addons:
         apt:
           packages:
+            - dirmngr
             - gnupg2
       script:
         - gpg2 --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB


### PR DESCRIPTION
This is needed, because the Travis CI apt addon installs packages with
--no-install-recommends and dirmngr is a recommended package for gnupg2.

See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=845720 for discussion.

No Changelog update since this only concerns CI.