### PR TITLE
added railsexpress patches for 2.4.6, 2.5.6 and 2.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,8 @@
 
 #### Changes
 * Installer now reports which URL(s) have failed to fetch version information and when version fetching has completely failed [\#4731](https://github.com/rvm/rvm/pull/4731)
-* Added railsexpress patches for Ruby 2.6.3 [\#4747](https://github.com/rvm/rvm/pull/4747)
-* Added railsexpress patches for Ruby 2.6.6, 2.5.6 and 2.4.6 [\#4772](https://github.com/rvm/rvm/pull/4772)
+* Added railsexpress patches for Ruby 2.6.3 [\#4747](https://github.com/rvm/rvm/pull/4747), 2.6.6, 2.5.6 and 2.4.6 [\#4772](https://github.com/rvm/rvm/pull/4772)
+
 #### Binaries:
 *
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 #### Changes
 * Installer now reports which URL(s) have failed to fetch version information and when version fetching has completely failed [\#4731](https://github.com/rvm/rvm/pull/4731)
 * Added railsexpress patches for Ruby 2.6.3 [\#4747](https://github.com/rvm/rvm/pull/4747)
-
+* Added railsexpress patches for Ruby 2.6.6, 2.5.6 and 2.4.6 [\#4772](https://github.com/rvm/rvm/pull/4772)
 #### Binaries:
 *
 

--- a/patchsets/ruby/2.4.6/railsexpress
+++ b/patchsets/ruby/2.4.6/railsexpress
@@ -1,0 +1,3 @@
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.4.6/railsexpress/01-skip-broken-tests.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.4.6/railsexpress/02-improve-gc-stats.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.4.6/railsexpress/03-display-more-detailed-stack-trace.patch

--- a/patchsets/ruby/2.5.6/railsexpress
+++ b/patchsets/ruby/2.5.6/railsexpress
@@ -1,0 +1,3 @@
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.5.6/railsexpress/01-fix-broken-tests-caused-by-ad.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.5.6/railsexpress/02-improve-gc-stats.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.5.6/railsexpress/03-more-detailed-stacktrace.patch

--- a/patchsets/ruby/2.6.4/railsexpress
+++ b/patchsets/ruby/2.6.4/railsexpress
@@ -1,0 +1,4 @@
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.6.4/railsexpress/01-fix-broken-tests-caused-by-ad.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.6.4/railsexpress/02-improve-gc-stats.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.6.4/railsexpress/03-more-detailed-stacktrace.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.6.4/railsexpress/04-04-malloc-trim.patch.patch

--- a/patchsets/ruby/2.6/head/railsexpress
+++ b/patchsets/ruby/2.6/head/railsexpress
@@ -1,3 +1,4 @@
 https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.6/head/railsexpress/01-fix-broken-tests-caused-by-ad.patch
 https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.6/head/railsexpress/02-improve-gc-stats.patch
 https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.6/head/railsexpress/03-more-detailed-stacktrace.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.6/head/railsexpress/04-04-malloc-trim.patch.patch


### PR DESCRIPTION
This PR provides rails express patches for MRI version 2.6.4, 2.5.6 and 2.4.6.

Can you please merge?