### PR TITLE
Export more shell functions which cause the subshell to choke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@
 * Fix installer fetching RVM tags from Bitbucket [\#4730](https://github.com/rvm/rvm/pull/4730)
 * Prevent downloading of null RVM versions in installer [\#4731](https://github.com/rvm/rvm/pull/4731)
 * RVM package fails to configure on fresh Ubuntu 18.04 server install [\#4742](https://github.com/rvm/rvm/pull/4742)
-* Ignore aliases when using `ls` command [\#4743](https://github.com/rvm/rvm/pull/4743)
+* Ignore aliases when using `ls` command [\#4743](https://github.com/rvm/rvm/pull/4743) [\#4744](https://github.com/rvm/rvm/pull/4744)
+* Export more shell functions which cause the subshell to choke [\#4745](https://github.com/rvm/rvm/pull/4745)
 
 #### Changes
 * Installer now reports which URL(s) have failed to fetch version information and when version fetching has completely failed [\#4731](https://github.com/rvm/rvm/pull/4731)

--- a/scripts/functions/environment
+++ b/scripts/functions/environment
@@ -186,7 +186,7 @@ __variables_definition()
 
   # prevent errors with bash "set -a", see https://github.com/rvm/rvm/issues/2872
   if [[ -n "${BASH_VERSION:-}" ]]
-  then export -fn __rvm_select_version_variables __rvm_ruby_string_parse_ __rvm_rm_rf_verbose __rvm_parse_args 2>/dev/null || true
+  then export -fn __rvm_select_version_variables __rvm_ruby_string_parse_ __rvm_rm_rf_verbose __rvm_parse_args __rvm_ruby_string_find __rvm_file_load_env __rvm_remove_without_gems 2>/dev/null || true
   fi
 }
 


### PR DESCRIPTION
Fixes #4721.

Changes proposed in this pull request:
* Export more shell functions which cause the subshell to choke.
