### PR TITLE
Ignore aliases when using `ls` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Fix installer fetching RVM tags from Bitbucket [\#4730](https://github.com/rvm/rvm/pull/4730)
 * Prevent downloading of null RVM versions in installer [\#4731](https://github.com/rvm/rvm/pull/4731)
 * RVM package fails to configure on fresh Ubuntu 18.04 server install [\#4742](https://github.com/rvm/rvm/pull/4742)
+* Ignore aliases when using `ls` command [\#4743](https://github.com/rvm/rvm/pull/4743)
 
 #### Changes
 * Installer now reports which URL(s) have failed to fetch version information and when version fetching has completely failed [\#4731](https://github.com/rvm/rvm/pull/4731)

--- a/scripts/functions/gemset
+++ b/scripts/functions/gemset
@@ -135,9 +135,7 @@ is_gem_installed()
     version_check="*([[:digit:]\.])"
   fi
 
-  _ls_command="[[ -f /bin/ls ]] && /bin/ls || ls"
-
-  _ls_command -ld "${rvm_ruby_gem_home:-$GEM_HOME}/gems"/${gem_name}-${version_check} >/dev/null 2>&1 ||
+  __rvm_ls -ld "${rvm_ruby_gem_home:-$GEM_HOME}/gems"/${gem_name}-${version_check} >/dev/null 2>&1 ||
   "${rvm_ruby_binary}" -rrubygems -e "$gem_spec" 2>/dev/null ||
   return $?
 }
@@ -170,10 +168,8 @@ gem_install_force()
   \typeset __available_gem
   \typeset -a install_params
 
-  _ls_command="[[ -f /bin/ls ]] && /bin/ls || ls"
-
   install_params=()
-  __available_gem="$( _ls_command -v1 "${rvm_path}/gem-cache"/${gem_name}-${version_check}.gem 2>/dev/null | tail -n 1 )"
+  __available_gem="$( __rvm_ls -v1 "${rvm_path}/gem-cache"/${gem_name}-${version_check}.gem 2>/dev/null | tail -n 1 )"
 
   if   [[ -n "${__available_gem}" ]]
   then install_params+=( --local )

--- a/scripts/functions/gemset
+++ b/scripts/functions/gemset
@@ -134,7 +134,10 @@ is_gem_installed()
   else
     version_check="*([[:digit:]\.])"
   fi
-  ls -ld "${rvm_ruby_gem_home:-$GEM_HOME}/gems"/${gem_name}-${version_check} >/dev/null 2>&1 ||
+
+  _ls_command="[[ -f /bin/ls ]] && /bin/ls || ls"
+
+  _ls_command -ld "${rvm_ruby_gem_home:-$GEM_HOME}/gems"/${gem_name}-${version_check} >/dev/null 2>&1 ||
   "${rvm_ruby_binary}" -rrubygems -e "$gem_spec" 2>/dev/null ||
   return $?
 }
@@ -167,8 +170,10 @@ gem_install_force()
   \typeset __available_gem
   \typeset -a install_params
 
+  _ls_command="[[ -f /bin/ls ]] && /bin/ls || ls"
+
   install_params=()
-  __available_gem="$( \ls -v1 "${rvm_path}/gem-cache"/${gem_name}-${version_check}.gem 2>/dev/null | tail -n 1 )"
+  __available_gem="$( _ls_command -v1 "${rvm_path}/gem-cache"/${gem_name}-${version_check}.gem 2>/dev/null | tail -n 1 )"
 
   if   [[ -n "${__available_gem}" ]]
   then install_params+=( --local )

--- a/scripts/functions/support
+++ b/scripts/functions/support
@@ -587,3 +587,5 @@ __rvm_record_ruby_configs()
     fi
   done
 }
+
+__rvm_ls() { \command \ls "$@" || return $?; }


### PR DESCRIPTION
This is an addendum on #4282 for ZSH and possibly other shells.
The current version works fine on bash when `alias ls='something-not-ls'` but on zsh `alias ls='something-not-ls'` is called it currently fails.

It also fixes another `ls` command invocation in `is_gem_installed()`. 

Where `/bin/ls` is installed, this is used instead of the terminals `ls` short command. Otherwise it defaults to the shell sessions `ls` alias if it doesn't find it.

This can be helpful to make sure the default command doesn't have extra arguments.

This was my first attempt and I was able to get rid of the bug, but I think it might be worth it to move the `_ls_command` command out of the function.