### PR TITLE
Fix checksums part two: only check URL checksums for Rubinius

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Filter redundant/incompatible rvm\_gem\_options [\#4705](https://github.com/rvm/rvm/pull/4705)
 * Remove rvm_gems_path as part of __rvm_remove_rvm_from_path [\#4712](https://github.com/rvm/rvm/pull/4712)
 * Fix checksum check condition to not try url if already found in config files [\#4707](https://github.com/rvm/rvm/pull/4707)
+* Fix checksum check to only try url checksums for Rubinius [\#4717](https://github.com/rvm/rvm/pull/4717)
 
 #### Changes
 * TruffleRuby is now always considered a "source Ruby" instead of both a source

--- a/scripts/functions/checksum
+++ b/scripts/functions/checksum
@@ -213,10 +213,11 @@ __rvm_checksum_read()
     __rvm_checksum_any && return 0
   done
 
-  # Only try to get the checksum from the network after checking the config files
+  # Only try to get the checksum from the network after checking the config files.
+  # Only for Rubinius, as querying that URL might return something else (e.g., the archive).
   for _name in "${list[@]}"
   do
-    if [[ $_name == http* ]]; then
+    if [[ $_name == http*rubinius* ]]; then
       if [[ -z "${_checksum_md5:-}" ]]; then
         _checksum_md5="$(__rvm_curl -s -L $_name.md5)"
       fi

--- a/scripts/functions/checksum
+++ b/scripts/functions/checksum
@@ -195,6 +195,8 @@ __rvm_checksum_read()
 
   for _name in "${list[@]}"
   do
+    rvm_debug "Searching checksum config files for $_name"
+
     # md5
     _checksum_md5="$(      __rvm_db_ "$rvm_path/config/md5"    "$_name" | \command \head -n 1 )"
 

--- a/scripts/functions/checksum
+++ b/scripts/functions/checksum
@@ -185,11 +185,12 @@ __rvm_checksum_read()
 
   for _name in "$@"
   do
-    list+=( "$_name" )
     if
       [[ "$_name" == *"?"* ]] # try url without ?... like ?rvm={version}
     then
       list+=( "${_name%\?*}" )
+    else
+      list+=( "$_name" )
     fi
   done
 


### PR DESCRIPTION
Now that checksums work again with #4707, I noticed new checksum mismatches, for example
https://travis-ci.org/rvm/rvm/jobs/547675787
Which seems to be the reason the CI currently fails on macOS.

In TravisCI, binary rubies from TravisCI are used on macOS, which meant https://rubies.travis-ci.org/osx/10.13/x86_64/ruby-2.3.4.tar.bz2?rvm=1.29.8-next.md5 would be tried.
And actually, even fixing that to https://rubies.travis-ci.org/osx/10.13/x86_64/ruby-2.3.4.tar.bz2.md5, that still downloads the full archive, not a checksum file.
So let's not assume `"#{archive_url}.md5"` always downloads a checksum file, but only do it for Rubinius which needs it (#4650).
Downloading a checksum from the same location as the archive seems also less good from a security point of view, so limiting that to the only case that needs it is also better.