### PR TITLE
Fix installer fetching RVM tags from Bitbucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 *
 
 #### Bug fixes
-*
+* Fix fetching RVM tags from Bitbucket in installer [\#4729](https://github.com/rvm/rvm/pull/4729)
 
 #### Changes
 *

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 *
 
 #### Bug fixes
-* Fix fetching RVM tags from Bitbucket in installer [\#4730](https://github.com/rvm/rvm/pull/4730)
+* Fix installer fetching RVM tags from Bitbucket [\#4730](https://github.com/rvm/rvm/pull/4730)
 
 #### Changes
 *

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 *
 
 #### Bug fixes
-* Fix fetching RVM tags from Bitbucket in installer [\#4729](https://github.com/rvm/rvm/pull/4729)
+* Fix fetching RVM tags from Bitbucket in installer [\#4730](https://github.com/rvm/rvm/pull/4730)
 
 #### Changes
 *

--- a/binscripts/rvm-installer
+++ b/binscripts/rvm-installer
@@ -259,7 +259,7 @@ fetch_version()
   done
 }
 
-# Returns a sorted list of all version tags from a repository
+# Returns a sorted list of most recent tags from a repository
 fetch_versions()
 {
   typeset _account _domain _repo _url
@@ -268,7 +268,7 @@ fetch_versions()
   _repo=$3
   case ${_domain} in
     (bitbucket.org)
-      _url=https://${_domain}/api/1.0/repositories/${_account}/${_repo}/branches-tags
+      _url="https://api.${_domain}/2.0/repositories/${_account}/${_repo}/refs/tags?sort=-name&pagelen=20"
       ;;
     (github.com)
       _url=https://api.${_domain}/repos/${_account}/${_repo}/tags
@@ -279,7 +279,7 @@ fetch_versions()
       ;;
   esac
   __rvm_curl -sS ${_url} |
-    \awk -v RS=',' -v FS='"' '$2=="name"{print $4}' |
+    \awk -v RS=',|values":' -v FS='"' '$2=="name"&&$4!="rvm"{print $4}' |
     sort -t. -k 1,1n -k 2,2n -k 3,3n -k 4,4n -k 5,5n
 }
 


### PR DESCRIPTION
Support for Bitbucket REST API v1 had been dropped.  This fix ensures that if GitHub returns a 403, the Bitbucket fallback can save the day.

Changes proposed in this pull request:

#### Bug fixes
* Fix rvm-installer's mechanism for fetching RVM tags from Bitbucket.
  _This is increasingly important when occasional 403 / api-rate-limiting issues occur when interacting with GitHub.  This is currently happening frequently on Travis-CI._