### PR TITLE
Add tests for ruby -S bundle for TruffleRuby and do not install rubygems-bundler by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,7 @@ matrix:
       script:
         - ruby -v
         - rake --version
+        - ruby -S bundle --version
         - ruby -ropen-uri -e 'puts open("https://rubygems.org/") { |f| f.read(1024) }'
 notifications:
   email:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@
 * RVM package fails to configure on fresh Ubuntu 18.04 server install [\#4742](https://github.com/rvm/rvm/pull/4742)
 * Ignore aliases when using `ls` command [\#4743](https://github.com/rvm/rvm/pull/4743) [\#4744](https://github.com/rvm/rvm/pull/4744)
 * Export more shell functions which cause the subshell to choke [\#4745](https://github.com/rvm/rvm/pull/4745)
-* Adds a check and returns if \_\_rvm\_remove\_from\_path is called with "/\*" [\$4759](https://github.com/rvm/rvm/issues/4759)
+* Adds a check and returns if \_\_rvm\_remove\_from\_path is called with "/\*" [\#4759](https://github.com/rvm/rvm/issues/4759)
+* Do not install `rubygems-bundler` by default on TruffleRuby to make `ruby -S bundle` work [\#4766](https://github.com/rvm/rvm/pull/4766)
 
 #### Changes
 * Installer now reports which URL(s) have failed to fetch version information and when version fetching has completely failed [\#4731](https://github.com/rvm/rvm/pull/4731)

--- a/gemsets/truffleruby/global.gems
+++ b/gemsets/truffleruby/global.gems
@@ -1,0 +1,2 @@
+gem-wrappers
+rvm

--- a/rvm-test/long/truffleruby_comment_test.sh
+++ b/rvm-test/long/truffleruby_comment_test.sh
@@ -2,7 +2,10 @@ rvm install truffleruby # status=0; match!=/Already installed/; match=/compiling
 rvm truffleruby do ruby -v # status=0; match=/truffleruby/
 rvm truffleruby do rake --version # status=0; match=/rake, version/
 rvm truffleruby do ruby -S bundle --version # status=0; match=/Bundler version/
+echo 'gem "rake"' > Gemfile # status=0
+rvm truffleruby do bundle install # status=0
 rvm truffleruby do ruby -S bundle exec rake --version # status=0; match=/rake, version/
+rm Gemfile
 rvm truffleruby do ruby -ropen-uri -e 'puts open("https://rubygems.org/") { |f| f.read(1024) }'
 # status=0; match=/RubyGems.org/
 rvm remove truffleruby # status=0; match=/removing.+truffleruby/

--- a/rvm-test/long/truffleruby_comment_test.sh
+++ b/rvm-test/long/truffleruby_comment_test.sh
@@ -1,6 +1,8 @@
 rvm install truffleruby # status=0; match!=/Already installed/; match=/compiling c-extensions/
 rvm truffleruby do ruby -v # status=0; match=/truffleruby/
 rvm truffleruby do rake --version # status=0; match=/rake, version/
+rvm truffleruby do ruby -S bundle --version # status=0; match=/Bundler version/
+rvm truffleruby do ruby -S bundle exec rake --version # status=0; match=/rake, version/
 rvm truffleruby do ruby -ropen-uri -e 'puts open("https://rubygems.org/") { |f| f.read(1024) }'
 # status=0; match=/RubyGems.org/
 rvm remove truffleruby # status=0; match=/removing.+truffleruby/

--- a/scripts/functions/manage/truffleruby
+++ b/scripts/functions/manage/truffleruby
@@ -34,4 +34,7 @@ truffleruby_install()
   __rvm_post_install
 
   __rvm_fetch_ruby_cleanup
+
+  rvm_log "RVM gem rubygems-bundler is not installed by default for TruffleRuby."
+  rvm_log "Use 'bundle exec' instead when needed. See rvm/rvm#4765."
 }


### PR DESCRIPTION
Fixes #4765

Changes proposed in this pull request:
* Add tests for `ruby -S bundle` for TruffleRuby (failing originally, see [this run](https://travis-ci.org/eregon/rvm/builds/576230778))
* Do not install rubygems-bundler for TruffleRuby
* Add a post-install message about rubygems-bundler

Make sure that your pull request includes entry in the [CHANGELOG](CHANGELOG.md).