### PR TITLE
Restore rvm test

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -5,14 +5,19 @@
 Note that the [`vboxtest`](docs/vm_tests.md) approach is now outdated.
 It's better to use the
 [`rvm-test`](https://github.com/rvm/rvm-test/) test suite
-which lives in a separate git submodule.  (It's separate in order to
+which lives in a separate git subtree.  (It's separate in order to
 allow reuse when hacking on rvm2).
 
-    $ git submodule init    # Register the rvm-test submodule in .git/config
-    $ git submodule update  # Check out the rvm-test submodule
+    # first time add remote:
+    $ gr add -f rvm-test git@github.com:rvm/rvm-test.git
+    # next time fetch it:
+    $ git fetch rvm-test master
+    # update the subtree
+    $ git subtree pull --prefix  rvm-test rvm-test master --squash
 
-Now read [`rvm-test`'s
-README.md](https://github.com/rvm/rvm-test/blob/master/README.md)
+[More details on subtrees](https://www.atlassian.com/blog/git/alternatives-to-git-submodule-git-subtree)
+
+Now read [`rvm-test`'s README.md](https://github.com/rvm/rvm-test/blob/master/README.md)
 and follow those instructions to make sure you can successfully run
 the tests (you will need rvm already installed).
 

--- a/rvm-test/.gitignore
+++ b/rvm-test/.gitignore
@@ -1,0 +1,9 @@
+*.log
+config/database.yml
+db/config.yml
+db/*.rvm
+db/*.db
+.idea
+config/github.yml
+config/github.rb
+Gemfile.lock

--- a/rvm-test/.travis.yml
+++ b/rvm-test/.travis.yml
@@ -1,0 +1,24 @@
+language: ruby
+rvm:
+  - 2.4.1
+before_install:
+  - unset BUNDLE_GEMFILE
+  - rvm get head
+  - rvm alias delete default
+  - hash -r
+  - rm ~/.rvm/hooks/after_use
+install: gem install tf -v '>=0.4.1'
+script: 'NOEXEC=skip tf --text $TEST'
+env:
+  - TEST=fast/*
+  - TEST=long/named_ruby_and_gemsets_comment_test.sh
+  - TEST=long/truffleruby_comment_test.sh
+notifications:
+  irc:
+    channels:
+      - "irc.freenode.org#rvm-test"
+  email:
+    recipients:
+      - mpapis@gmail.com
+      - me@deryldoucette.com
+    on_failure: change

--- a/rvm-test/.versions.conf
+++ b/rvm-test/.versions.conf
@@ -1,0 +1,4 @@
+ruby=2.4.1
+ruby-gemset=rvm-test
+ruby-gem-install=bundler
+ruby-bundle-install=true

--- a/rvm-test/Gemfile
+++ b/rvm-test/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'tf'

--- a/rvm-test/README.md
+++ b/rvm-test/README.md
@@ -1,0 +1,23 @@
+# RVM - Tests
+
+Set of tests for [RVM](https://github.com/wayneeseguin/rvm/).
+
+## Usage
+
+    $ gem install tf    # Install testing framework
+    $ tf fast/*         # Run the short tests (those are run on travis)
+    $ tf long/*         # Run the long set of tests, like installing rubies.
+    $ tf --text long/*  # Same as above, but watch output
+
+## Comment tests
+
+Filenames have to end with `_comment_test.sh`
+
+Example test file:
+
+    ## User comments start with double #
+    ## command can be writen in one line with multiple tests:
+    true # status=0; match=/^$/
+    ## or tests can be placed in following lines:
+    false
+    # status=1

--- a/rvm-test/fast/alias_comment_test.sh
+++ b/rvm-test/fast/alias_comment_test.sh
@@ -1,0 +1,33 @@
+source "$rvm_path/scripts/rvm"
+
+rvm use 2.3.4 --install
+rvm use 2.4.0 --install
+rvm gemset create test_gemset
+
+rvm alias create default 2.4.0@test_gemset # status=0
+ls -l $rvm_path/environments/default       # status=0; match=/2.4.0@test_gemset/
+rvm alias list                             # match=/^default => ruby-2.4.0@test_gemset$/
+rvm alias delete default                   # status=0
+ls -l $rvm_path/environments/default       # status!=0
+
+rvm alias create ruby-test-default 2.4.0@test_gemset # status=0
+ls -l $rvm_path/environments/ruby-test-default       # status=0
+rvm alias list                                       # match=/^ruby-test-default => ruby-2.4.0@test_gemset$/
+rvm alias list names                                 # match=/^ruby-test-default$/
+rvm alias delete ruby-test-default                   # status=0
+ls -l $rvm_path/environments/ruby-test-default       # status!=0
+
+rvm --force gemset delete test_gemset
+
+: overwrite existing aliases
+rvm alias create veve 2.3.4  # status=0
+ls -l $rvm_path/environments/veve # status=0; match=/2.3.4/
+ls -l $rvm_path/wrappers/veve     # status=0; match=/2.3.4/
+rvm alias list                    # match=/^veve => ruby-2.3.4$/
+rvm alias create veve 2.4.0       # status=0
+ls -l $rvm_path/environments/veve # status=0; match=/2.4.0/
+ls -l $rvm_path/wrappers/veve     # status=0; match=/2.4.0/
+rvm alias list                    # match=/^veve => ruby-2.4.0$/
+rvm alias delete veve             # status=0
+ls -l $rvm_path/environments/veve # status!=0
+rvm alias list                    # match!=/^veve => /

--- a/rvm-test/fast/current_and_list_comment_test.sh
+++ b/rvm-test/fast/current_and_list_comment_test.sh
@@ -1,0 +1,32 @@
+source "$rvm_path/scripts/rvm"
+
+rvm try_install 2.4.0
+rvm try_install 2.3.4
+rvm try_install 2.4.1
+
+: separate default/current
+rvm use 2.4.0@abc-test --create --default
+# status=0
+# match=/Using .*ruby-2.4.0 with gemset abc-test/
+rvm current
+# match=/ruby-2.4.0@abc-test/
+
+rvm use 2.3.4@abc-test --create
+# status=0
+# match=/Using .*ruby-2.3.4 with gemset abc-test/
+rvm current
+# match=/ruby-2.3.4@abc-test/
+
+rvm list
+# match=/^ \* ruby-2.4.0/
+# match=/^=> ruby-2.3.4/
+
+: default == current
+rvm use 2.4.1@abc-test --create --default
+# status=0
+# match=/Using .*ruby-2.4.1 with gemset abc-test/
+rvm current
+# match=/ruby-2.4.1@abc-test/
+
+rvm list
+# match=/^=\* ruby-2.4.1/

--- a/rvm-test/fast/do_comment_test.sh
+++ b/rvm-test/fast/do_comment_test.sh
@@ -1,0 +1,83 @@
+source "$rvm_path/scripts/rvm"
+
+rvm use 2.3.4 --install # status=0
+rvm gemset create test1 # status=0
+rvm gemset create test2 # status=0
+rvm use 2.4.0 --install # status=0
+
+: do
+rvm 8.9.9 do rvm gemdir # status=1; match=/is not installed/
+rvm 2.3.4 do rvm gemdir # status=0; match=/2.3.4/
+rvm 2.3.4@test0 do rvm gemdir # status=2; match=/Gemset .* does not exist/
+rvm 2.3.4@test1 do rvm gemdir # status=0; match=/2.3.4@test1/
+rvm 2.3.4@test2 do rvm gemdir # status=0; match=/2.3.4@test2/
+
+rvm 2.3.4@global,2.3.4 do rvm gemdir # status=0; match=/2.3.4@global$/; match=/2.3.4$/
+
+rvm --force gemset delete test1 # status=0
+rvm --force gemset delete test2 # status=0
+
+: FIXME: The following tests have awful duplication due to https://github.com/mpapis/tf/issues/6
+
+: -----------------------------------------------------------------
+: do in directory with no version
+
+true TMPDIR:${TMPDIR:=/tmp}:
+d=$TMPDIR/test-rvm-do-in
+mkdir -p $d
+
+: absolute directory
+rvm in $d do rvm info ruby  # status=1; match=/Could not determine which Ruby to use/
+rvm in $d do ruby --version # status=1; match=/Could not determine which Ruby to use/
+
+: relative directory
+cd $TMPDIR
+rvm in test-rvm-do-in do rvm info ruby  # status=1; match=/Could not determine which Ruby to use/
+rvm in test-rvm-do-in do ruby --version # status=1; match=/Could not determine which Ruby to use/
+
+: current directory
+cd $d
+rvm in . do rvm info ruby  # status=1; match=/Could not determine which Ruby to use/
+rvm in . do ruby --version # status=1; match=/Could not determine which Ruby to use/
+rvm    . do rvm info ruby  # status=1; match=/Could not determine which Ruby to use/
+rvm    . do ruby --version # status=1; match=/Could not determine which Ruby to use/
+
+: -----------------------------------------------------------------
+mkdir -p $d/2.3.4
+echo "2.3.4" > $d/2.3.4/.ruby-version
+
+: absolute directory
+rvm in $d/2.3.4 do rvm info ruby  # status=0; match=/version: *"2.3.4/
+rvm in $d/2.3.4 do ruby --version # status=0; match=/^ruby 2.3.4/
+
+: relative directory
+cd $d
+rvm in 2.3.4 do rvm info ruby  # status=0; match=/version: *"2.3.4/
+rvm in 2.3.4 do ruby --version # status=0; match=/^ruby 2.3.4/
+
+: current directory
+cd $d/2.3.4
+rvm . do rvm info ruby  # status=0; match=/version: *"2.3.4/
+rvm . do ruby --version # status=0; match=/^ruby 2.3.4/
+
+: -----------------------------------------------------------------
+ver=2.4.0
+mkdir -p $d/2.4.0
+echo "2.4.0" > $d/2.4.0/.ruby-version
+
+: absolute directory
+rvm in $d/2.4.0 do rvm info ruby  # status=0; match=/version: *"2.4.0/
+rvm in $d/2.4.0 do ruby --version # status=0; match=/^ruby 2.4.0/
+
+: relative directory
+cd $d
+rvm in 2.4.0 do rvm info ruby  # status=0; match=/version: *"2.4.0/
+rvm in 2.4.0 do ruby --version # status=0; match=/^ruby 2.4.0/
+
+: current directory
+cd $d/2.4.0
+rvm . do rvm info ruby  # status=0; match=/version: *"2.4.0/
+rvm . do ruby --version # status=0; match=/^ruby 2.4.0/
+
+## cleanup
+rm -rf $d

--- a/rvm-test/fast/env_comment_test.sh
+++ b/rvm-test/fast/env_comment_test.sh
@@ -1,0 +1,7 @@
+source "$rvm_path/scripts/rvm"
+
+rvm use 2.4.0 --install
+
+rvm env 2.4.0           # match=/2.4.0/; match=/GEM_HOME=/; match=/GEM_PATH=/
+rvm env 2.4.0 --path    # match=/2.4.0/; match=/environments/
+rvm env 2.4.0 -- --path # match=/2.4.0/; match=/environments/

--- a/rvm-test/fast/exports_comment_test.sh
+++ b/rvm-test/fast/exports_comment_test.sh
@@ -1,0 +1,9 @@
+source "$rvm_path/scripts/rvm"
+
+export TEST_VAR=2     # env[TEST_VAR]=/^2$/
+rvm export TEST_VAR=3 # env[TEST_VAR]=/^3$/
+rvm unexport          # env[TEST_VAR]=/^2$/
+
+unset TEST_VAR        # env[TEST_VAR]=/^$/
+rvm export TEST_VAR=3 # env[TEST_VAR]=/^3$/
+rvm unexport          # env[TEST_VAR]=/^$/

--- a/rvm-test/fast/gem-bundle_comment_test.sh
+++ b/rvm-test/fast/gem-bundle_comment_test.sh
@@ -1,0 +1,21 @@
+source "$rvm_path/scripts/rvm"
+
+: setup/pretest
+export BUNDLE_GEMFILE=${TMPDIR:-/tmp}/Gemfile
+touch ${BUNDLE_GEMFILE}
+rvm alias delete default
+rvm use 2.3.4 --install
+rvm @global do gem uninstall bundler
+rvm gemset create gemtest
+rvm gemset use gemtest # status=0
+
+: test
+## this only happens after installing rvm: match=/Gem bundler is not installed/
+bundle config             # status=127
+gem install bundler --pre # status=0
+bundle config             # status=0 ; match=/Settings are listed in order of priority/
+
+: reset
+rvm gemset use default
+rvm --force gemset delete gemtest # status=0
+rm -f ${BUNDLE_GEMFILE}

--- a/rvm-test/fast/gemfile_comment_test.sh
+++ b/rvm-test/fast/gemfile_comment_test.sh
@@ -1,0 +1,47 @@
+source "$rvm_path/scripts/rvm"
+
+: settings
+true TMPDIR:${TMPDIR:=/tmp}:
+d=$TMPDIR/test-rvmrc
+f_rvmrc=$d/.rvmrc
+f_gemfile=$d/sub/Gemfile
+
+: prepare1
+rvm use 2.3.4 --install
+rvm gemset create gemfile
+rvm gemset create rvmrc
+mkdir -p $d/sub
+printf "rvm use 2.3.4@rvmrc\n"   > $f_rvmrc
+
+: test1
+rvm current           # match=/^ruby-2.3.4$/
+rvm_current_rvmrc=""
+rvm rvmrc load $d/sub # status=0; match=/Using .*ruby-2.3.4.*rvmrc/
+rvm current           # match=/^ruby-2.3.4@rvmrc$/
+
+: prepare2
+rvm use 2.3.4
+printf "source :rubygems\n\ngem 'haml'\n" > $f_gemfile
+
+: test2
+rvm current           # match=/^ruby-2.3.4$/
+rvm_current_rvmrc=""
+rvm rvmrc load $d/sub # status=0; match=/Using .*ruby-2.3.4.*rvmrc/
+rvm current           # match=/^ruby-2.3.4@rvmrc$/
+
+: prepare3
+rvm use 2.3.4
+## escape # -> \x23
+printf "source :rubygems\n\x23ruby=2.3.4\n\x23ruby-gemset=gemfile\ngem 'haml'\n" > $f_gemfile
+
+: test3
+rvm current           # match=/^ruby-2.3.4$/
+rvm_current_rvmrc=""
+rvm rvmrc load $d/sub # status=0; match!=/Using .*ruby-2.3.4.*rvmrc/
+rvm current           # match=/^ruby-2.3.4@gemfile$/
+
+: clean
+rvm use 2.3.4
+rvm --force gemset delete gemfile
+rvm --force gemset delete rvmrc
+rm -rf $d

--- a/rvm-test/fast/gemset-copy_comment_test.sh
+++ b/rvm-test/fast/gemset-copy_comment_test.sh
@@ -1,0 +1,9 @@
+source "$rvm_path/scripts/rvm"
+
+rvm use 2.4.0 --install
+
+:
+rvm gemset copy 2.4.0 2.4.0@testset # status=0; match=/Copying gemset/; match[stderr]=/^$/
+rvm gemset list                     # status=0; match=/ testset$/
+rvm gemset --force delete testset   # status=0; match=/Removing gemset testset/
+rvm gemset list                     # status=0; match!=/ testset$/

--- a/rvm-test/fast/gemsets_comment_test.sh
+++ b/rvm-test/fast/gemsets_comment_test.sh
@@ -1,0 +1,85 @@
+source "$rvm_path/scripts/rvm"
+
+rvm use 2.4.0 --install
+
+: create/use/rename/delete
+rvm gemset create test_gemset            # status=0 ; match=/gemset created/
+rvm gemset use test_gemset               # status=0 ; match=/Using /
+rvm current                              # match=/test_gemset/
+rvm gemset list                          # match=/test_gemset/; match!=/other_gems/
+rvm gemset rename test_gemset other_gems # status=0
+rvm current                              # match=/other_gems/
+rvm gemset list                          # match!=/test_gemset/; match=/other_gems/
+rvm --force gemset delete other_gems     # status=0
+rvm gemset list                          # match!=/test_gemset/
+rvm gemset create test_gemset            # status=0 ; match=/gemset created/
+rvm gemset use test_gemset               # status=0 ; match=/Using /
+rvm current                              # match=/test_gemset/
+rvm --force gemset delete test_gemset    # status=0
+rvm current                              # match=/^ruby-2.4.0$/
+rvm gemset list                          # match!=/test_gemset/
+
+: rvm ... do
+rvm 2.4.0 do rvm gemset create test_gemset            # status=0 ; match=/gemset created/
+rvm 2.4.0 do rvm gemset list                          # match=/test_gemset/; match!=/other_gems/
+rvm 2.4.0 do rvm --force gemset delete test_gemset    # status=0
+
+: rvm ... do new rvm_gemsets_path
+rvm use 2.4.0
+true TMPDIR:${TMPDIR:=/tmp}:
+d=$TMPDIR/test-rvm_gemsets_path
+mkdir -p $d
+echo rvm_gems_path=$d  >> ~/.rvmrc
+echo rvm_create_flag=1 >> ~/.rvmrc
+rvm gemset create test_gemset            # status=0 ; match=/gemset created/; match=/test-rvm_gemsets_path/
+rvm gemset list                          # match=/test_gemset/; match!=/other_gems/; match=/test-rvm_gemsets_path/
+rvm --force gemset delete test_gemset    # status=0
+rvm 2.4.0 do rvm gemset create test_gemset            # status=0 ; match=/gemset created/; match=/test-rvm_gemsets_path/
+rvm 2.4.0 do rvm gemset list                          # match=/test_gemset/; match!=/other_gems/; match=/test-rvm_gemsets_path/
+rvm 2.4.0 do rvm --force gemset delete test_gemset    # status=0
+\sed -e "\%rvm_gems_path=$d% d" -e "\%rvm_create_flag=1% d" < ~/.rvmrc > ~/.rvmrc.new && \mv -f ~/.rvmrc.new ~/.rvmrc
+rm -rf $d
+
+: export/import/use/empty
+rvm use 2.4.0
+rvm gemset create test_gemset
+rvm gemset use test_gemset               # status=0 ; match=/Using /
+rvm gemdir                               # match=/@test_gemset$/
+gem install haml
+rvm gemset export haml.gems              # status=0; match=/Exporting /
+[[ -f haml.gems ]]                       # status=0
+rvm --force gemset empty                 # status=0
+gem list                                 # match!=/haml/
+rvm gemset import haml.gems              # status=0; match=/Installing /
+rm haml.gems
+gem list                                 # match=/haml/
+rvm gemset use default                   # status=0 ; match=/Using /
+rvm --force --debug gemset empty test_gemset # status=0 ; match=/GEM_HOME=.*ruby-2.4.0@test_gemset/
+rvm gemset use test_gemset               # status=0 ; match=/Using /
+gem list                                 # match!=/haml/
+echo yes | rvm gemset delete test_gemset # status=0
+rvm gemset list                          # match!=/test_gemset/
+
+: use/create
+ls $rvm_path/wrappers/*test_gemset*      # status!=0
+ls $rvm_path/gems/*test_gemset*          # status!=0
+rvm gemset list                          # match!=/test_gemset/
+rvm --force gemset delete test_gemset    # status=0
+rvm gemset use test_gemset --create      # status=0 ; match=/Using /
+ls $rvm_path/wrappers/*test_gemset*      # status=0
+ls $rvm_path/gems/*test_gemset*          # status=0
+rvm gemset list                          # match=/test_gemset/
+rvm --force gemset delete test_gemset    # status=0
+
+: cleanup
+rm -rf $rvm_path/log/*
+ls $rvm_path/*/*test_gemset*             # status!=0
+rvm gemset list                          # match!=/test_gemset/
+
+: use
+rvm --force gemset delete unknown_gemset # status=0
+rvm gemset use unknown_gemset            # status!=0; match=/does not exist/
+rvm current                              # match!=/unknown_gemset/
+
+: default
+rvm gemset list                          # match=/default/

--- a/rvm-test/fast/globalcache_comment_test.sh
+++ b/rvm-test/fast/globalcache_comment_test.sh
@@ -1,0 +1,39 @@
+source "$rvm_path/scripts/rvm"
+
+rvm use 2.3.4 --install                           # status=0; env[GEM_HOME]=/2.3.4/
+rvm --force gemset globalcache disable
+rvm gemset globalcache enabled                    # match=/Disabled/
+
+[[ -L "$rvm_path/gems/cache" ]]                   # status!=0
+
+rvm gemset globalcache enable                     # status=0; match=/ global cache /
+rvm gemset globalcache enabled                    # status=0; match=/Enabled/
+rvm gemset list                                   # status=0; match!=/ testset$/
+
+rvm gemset create testset                         # status=0; match=/gemset created/
+rvm gemset list                                   # status=0; match=/ testset$/
+
+[[ -L "$rvm_path/gems/cache" ]]                   # status!=0
+[[ -d "$rvm_path/gems/cache" ]]                   # status=0
+
+rvm gemset copy 2.3.4@testset 2.3.4@testset2
+# status=0
+# match=/Copying gemset/
+# match!=/Unknown file type/
+# match!=/cannot overwrite directory/
+# match!=/with non-directory/
+# match!=/Error running/
+# match[stderr]=/^$/
+rvm gemset list                                   # status=0; match=/ testset2$/
+
+rvm gemset --force delete testset                 # status=0; match=/Removing gemset testset/
+rvm gemset --force delete testset2                # status=0; match=/Removing gemset testset2/
+
+rvm system                                        # status=0
+
+[[ -L "$rvm_path/gems/cache" ]]                   # status!=0
+[[ -d "$rvm_path/gems/cache" ]]                   # status=0
+[[ -d "$rvm_path/gems/cache/cache" ]]             ## status!=0 ... need more testing for this
+
+rvm --force gemset globalcache disable            # status=0;  match=/Removing the global cache/
+rvm gemset globalcache enabled                    # status!=0; match=/Disabled/

--- a/rvm-test/fast/remote_comment_test.sh
+++ b/rvm-test/fast/remote_comment_test.sh
@@ -1,0 +1,29 @@
+source "$rvm_path/scripts/rvm"
+
+: prepare
+true TMPDIR:${TMPDIR:=/tmp}:
+d=$TMPDIR/test-remote
+mkdir $d
+pushd $d
+rvm use 2.3.4 --install # status=0
+rvm list
+# match=/ruby-2.3.4/
+
+: tast packaging
+rvm prepare 2.3.4           # status=0
+[[ -f ruby-2.3.4.tar.bz2 ]] # status=0
+
+: remove it
+rvm remove --gems 2.3.4     # status=0
+rvm list
+# match!=/ruby-2.3.4/
+
+: get local ruby
+rvm mount -r ruby-2.3.4.tar.bz2 # status=0
+rvm list
+# match=/ruby-2.3.4/
+rvm use 2.3.4 # status=0; match[stderr]=/^$/
+
+: clean
+popd
+rm -rf $d

--- a/rvm-test/fast/ruby-version_comment_test.sh
+++ b/rvm-test/fast/ruby-version_comment_test.sh
@@ -1,0 +1,61 @@
+source "$rvm_path/scripts/rvm"
+
+: prepare
+true TMPDIR:${TMPDIR:=/tmp}:
+d=$TMPDIR/test-ruby-version
+f=$d/.ruby-version
+g=$d/.ruby-gemset
+e=$d/.ruby-env
+mkdir -p $d
+cd $d
+rvm use --install 2.4.1
+rvm use --install 2.4.0
+rvm use --install 2.3.4
+
+## simple
+: short version
+echo "2.4.0" > $f           # env[GEM_HOME]=/2.3.4/
+rvm use .                   # env[GEM_HOME]=/2.4.0/
+
+: ruby version
+rvm use 2.3.4
+echo "ruby-2.4.0" > $f      # env[GEM_HOME]=/2.3.4/
+rvm use .                   # env[GEM_HOME]=/2.4.0/
+
+: patch version
+rvm use 2.3.4
+echo "2.4.1" > $f      # env[GEM_HOME]=/2.3.4/
+rvm use .                   # env[GEM_HOME]=/2.4.1/
+
+: full version
+rvm use 2.3.4
+echo "ruby-2.4.1" > $f # env[GEM_HOME]=/2.3.4/
+rvm use .                   # env[GEM_HOME]=/2.4.1/
+
+: gemset
+rvm use 2.3.4
+echo "veve" > $g            # env[GEM_HOME]=/2.3.4/
+rvm use .                   # env[GEM_HOME]=/2.4.1@veve/
+rm -f $g
+
+: environment
+rvm use 2.3.4
+echo "test_me=3" > $e
+rvm use .                   # env[GEM_HOME]=/2.4.1/; env[test_me]=/^3$/
+rvm use 2.3.4               # env[GEM_HOME]=/2.3.4/; env[test_me]=/^$/
+
+: environment spaces
+rvm use 2.3.4
+echo 'test_space=test me' > $e
+rvm use .                   # env[GEM_HOME]=/2.4.1/; env[test_space]=/^test me$/
+rvm use 2.3.4               # env[GEM_HOME]=/2.3.4/; env[test_space]=/^$/
+
+: environment quotes and spaces
+rvm use 2.3.4
+echo 'test_space="test me"' > $e
+rvm use .                   # env[GEM_HOME]=/2.4.1/; env[test_space]=/^test me$/
+rvm use 2.3.4               # env[GEM_HOME]=/2.3.4/; env[test_space]=/^$/
+
+: clean
+cd ..
+rm -rf $d

--- a/rvm-test/fast/rvm-prompt_comment_test.sh
+++ b/rvm-test/fast/rvm-prompt_comment_test.sh
@@ -1,0 +1,14 @@
+source "$rvm_path/scripts/rvm"
+
+command rvm install 2.4.1
+command rvm install 2.4.0
+command rvm install 2.3.4
+
+rvm 1.9.1 do rvm-prompt      # match=/Ruby (ruby-)?1.9.1(-p[[:digit:]]+)? is not installed./
+rvm 2.4.0 do rvm-prompt      # match=/^ruby-2.4.0$/
+rvm 2.3.4 do rvm-prompt i    # match=/^ruby$/
+rvm 2.3.4 do rvm-prompt i v  # match=/^ruby-2.3.4$/
+rvm 2.3.4 do rvm-prompt v    # match=/^2.3.4$/
+rvm system do rvm-prompt     # match=/^$/
+rvm system do rvm-prompt s v # match=/^system$/
+rvm 2.4.1 do rvm-prompt s v  # match=/^2.4.1$/

--- a/rvm-test/fast/rvm-shell_comment_test.sh
+++ b/rvm-test/fast/rvm-shell_comment_test.sh
@@ -1,0 +1,33 @@
+source "$rvm_path/scripts/rvm"
+
+: prepare
+d=${TMPDIR:=/tmp}/test-rvm-shell/ # status=0
+mkdir -p $d                       # status=0
+echo "rvm current" > $d/rvm-shell-rvm-current-script.sh # status=0
+chmod +x $d/rvm-shell-rvm-current-script.sh
+rvm use 2.3.4 --install
+rvm use system
+
+: Test1
+echo "rvm use 2.3.4@acme --create" > $d/.rvmrc     # status=0
+ls -ld $d/.rvmrc
+rvm rvmrc trust $d/.rvmrc                               # status=0
+rvm $d do rvm current                                   # match=/ruby-2.3.4@acme/
+rvm-shell --path $d -c "rvm current"                    # match=/ruby-2.3.4@acme/
+rvm $d do $d/rvm-shell-rvm-current-script.sh            # match=/ruby-2.3.4@acme/
+rvm-shell --path $d $d/rvm-shell-rvm-current-script.sh  # match=/ruby-2.3.4@acme/
+rvm use $d                                              # env[GEM_HOME]=/ruby-2.3.4@acme$/
+rvm use system
+
+: Test2
+echo "rvm 2.3.4@acme --create" > $d/.rvmrc         # status=0
+ls -ld $d/.rvmrc
+rvm rvmrc trust $d/.rvmrc                               # status=0
+rvm $d do rvm current                                   # match=/ruby-2.3.4@acme/
+rvm-shell --path $d -c "rvm current"                    # match=/ruby-2.3.4@acme/
+rvm $d do $d/rvm-shell-rvm-current-script.sh            # match=/ruby-2.3.4@acme/
+rvm-shell --path $d $d/rvm-shell-rvm-current-script.sh  # match=/ruby-2.3.4@acme/
+rvm $d                                                  # env[GEM_HOME]=/ruby-2.3.4@acme$/
+
+: Cleaning
+rm -rf $d # status=0

--- a/rvm-test/fast/rvmrc-create_comment_test.sh
+++ b/rvm-test/fast/rvmrc-create_comment_test.sh
@@ -1,0 +1,59 @@
+source "$rvm_path/scripts/rvm"
+
+: prepare
+true TMPDIR:${TMPDIR:=/tmp}:
+d=$TMPDIR/test-rvmrc
+mkdir $d
+pushd $d
+command rvm install 2.4.1
+rvm 2.4.1 do rvm gemset reset_env
+rvm use 2.3.4 --install
+
+: .rvmrc generated
+rvm rvmrc create 2.4.1
+[ -f .rvmrc ]         # status=0
+rvm current           # match=/2.3.4/
+rvm rvmrc trust .rvmrc
+rvm rvmrc load .rvmrc # env[GEM_HOME]=/2.4.1$/ ; env[PATH]=/2.4.1/
+rvm current           # match=/2.4.1/
+
+: .rvmrc with use
+rvm_current_rvmrc=""
+echo "rvm use 2.3.4" > .rvmrc
+rvm rvmrc trust .
+rvm rvmrc load .
+rvm current           # match=/2.3.4/
+
+: .rvmrc without use
+rvm_current_rvmrc=""
+echo "rvm 2.4.0" > .rvmrc
+rvm rvmrc trust
+rvm rvmrc load
+rvm current           # match=/2.4.0/
+
+rm -f .rvmrc
+rvm use 2.3.4
+
+: .versions.conf
+rvm rvmrc create 2.4.0 .versions.conf
+[ -f .versions.conf ] # status=0
+rvm current           # match=/2.3.4/
+rvm rvmrc load .
+rvm current           # match=/2.4.0/
+
+rm -f .versions.conf
+rvm use 2.3.4
+
+: .ruby-version
+rvm rvmrc create 2.4.0 .ruby-version
+[ -f .ruby-version ]  # status=0
+rvm current           # match=/2.3.4/
+rvm rvmrc load .
+rvm current           # match=/2.4.0/
+
+rm -f .ruby-version
+rvm use 2.3.4
+
+: clean
+popd
+rm -rf $d

--- a/rvm-test/fast/rvmrc-warning_comment_test.sh
+++ b/rvm-test/fast/rvmrc-warning_comment_test.sh
@@ -1,0 +1,42 @@
+source "$rvm_path/scripts/rvm"
+
+: prepare
+unset __rvmrc_warning_path
+true TMPDIR:${TMPDIR:=/tmp}:
+d=$TMPDIR/test-rvmrc-warning
+f=$d/Gemfile
+mkdir -p $d
+touch $f
+mv $rvm_path/user/rvmrc_ignored $d/rvmrc_ignored
+
+: single file
+rvm rvmrc warning list      # match!=/Gemfile/
+rvm --debug rvmrc warning check  $f # status=1 ; match=/is not ignored/
+rvm rvmrc warning ignore $f # status=0
+rvm rvmrc warning check  $f # status=0 ; match=/is ignored/
+rvm rvmrc warning list      # match=/test-rvmrc-warning/Gemfile/
+rvm rvmrc warning reset  $f # status=0
+rvm rvmrc warning check  $f # status=1 ; match=/is not ignored/
+rvm rvmrc warning list      # match!=/Gemfile/
+
+: all files
+rvm rvmrc warning check  allGemfiles # status=1 ; match=/is not ignored/
+rvm rvmrc warning ignore allGemfiles # status=0
+rvm rvmrc warning check  $f          # status=0 ; match=/is ignored/
+rvm rvmrc warning check  allGemfiles # status=0 ; match=/is ignored/
+rvm rvmrc warning list               # match=/allGemfiles/
+rvm rvmrc warning reset  allGemfiles # status=0
+rvm rvmrc warning check  $f          # status=1 ; match=/is not ignored/
+rvm rvmrc warning check  allGemfiles # status=1 ; match=/is not ignored/
+rvm rvmrc warning list               # match!=/Gemfile/
+
+: single + all
+rvm rvmrc warning ignore $f          # status=0
+rvm rvmrc warning ignore allGemfiles # status=0
+rvm rvmrc warning list               # match=/allGemfiles/ ; match=/test-rvmrc-warning/Gemfile/
+rvm rvmrc warning check  $f          # status=0 ; match=/is ignored/
+rvm rvmrc warning check  allGemfiles # status=0 ; match=/is ignored/
+
+: clean
+mv -f $d/rvmrc_ignored $rvm_path/user/rvmrc_ignored
+rm -rf $d

--- a/rvm-test/fast/rvmrc_comment_test.sh
+++ b/rvm-test/fast/rvmrc_comment_test.sh
@@ -1,0 +1,82 @@
+source "$rvm_path/scripts/rvm"
+rvm_scripts_path="$rvm_path/scripts" rvm_project_rvmrc=cd source "$rvm_path/scripts/cd"
+
+: prepare
+true TMPDIR:${TMPDIR:=/tmp}:
+d=$TMPDIR/test-rvmrc
+f=$d/.rvmrc
+mkdir -p $d
+echo "echo loading-rvmrc" > $f
+rvm use 2.4.0 --install # status=0
+rvm use 2.4.1 --install # status=0
+
+## simple
+: trust
+rvm rvmrc trust $d     # match=/ as trusted$/
+rvm rvmrc trusted $d   # match=/is currently trusted/
+
+: untrust
+rvm rvmrc untrust $d   # match=/ as untrusted$/
+rvm rvmrc trusted $d   # match=/is currently untrusted/
+
+: reset
+rvm rvmrc reset $d     # match=/^Reset/
+rvm rvmrc trusted $d   # match=/contains unreviewed changes/
+
+## spaces
+ds="$d/with spaces"
+mkdir -p "$ds"
+echo "echo loading-rvmrc" > "$ds/.rvmrc"
+rvm rvmrc trust "$ds"     # match=/ as trusted$/
+rvm rvmrc trusted "$ds"   # match=/is currently trusted/
+rvm rvmrc reset "$ds"     # match=/^Reset/
+
+## brackets
+ds="$d/with(brackets)"
+mkdir -p "$ds"
+echo "echo loading-rvmrc" > "$ds/.rvmrc"
+rvm rvmrc trust "$ds"     # match=/ as trusted$/
+rvm rvmrc trusted "$ds"   # match=/is currently trusted/
+rvm rvmrc reset "$ds"     # match=/^Reset/
+
+: prepare for load/cd test
+rvm alias create default 2.4.1
+rvm alias list            # match=/default => ruby-2.4.1/
+export rvm_project_rvmrc_default=1
+
+## load default
+builtin cd
+rvm use 2.4.0
+rvm rvmrc load            # env[GEM_HOME]!=/^$/
+
+## load ruby
+cd
+rvm use 2.4.0
+echo "rvm use 2.4.1" > "$d/.rvmrc"
+rvm rvmrc trust "$d"      # match=/ as trusted$/
+cd "$d"                   # env[GEM_HOME]=/2.4.1$/
+
+## load ruby@gemset
+cd
+rvm use 2.4.0
+echo "rvm use 2.4.1@vee --create" > "$d/.rvmrc"
+rvm rvmrc trust "$d"      # match=/ as trusted$/
+cd "$d"                   # env[GEM_HOME]=/2.4.1@vee$/
+
+## load @gemset
+cd
+rvm use 2.4.0
+echo "rvm use @vee --create" > "$d/.rvmrc"
+rvm rvmrc trust "$d"      # match=/ as trusted$/
+cd "$d"                   # env[GEM_HOME]=/2.4.0@vee$/
+
+## load @gemset after system
+cd
+rvm use system
+echo "rvm use @vee --create" > "$d/.rvmrc"
+rvm rvmrc trust "$d"      # match=/ as trusted$/
+cd "$d"                   # env[GEM_HOME]=/2.4.1@vee$/
+
+: clean
+rvm alias delete default  # status=0
+rm -rf $d

--- a/rvm-test/fast/use_comment_test.sh
+++ b/rvm-test/fast/use_comment_test.sh
@@ -1,0 +1,13 @@
+source "$rvm_path/scripts/rvm"
+
+command rvm install 2.3.4
+command rvm install 2.4.0
+
+rvm use 8.9.9           # status=1; match!=/Using /; env[GEM_HOME]!=/8.9.9/ ; match=/Unknown ruby interpreter version/
+rvm reset               # env[GEM_HOME]=/^$/
+rvm current             # match=/system/
+rvm use 2.3.4      # status=0; match=/Using / ; env[GEM_HOME]=/2.3.4/
+rvm current             # match=/2.3.4/
+command rvm use 2.4.0   # status=0; match!=/Using /; env[GEM_HOME]!=/2.4.0/ ; match=/RVM is not a function/
+rvm use 2.4.0           # status=0; match=/Using / ; env[GEM_HOME]=/2.4.0/
+rvm use 1.9.1           # status=1; env[rvm_recommended_ruby]=/rvm install ruby-1.9.1/

--- a/rvm-test/fast/versions.conf_comment_test.sh
+++ b/rvm-test/fast/versions.conf_comment_test.sh
@@ -1,0 +1,51 @@
+rvm_reload_flag=1 source "$rvm_path/scripts/rvm"
+
+: prepare
+true TMPDIR:${TMPDIR:=/tmp}:
+d=$TMPDIR/test-versions-conf
+mcd(){ mkdir -p $1 ; cd $1 ; }
+mcd $d
+rm -f */*
+
+: generate
+mcd $d/a
+rvm use 2.4.0@versions-conf-a --create --versions-conf --install
+rvm current             # match=/^ruby-2.4.0@versions-conf-a$/
+[[ -f .versions.conf ]] # status=0
+
+mcd $d/b
+rvm use 2.3.4@versions-conf-b --create --versions-conf --install
+rvm current             # match=/^ruby-2.3.4@versions-conf-b$/
+[[ -f .versions.conf ]] # status=0
+
+: test
+rvm rvmrc load $d/a
+rvm current         # match=/^ruby-2.4.0@versions-conf-a$/
+rvm rvmrc load $d/b
+rvm current         # match=/^ruby-2.3.4@versions-conf-b$/
+
+: test bundler without flag of doom
+mcd $d/b ## on travis cd hook is disabled ?
+rvm rvmrc load $d/b
+gem list # match!=/haml/
+printf "ruby-gem-install=bundler\nruby-bundle-install=true\n" >> .versions.conf
+printf "source :rubygems\n\ngem 'haml'\n" > Gemfile
+rvm_current_rvmrc=""
+rvm rvmrc load . # match!=/Installing haml/
+gem list # match!=/haml/; match=/bundler/
+
+: test bundler with flag of doom
+mcd $d/b ## on travis cd hook is disabled ?
+rvm rvmrc load $d/b
+gem list # match!=/haml/
+printf "ruby-gem-install=bundler\nruby-bundle-install=true\n" >> .versions.conf
+printf "source :rubygems\n\ngem 'haml'\n" > Gemfile
+rvm_current_rvmrc=""
+rvm_autoinstall_bundler_flag=1
+rvm rvmrc load . # match=/Installing haml/
+gem list # match=/haml/; match=/bundler/
+
+: clean
+rvm 2.4.0 do rvm --force gemset delete versions-conf-a
+rvm 2.3.4 do rvm --force gemset delete versions-conf-b
+rm -rf $d

--- a/rvm-test/fast/wrapper_comment_test.sh
+++ b/rvm-test/fast/wrapper_comment_test.sh
@@ -1,0 +1,48 @@
+source "$rvm_path/scripts/rvm"
+
+: prepare
+true TMPDIR:${TMPDIR:=/tmp}:
+d=$TMPDIR/test-wrappers
+mkdir $d
+pushd $d
+rvm install 2.4.0 # status=0
+rvm use --install 2.3.4 # status=0
+rvm 2.3.4@global do gem install rake -v "<10.2"
+
+: help
+rvm wrapper      # status!=0; match=/Usage/
+rvm wrapper help # status=0;  match=/Usage/
+
+: show
+rvm wrapper show
+# status=0
+# match=/Wrappers path: .*/gems/ruby-2.3.4\/wrappers/
+# match=/Environment file: .*/gems/ruby-2.3.4/environment/
+# match=/Executables: .*, rake, /
+
+: show rake
+rvm wrapper show rake
+# status=0
+# match=/.*/gems/ruby-2.3.4\/wrappers\/rake/
+
+: for file
+echo 'echo "$GEM_HOME"' > $d/custom-script
+chmod +x $d/custom-script
+rvm 2.4.0 do rvm wrapper $d/custom-script # status=0
+wrapper_script=`rvm 2.4.0 do rvm wrapper show custom-script`
+# status=0
+# env[wrapper_script]=/.*/gems/ruby-2.4.0\/wrappers\/custom-script/
+$wrapper_script
+# status=0
+# match=/.*/gems/ruby-2.4.0\Z/
+# env[GEM_HOME]=/.*/gems/ruby-2.3.4\Z/
+
+: regenerate
+rm -f $GEM_HOME/wrappers/rake
+rvm wrapper show rake   # status!=0
+rvm wrapper regenerate  # status=0
+rvm wrapper show rake   # status=0
+
+: clean
+popd
+rm -rf $d

--- a/rvm-test/long/jruby_comment_test.sh
+++ b/rvm-test/long/jruby_comment_test.sh
@@ -1,0 +1,3 @@
+rvm reinstall jruby            # status=0; match!=/Already installed/
+rvm jruby-ntest do ruby -v     # match=/1.9./; match=/Java/
+rvm remove jruby-ntest         # status=0; match=/Removing/

--- a/rvm-test/long/named_ruby_and_gemsets_comment_test.sh
+++ b/rvm-test/long/named_ruby_and_gemsets_comment_test.sh
@@ -1,0 +1,68 @@
+source "$rvm_path/scripts/rvm"
+
+rvm remove  1.8.7-p374-ntest --gems
+
+## without gemsets
+
+rvm install 1.8.7-p374-ntest --skip-gemsets --disable-binary
+# status=0
+# match!=/Already installed/
+# match=/Skipped importing default gemsets/
+## match=/WARNING: Please be aware that you just installed a ruby that/
+## match=/for a list of maintained rubies visit:/
+
+rvm install 1.8.7-p374-ntest
+# status=0; match=/Already installed/
+
+rvm 1.8.7-p374-ntest do which gem
+# match=/1.8.7-p374-ntest/
+
+rvm 1.8.7-p374-ntest do gem env
+
+rvm 1.8.7-p374-ntest do gem list
+# match[stderr]=/\A\Z/
+# match[stdout]!=/rubygems-bundler/
+
+rvm 1.8.7-p374-ntest do ruby -v
+# match=/1.8.7.*patchlevel 374/
+
+rvm remove  1.8.7-p374-ntest --gems
+# status=0; match=/[Rr]emoving/
+
+
+## default/global gemsets
+
+mkdir -p $rvm_path/gemsets/ruby/1.8.7/p374/
+printf "gem-wrappers\ntf\n"   > $rvm_path/gemsets/ruby/1.8.7/p374/global.gems
+printf "gem-wrappers\nhaml -v <5\n" > $rvm_path/gemsets/ruby/1.8.7/p374/default.gems
+
+rvm install 1.8.7-p374-ntest
+# status=0
+# match!=/Already installed/
+# match=/importing gemset .*gemsets\/ruby\/1.8.7\/p374\/global.gems/
+# match=/importing gemset .*gemsets\/ruby\/1.8.7\/p374\/default.gems/
+## match=/WARNING: Please be aware that you just installed a ruby that/
+## match=/for a list of maintained rubies visit:/
+
+rvm 1.8.7-p374-ntest do gem list
+# match[stderr]=/\A\Z/
+# match[stdout]=/haml/
+# match[stdout]=/tf/
+
+rvm 1.8.7-p374-ntest@global do gem list
+# match[stderr]=/\A\Z/
+# match[stdout]!=/haml/
+# match[stdout]=/tf/
+
+## Cleanup
+
+rvm remove 1.8.7-p374-ntest --gems
+# status=0; match=/[Rr]emoving/
+
+rm -rf $rvm_path/gemsets/ruby/1.8.7/p374
+
+ls -1d $rvm_path/environments/*1.8.7-p374-ntest*   # status!=0
+ls -1d $rvm_path/wrappers/*1.8.7-p374-ntest*       # status!=0
+ls -1d $rvm_path/gems/*1.8.7-p374-ntest*           # status!=0
+ls -1d $rvm_path/bin/*1.8.7-p374-ntest*            # status!=0
+

--- a/rvm-test/long/rubinius_comment_test.sh
+++ b/rvm-test/long/rubinius_comment_test.sh
@@ -1,0 +1,4 @@
+rvm use 1.9.3
+rvm reinstall rbx-ntest --19 # status=0; match!=/Already installed/
+rvm rbx-ntest do ruby -v     # match=/1.9./; match=/rubinius/
+rvm remove rbx-ntest         # status=0; match=/Removing/

--- a/rvm-test/long/ruby-1.8.7_comment_test.sh
+++ b/rvm-test/long/ruby-1.8.7_comment_test.sh
@@ -1,0 +1,4 @@
+rvm reinstall 1.8.7-ntest -C --program-suffix=1.8 # status=0; match=/linking ruby1.8 -> ruby/; match=/linking gem1.8 -> gem/
+
+rvm 1.8.7-ntest do ruby1.8 -v  # match=/1.8.7/
+rvm remove 1.8.7-ntest         # status=0; match=/Removing/

--- a/rvm-test/long/ruby-1.9.3_comment_test.sh
+++ b/rvm-test/long/ruby-1.9.3_comment_test.sh
@@ -1,0 +1,5 @@
+rvm reinstall 1.9.3-ntest    # status=0; match!=/Already installed/
+rvm 1.9.3-ntest do ruby -v   # match=/1.9.3/
+rvm 1.9.3-ntest do which gem # match=/1.9.3-p[[:digit:]]+-ntest/
+rvm remove 1.9.3-ntest       # status=0; match=/Removing/
+

--- a/rvm-test/long/truffleruby_comment_test.sh
+++ b/rvm-test/long/truffleruby_comment_test.sh
@@ -1,0 +1,11 @@
+rvm install truffleruby # status=0; match!=/Already installed/; match=/compiling c-extensions/
+rvm truffleruby do ruby -v # status=0; match=/truffleruby/
+rvm truffleruby do rake --version # status=0; match=/rake, version/
+rvm truffleruby do ruby -ropen-uri -e 'puts open("https://rubygems.org/") { |f| f.read(1024) }'
+# status=0; match=/RubyGems.org/
+rvm remove truffleruby # status=0; match=/removing.+truffleruby/
+
+## Test that the right version is installed (#4633)
+rvm install truffleruby-1.0.0-rc13 # status=0; match!=/Already installed/
+rvm truffleruby-1.0.0-rc13 do ruby -v # status=0; match=/truffleruby 1.0.0-rc13/
+rvm remove truffleruby-1.0.0-rc13


### PR DESCRIPTION
In the commit https://github.com/rvm/rvm/commit/14f63a534cd9508945a1a2bc58b59cfee7c869f0#diff-2e75a27c9aaa67b42e289b349ec82b55 our `rvm-test` submodule was removed, restoring it as subtree, should be easier to manage and hopefully less troublesome.