### PR TITLE
Always use the "from source" installation path for TruffleRuby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@
 * Filter redundant/incompatible rvm\_gem\_options [\#4705](https://github.com/rvm/rvm/pull/4705)
 
 #### Changes
-*
+* TruffleRuby is now always considered a "source Ruby" instead of both a source
+  and binary Ruby to improve reliability and avoiding code duplication [\#4708](https://github.com/rvm/rvm/pull/4708)
 
 #### Binaries:
 *

--- a/config/db
+++ b/config/db
@@ -8,8 +8,6 @@ niceness=0
 rvm_remote_server_path1=maven2/org/jruby/jruby-dist
 rvm_remote_server_url1=https://repo1.maven.org
 rvm_remote_server_url2=https://rubies.travis-ci.org
-rvm_remote_server_path3=releases/download
-rvm_remote_server_url3=https://github.com/oracle/truffleruby
 rvm_remote_server_url=https://rvm_io.global.ssl.fastly.net/binaries
 #
 # RubyGems

--- a/config/db
+++ b/config/db
@@ -5,11 +5,11 @@ niceness=0
 #
 # RVM
 #
-rvm_remote_server_path0=releases/download
-rvm_remote_server_url0=https://github.com/oracle/truffleruby
 rvm_remote_server_path1=maven2/org/jruby/jruby-dist
 rvm_remote_server_url1=https://repo1.maven.org
 rvm_remote_server_url2=https://rubies.travis-ci.org
+rvm_remote_server_path3=releases/download
+rvm_remote_server_url3=https://github.com/oracle/truffleruby
 rvm_remote_server_url=https://rvm_io.global.ssl.fastly.net/binaries
 #
 # RubyGems

--- a/scripts/functions/manage/base_install
+++ b/scripts/functions/manage/base_install
@@ -226,6 +226,13 @@ __rvm_install_ruby_try_remote()
     (( rvm_remote_flag > 0 )) || # remote flag wins!
     (( rvm_head_flag == 0 && rvm_disable_binary_flag == 0 )) # not a head and disabled binary
   then
+    case "$rvm_ruby_string" in
+      truffleruby*)
+        # always use the "from source" installation path for TruffleRuby
+        return 2
+        ;;
+    esac
+
     rvm_log "Searching for binary rubies, this might take some time."
     \typeset __rvm_ruby_url __rvm_ruby_verify_download_flag __ruby_identifier
     __ruby_identifier="${rvm_ruby_string}"

--- a/scripts/functions/selector_interpreters
+++ b/scripts/functions/selector_interpreters
@@ -256,8 +256,7 @@ __rvm_truffleruby_set_rvm_ruby_url()
 
   rvm_ruby_package_name="truffleruby-${truffleruby_version}"
   rvm_ruby_package_file="${rvm_ruby_package_name}-${platform}-${arch}"
-  truffleruby_baseurl="vm-${truffleruby_version}/${rvm_ruby_package_file}.tar.gz"
-  rvm_ruby_url="${rvm_ruby_repo_url:-$(__rvm_db "truffleruby_url")/${truffleruby_baseurl}}"
+  rvm_ruby_url="${rvm_ruby_repo_url:-$(__rvm_db "truffleruby_url")/vm-${truffleruby_version}/${rvm_ruby_package_file}.tar.gz}"
 
   true # for OSX
 }

--- a/scripts/functions/utility
+++ b/scripts/functions/utility
@@ -284,7 +284,7 @@ __rvm_find_first_file()
 file_exists_at_url_command()
 {
   __rvm_curl --silent --insecure --location --list-only \
-    --max-time ${rvm_max_time_flag:-5} --head -X GET "$@" 2>&1 |
+    --max-time ${rvm_max_time_flag:-5} --head "$@" 2>&1 |
     __rvm_grep -E 'HTTP/[0-9\.]+ 200' >/dev/null 2>&1 ||
     {
       \typeset __ret=$?

--- a/scripts/functions/utility_system
+++ b/scripts/functions/utility_system
@@ -52,10 +52,6 @@ __rvm_ruby_package_file()
       )"
       rvm_ruby_package_file="/${__version}/jruby-dist-${__version}-bin.$(__rvm_remote_extension "$1" -)"
       ;;
-    truffleruby*)
-      __rvm_select_interpreter_truffleruby
-      rvm_ruby_package_file="/${truffleruby_baseurl}"
-      ;;
     "")
       rvm_ruby_package_file=""
       ;;

--- a/scripts/functions/utility_system
+++ b/scripts/functions/utility_system
@@ -129,12 +129,7 @@ __rvm_remote_server_path()
   \typeset _iterator
   _iterator=""
   while ! __rvm_remote_server_path_single 0 1 "${_iterator}" "${1:-}"
-  do
-    if [[ -z "$_iterator" ]]; then
-      _iterator=0
-    else
-      : $(( _iterator+=1 ))
-    fi
+  do : $(( _iterator+=1 ))
   done
 }
 

--- a/scripts/functions/utility_system
+++ b/scripts/functions/utility_system
@@ -20,9 +20,6 @@ __rvm_remote_extension()
     jruby-*)
       rvm_remote_extension="tar.gz"
       ;;
-    truffleruby-*)
-      rvm_remote_extension="tar.gz"
-      ;;
     *)
       rvm_remote_extension="tar.bz2"
       ;;

--- a/scripts/functions/utility_system
+++ b/scripts/functions/utility_system
@@ -53,7 +53,6 @@ __rvm_ruby_package_file()
       rvm_ruby_package_file="/${__version}/jruby-dist-${__version}-bin.$(__rvm_remote_extension "$1" -)"
       ;;
     truffleruby*)
-      __rvm_ruby_string_parse || return $? # Sets rvm_ruby_version
       __rvm_select_interpreter_truffleruby
       rvm_ruby_package_file="/${truffleruby_baseurl}"
       ;;


### PR DESCRIPTION
TruffleRuby is a mix of "source" and "binary" Ruby in RVM terminology (https://github.com/rvm/rvm/issues/4297#issuecomment-397843910 for details).
So originally I added the "from source" code (#4406), and then later the "binary" code (#4456) as that's what TravisCI normally uses. However, the TravisCI code had to be modified anyway, so there is no need for handling TruffleRuby as a "binary" Ruby in RVM anymore.

I want to remove the code (which I added) for handling TruffleRuby as a "binary" Ruby. It's duplicating a fair bit of code, it does not work well, and introduces more ways to fail.
For example, one part which is fragile with binary rubies is for instance downloading with a timeout and trying all the remotes. I don't want that, I know exactly the one URL where TruffleRuby should be downloaded from for a given version.
Here are some issues that are all avoided by using the "source" installation path: #4633 #4497 #4506.

This PR effectively reverts #4456 and #4662, except a commit that is a pure refactoring (58251a968139a15169020602799c27cfc55d906e) and a commit adding behavior potentially useful when using `rvm mount` (e9d9c884df6b8e47b5cd6ee2557fe4ce96ddd427).

cc @pkuczynski 