### PR TITLE
Fix checksum check condition to not try url if already found in config files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Fix endless loop on macOS when listing remotes [\#4703](https://github.com/rvm/rvm/pull/4703)
 * Filter redundant/incompatible rvm\_gem\_options [\#4705](https://github.com/rvm/rvm/pull/4705)
 * Remove rvm_gems_path as part of __rvm_remove_rvm_from_path [\#4712](https://github.com/rvm/rvm/pull/4712)
+* Fix checksum check condition to not try url if already found in config files [\#4707](https://github.com/rvm/rvm/pull/4707)
 
 #### Changes
 * TruffleRuby is now always considered a "source Ruby" instead of both a source

--- a/scripts/functions/checksum
+++ b/scripts/functions/checksum
@@ -201,7 +201,7 @@ __rvm_checksum_read()
     [[ -n "${_checksum_md5:-}" ]] ||
       _checksum_md5="$(    __rvm_db_ "$rvm_user_path/md5"      "$_name" | \command \head -n 1 )"
 
-    [[ -n "${_checksum_md5:-}" && $_name == http* ]] ||
+    [[ -z "${_checksum_md5:-}" && $_name == http* ]] &&
        _checksum_md5="$(__rvm_curl -s -L $_name.md5)"
 
     # sha512
@@ -210,7 +210,7 @@ __rvm_checksum_read()
     [[ -n "${_checksum_sha512:-}" ]] ||
       _checksum_sha512="$( __rvm_db_ "$rvm_user_path/sha512"   "$_name" | \command \head -n 1 )"
 
-    [[ -n "${_checksum_sha512:-}" && $_name == http* ]] ||
+    [[ -z "${_checksum_sha512:-}" && $_name == http* ]] &&
        _checksum_sha512="$(__rvm_curl -s -L $_name.sha512)"
 
     __rvm_checksum_none || return 0

--- a/scripts/functions/checksum
+++ b/scripts/functions/checksum
@@ -201,17 +201,27 @@ __rvm_checksum_read()
     [[ -n "${_checksum_md5:-}" ]] ||
       _checksum_md5="$(    __rvm_db_ "$rvm_user_path/md5"      "$_name" | \command \head -n 1 )"
 
-    [[ -z "${_checksum_md5:-}" && $_name == http* ]] &&
-       _checksum_md5="$(__rvm_curl -s -L $_name.md5)"
-
     # sha512
     _checksum_sha512="$(   __rvm_db_ "$rvm_path/config/sha512" "$_name" | \command \head -n 1 )"
 
     [[ -n "${_checksum_sha512:-}" ]] ||
       _checksum_sha512="$( __rvm_db_ "$rvm_user_path/sha512"   "$_name" | \command \head -n 1 )"
 
-    [[ -z "${_checksum_sha512:-}" && $_name == http* ]] &&
-       _checksum_sha512="$(__rvm_curl -s -L $_name.sha512)"
+    __rvm_checksum_none || return 0
+  done
+
+  # Only try to get the checksum from the network after checking the config files
+  for _name in "${list[@]}"
+  do
+    if [[ $_name == http* ]]; then
+      if [[ -z "${_checksum_md5:-}" ]]; then
+        _checksum_md5="$(__rvm_curl -s -L $_name.md5)"
+      fi
+
+      if [[ -z "${_checksum_sha512:-}" ]]; then
+        _checksum_sha512="$(__rvm_curl -s -L $_name.sha512)"
+      fi
+    fi
 
     __rvm_checksum_none || return 0
   done

--- a/scripts/functions/checksum
+++ b/scripts/functions/checksum
@@ -178,7 +178,7 @@ __rvm_checksum_read()
 {
   rvm_debug "Load checksums for $1"
 
-  __rvm_checksum_none || return 0
+  __rvm_checksum_any && return 0
   \typeset _type _value _name
   \typeset -a _list
   list=()
@@ -207,7 +207,7 @@ __rvm_checksum_read()
     [[ -n "${_checksum_sha512:-}" ]] ||
       _checksum_sha512="$( __rvm_db_ "$rvm_user_path/sha512"   "$_name" | \command \head -n 1 )"
 
-    __rvm_checksum_none || return 0
+    __rvm_checksum_any && return 0
   done
 
   # Only try to get the checksum from the network after checking the config files
@@ -223,7 +223,7 @@ __rvm_checksum_read()
       fi
     fi
 
-    __rvm_checksum_none || return 0
+    __rvm_checksum_any && return 0
   done
 
   rvm_debug "    ...checksums not found"


### PR DESCRIPTION
Fix condition to only try `curl` if no checksum is found
* This would cause checksum checks to fail even if checksums exist in the config files, as long as the given URL does not exist.
* This bug was introduced by #4650

Only try to get the checksum from the network after checking the config files (avoiding extra `curl` queries if not needed).

This notably fixes the checksum check for TruffleRuby.

cc @pkuczynski @mpapis 