### PR TITLE
Filter redundant/incompatible rvm_gem_options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,7 @@
 #### Bug fixes
 * Fix rvm version validation per project [\#4692](https://github.com/rvm/rvm/pull/4692)
 * Fix endless loop on macOS when listing remotes [\#4703](https://github.com/rvm/rvm/pull/4703)
-* Filter redundant/incompatible rvm\_gem\_options
-*
+* Filter redundant/incompatible rvm\_gem\_options [\#4705](https://github.com/rvm/rvm/pull/4705)
 
 #### Changes
 *

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 #### Bug fixes
 * Fix rvm version validation per project [\#4692](https://github.com/rvm/rvm/pull/4692)
 * Fix endless loop on macOS when listing remotes [\#4703](https://github.com/rvm/rvm/pull/4703)
+* Filter redundant/incompatible rvm\_gem\_options
+*
 
 #### Changes
 *

--- a/scripts/functions/gemset
+++ b/scripts/functions/gemset
@@ -181,7 +181,17 @@ gem_install_force()
   else install_params+=( --no-ri --no-rdoc )
   fi
 
-  install_params+=( $rvm_gem_options )
+  for __gem_option in ${rvm_gem_options}
+  do
+    case "${__gem_option}" in
+      (--no-ri|--no-rdoc|--no-document)
+        # skip
+        ;;
+      (*)
+        install_params+=( "${__gem_option}" )
+        ;;
+    esac
+  done
 
   __rvm_log_command \
     "gem.install.${gem_name}${gem_version:+-}${gem_version:-}" \


### PR DESCRIPTION
This removes any occurrence of `--no-document`, `--no-ri` and `--no-rdoc` from `rvm_gem_options` when merging with the auto-detected `install_params` to avoid duplicate, deprecated or incompatible options.

This should fix the current test failures for ruby-1.8.7 under Xenial on Travis CI, where the default Travis `~/.rvmrc` contains `rvm_gem_options='--no-ri --no-rdoc --no-document'` breaking rvm gem installs with rubygems 1.8.25 which does not yet support the `--no-document` option.