### PR TITLE
Handle an error on tags fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Fix checksum check condition to not try url if already found in config files [\#4707](https://github.com/rvm/rvm/pull/4707)
 * Fix checksum check to only try url checksums for Rubinius [\#4717](https://github.com/rvm/rvm/pull/4717)
 * Fix `sed: illegal option -- r` error on macOS when changing to any ruby directory [\#4711](https://github.com/rvm/rvm/pull/4711)
+* Don't ignore `curl` error on repo tags fetch [\#4722](https://github.com/rvm/rvm/pull/4722)
 
 #### Changes
 * TruffleRuby is now always considered a "source Ruby" instead of both a source

--- a/binscripts/rvm-installer
+++ b/binscripts/rvm-installer
@@ -3,6 +3,7 @@
 shopt -s extglob
 set -o errtrace
 set -o errexit
+set -o pipefail
 
 rvm_install_initialize()
 {
@@ -277,7 +278,7 @@ fetch_versions()
       _url=https://${_domain}/api/v3/repos/${_account}/${_repo}/tags
       ;;
   esac
-  __rvm_curl -s ${_url} |
+  __rvm_curl -sS ${_url} |
     \awk -v RS=',' -v FS='"' '$2=="name"{print $4}' |
     sort -t. -k 1,1n -k 2,2n -k 3,3n -k 4,4n -k 5,5n
 }


### PR DESCRIPTION
See https://travis-ci.community/t/rvm-tries-to-download-blank-version-of-itself/3972

I believe this happens if `__rvm_curl -s https://api.github.com/repos/rvm/rvm/tags` fails -- then the output is blank and `_version` in `install_release()` gets set to nothing.

Changes proposed in this pull request:
* Don't ignore a possible error on repo tags fetch
