### PR TITLE
Remove rvm_gems_path from PATH as part of __rvm_remove_rvm_from_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Fix rvm version validation per project [\#4692](https://github.com/rvm/rvm/pull/4692)
 * Fix endless loop on macOS when listing remotes [\#4703](https://github.com/rvm/rvm/pull/4703)
 * Filter redundant/incompatible rvm\_gem\_options [\#4705](https://github.com/rvm/rvm/pull/4705)
+* Remove rvm_gems_path as part of __rvm_remove_rvm_from_path [\#4712](https://github.com/rvm/rvm/pull/4712)
 
 #### Changes
 * TruffleRuby is now always considered a "source Ruby" instead of both a source

--- a/scripts/functions/env
+++ b/scripts/functions/env
@@ -135,6 +135,7 @@ __rvm_remove_rvm_from_path()
 {
   \typeset local_rvm_path
   __rvm_remove_from_path "${rvm_path%/}/*"
+  __rvm_remove_from_path "${rvm_gems_path%/}/*"
   __rvm_remove_from_path "${rvm_bin_path}"  #TODO: this might be dangerous if rvm is available in some common path
 
   while local_rvm_path="$( __rvm_which rvm 2>/dev/null )"


### PR DESCRIPTION
Fixes # .

I'm running Ubuntu with RVM installed using the PPA.  The rvm_path is set to ```/usr/share/rvm``` however my gems (by default) are installed to ```~/.rvm/gems```.  As a result, when I cd to different directories my PATH gets longer and longer because the gems paths aren't removed.

Changes proposed in this pull request:
* When removing directories from PATH in ```__rvm_remove_rvm_from_path``` also remove directories with ```rvm_gems_path``` as a prefix.


Make sure that your pull request includes entry in the [CHANGELOG](CHANGELOG.md).