### PR TITLE
Fix rvm-installer's RVM version-fetching from Bitbucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,11 @@
 *
 
 #### Bug fixes
-* Prevent attempted download of null RVM versions in rvm-installer.
-* Fix rvm-installer's mechanism for fetching RVM tags from Bitbucket.
+* Prevent downloading of null RVM versions in installer [\#4728](https://github.com/rvm/rvm/pull/4728)
+* Fix fetching RVM tags from Bitbucket [\#4728](https://github.com/rvm/rvm/pull/4728)
 
 #### Changes
-* rvm-installer now reports which URL it is fetching version information from.
-* rvm-installer now reports when version fetching has completely failed.
+* Installer now reports which URL it is using to fetch the version information and when version fetching has completely failed [\#4728](https://github.com/rvm/rvm/pull/4728)
 
 #### Binaries:
 *

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 #### Changes
 * rvm-installer now reports which URL it is fetching version information from.
+* rvm-installer now reports when version fetching has completely failed.
 
 #### Binaries:
 *

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 #### Bug fixes
 * Prevent attempted download of null RVM versions in rvm-installer.
+* Fix rvm-installer's mechanism for fetching RVM tags from Bitbucket.
 
 #### Changes
 * rvm-installer now reports which URL it is fetching version information from.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 *
 
 #### Changes
-*
+* rvm-installer now reports which URL it is fetching version information from.
 
 #### Binaries:
 *

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 *
 
 #### Bug fixes
-*
+* Prevent attempted download of null RVM versions in rvm-installer.
 
 #### Changes
 * rvm-installer now reports which URL it is fetching version information from.

--- a/binscripts/rvm-installer
+++ b/binscripts/rvm-installer
@@ -29,6 +29,7 @@ log()  { printf "%b\n" "$*"; }
 debug(){ [[ ${rvm_debug_flag:-0} -eq 0 ]] || printf "%b\n" "$*" >&2; }
 notice() { log "$*" >&2 ; }
 fail() { log "\nERROR: $*\n" >&2 ; exit 1 ; }
+fail_with_code() { code="$1" ; shift ; log "\nERROR: $*\n" >&2 ; exit "$code" ; }
 
 rvm_install_commands_setup()
 {
@@ -831,7 +832,7 @@ and re-mount partition ${partition} without the noexec option."
 
 rvm_install_select_and_get_version()
 {
-  typeset _version_release
+  typeset dir _version_release _version
 
   for dir in "$rvm_src_path" "$rvm_archives_path"
   do
@@ -842,20 +843,23 @@ rvm_install_select_and_get_version()
   case "${version}" in
     (head)
       _version_release="${branch}"
-      install_head sources[@] ${branch:-master} || exit $?
+      install_head sources[@] ${branch:-master} || fail_with_code $? "Failed to install version '$version'"
       ;;
 
     (latest)
-      install_release sources[@] $(fetch_version sources[@]) || exit $?
+      _version=$(fetch_version sources[@])   || fail "Failed to fetch version '$version'"
+      install_release sources[@] "$_version" || fail_with_code $? "Failed to install version '$version'"
       ;;
 
     (latest-minor)
       version="$(\cat "$rvm_path/VERSION")"
-      install_release sources[@] $(fetch_version sources[@] ${version%.*}) || exit $?
+      _version=$(fetch_version sources[@] ${version%.*}) || fail "Failed to fetch version '$version'"
+      install_release sources[@] "$_version"             || fail_with_code $? "Failed to install version '$version'"
       ;;
 
     (latest-*)
-      install_release sources[@] $(fetch_version sources[@] ${version#latest-}) || exit $?
+      _version=$(fetch_version sources[@] ${version#latest-}) || fail "Failed to fetch version '$version'"
+      install_release sources[@] "$_version"                  || fail_with_code $? "Failed to install version '$version'"
       ;;
 
     (+([[:digit:]]).+([[:digit:]]).+([[:digit:]])) # x.y.z

--- a/binscripts/rvm-installer
+++ b/binscripts/rvm-installer
@@ -263,7 +263,7 @@ fetch_version()
   return 4
 }
 
-# Returns a sorted list of all version tags from a repository
+# Returns a sorted list of most recent tags from a repository
 fetch_versions()
 {
   typeset _account _domain _repo _url
@@ -272,7 +272,7 @@ fetch_versions()
   _repo=$3
   case ${_domain} in
     (bitbucket.org)
-      _url=https://${_domain}/api/1.0/repositories/${_account}/${_repo}/branches-tags
+      _url="https://api.${_domain}/2.0/repositories/${_account}/${_repo}/refs/tags?sort=-name&pagelen=20"
       ;;
     (github.com)
       _url=https://api.${_domain}/repos/${_account}/${_repo}/tags
@@ -284,7 +284,7 @@ fetch_versions()
   esac
   notice "Fetching ${_url}"
   __rvm_curl -sS ${_url} |
-    \awk -v RS=',' -v FS='"' '$2=="name"{print $4}' |
+    \awk -v RS=',|values":' -v FS='"' '$2=="name"&&$4!="rvm"{print $4}' |
     sort -t. -k 1,1n -k 2,2n -k 3,3n -k 4,4n -k 5,5n
 }
 

--- a/binscripts/rvm-installer
+++ b/binscripts/rvm-installer
@@ -258,6 +258,8 @@ fetch_version()
       return 0
     fi
   done
+  notice "Exhausted all sources trying to fetch version of RVM!"
+  return 4
 }
 
 # Returns a sorted list of all version tags from a repository

--- a/binscripts/rvm-installer
+++ b/binscripts/rvm-installer
@@ -27,6 +27,7 @@ rvm_install_initialize()
 
 log()  { printf "%b\n" "$*"; }
 debug(){ [[ ${rvm_debug_flag:-0} -eq 0 ]] || printf "%b\n" "$*" >&2; }
+notice() { log "$*" >&2 ; }
 fail() { log "\nERROR: $*\n" >&2 ; exit 1 ; }
 
 rvm_install_commands_setup()
@@ -278,6 +279,7 @@ fetch_versions()
       _url=https://${_domain}/api/v3/repos/${_account}/${_repo}/tags
       ;;
   esac
+  notice "Fetching ${_url}"
   __rvm_curl -sS ${_url} |
     \awk -v RS=',' -v FS='"' '$2=="name"{print $4}' |
     sort -t. -k 1,1n -k 2,2n -k 3,3n -k 4,4n -k 5,5n


### PR DESCRIPTION
Support for Bitbucket REST API v1 had been dropped.  This fix ensures that if GitHub returns a 403, the Bitbucket fallback can save the day.

3 additional changes are in this PR order to improve the strictness of the fetch_version function, leading to clearer error messages and avoids fetching bogus URLs without tags.

Changes proposed in this pull request:

#### Bug fixes
* Prevent attempted download of null RVM versions in rvm-installer.
* Fix rvm-installer's mechanism for fetching RVM tags from Bitbucket.
  _This is increasingly important when occasional 403 / api-rate-limiting issues occur when interacting with GitHub._

#### Changes
* rvm-installer now reports which URL it is fetching version information from.
* rvm-installer now reports when version fetching has completely failed.