### PR TITLE
Patch the 2.6.4 string corruption bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Installer now reports which URL(s) have failed to fetch version information and when version fetching has completely failed [\#4731](https://github.com/rvm/rvm/pull/4731)
 * Added railsexpress patches for Ruby 2.6.3 [\#4747](https://github.com/rvm/rvm/pull/4747), 2.6.6, 2.5.6 and 2.4.6 [\#4772](https://github.com/rvm/rvm/pull/4772)
 * Fix string corruption bug on railsexpress ruby 2.6.4 [\#4778](https://github.com/rvm/rvm/pull/4778)
+* Fix string corruption bug by default for ruby 2.6.4 [\#4780](https://github.com/rvm/rvm/pull/4780)
 
 #### Binaries:
 *

--- a/config/db
+++ b/config/db
@@ -77,7 +77,7 @@ ruby_unmaintained_date=2017-04-01
 ruby_unmaintained_version=2.1.0
 ruby_url=https://cache.ruby-lang.org/pub/ruby
 ruby_url_fallback_1=https://ftp.ruby-lang.org/pub/ruby
-ruby_version=2.6.3
+ruby_version=2.6.4
 #
 # REE
 #

--- a/patches/ruby/2.6.4/fix_string_corruption.patch
+++ b/patches/ruby/2.6.4/fix_string_corruption.patch
@@ -1,0 +1,12 @@
+--- a/symbol.c
++++ b/symbol.c
+@@ -743,7 +743,8 @@ rb_str_intern(VALUE str)
+ 	enc = ascii;
+     }
+     else {
+-	str = rb_str_new_frozen(str);
++    str = rb_str_dup(str);
++    OBJ_FREEZE(str);
+     }
+     str = rb_fstring(str);
+     type = rb_str_symname_type(str, IDSET_ATTRSET_FOR_INTERN);

--- a/patchsets/ruby/2.6.4/default
+++ b/patchsets/ruby/2.6.4/default
@@ -1,0 +1,1 @@
+fix_string_corruption


### PR DESCRIPTION
This patches the Ruby 2.6.4 string corruption bug by default for Ruby 2.6.4.

https://bugs.ruby-lang.org/issues/16136
