### PR TITLE
Fix string corruption bug on railsexpress ruby 2.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 #### Changes
 * Installer now reports which URL(s) have failed to fetch version information and when version fetching has completely failed [\#4731](https://github.com/rvm/rvm/pull/4731)
 * Added railsexpress patches for Ruby 2.6.3 [\#4747](https://github.com/rvm/rvm/pull/4747), 2.6.6, 2.5.6 and 2.4.6 [\#4772](https://github.com/rvm/rvm/pull/4772)
+* Fix string corruption bug on railsexpress ruby 2.6.4 [\#4778](https://github.com/rvm/rvm/pull/4778)
 
 #### Binaries:
 *

--- a/patchsets/ruby/2.6.4/railsexpress
+++ b/patchsets/ruby/2.6.4/railsexpress
@@ -2,3 +2,4 @@ https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.6.4/
 https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.6.4/railsexpress/02-improve-gc-stats.patch
 https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.6.4/railsexpress/03-more-detailed-stacktrace.patch
 https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.6.4/railsexpress/04-04-malloc-trim.patch.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.6.4/railsexpress/05-use-after-free-bug-in-symbol-c.patch


### PR DESCRIPTION
See https://bugs.ruby-lang.org/issues/16136