### PR TITLE
Guard to prevent removal of the entire path in __rvm_remove_from_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * RVM package fails to configure on fresh Ubuntu 18.04 server install [\#4742](https://github.com/rvm/rvm/pull/4742)
 * Ignore aliases when using `ls` command [\#4743](https://github.com/rvm/rvm/pull/4743) [\#4744](https://github.com/rvm/rvm/pull/4744)
 * Export more shell functions which cause the subshell to choke [\#4745](https://github.com/rvm/rvm/pull/4745)
+* Adds a check and returns if \_\_rvm\_remove\_from\_path is called with "/\*" [\$4759](https://github.com/rvm/rvm/issues/4759)
 
 #### Changes
 * Installer now reports which URL(s) have failed to fetch version information and when version fetching has completely failed [\#4731](https://github.com/rvm/rvm/pull/4731)

--- a/scripts/functions/utility
+++ b/scripts/functions/utility
@@ -56,6 +56,14 @@ __rvm_remove_from_path()
   \typeset _value
   _value="${1//+(\/)//}"
 
+  # Guard to prevent removal of the entire path
+  # https://github.com/rvm/rvm/issues/4759
+  if
+    [[ $_value == "/*" ]]
+  then
+    return
+  fi
+
   # remove multiple slashes https://github.com/rvm/rvm/issues/1364
   while [[ "$PATH" == *"//"* ]] ; do PATH="${PATH/\/\///}" ; done
   while [[ "$PATH" == *"/:"* ]] ; do PATH="${PATH/\/:/:}" ; done


### PR DESCRIPTION
Fixes #4759 

Changes proposed in this pull request:
* Adds a check and returns if __rvm_remove_from_path is called with "/*"
