### PR TITLE
Add railsexpress patches for ruby 2.4.9, 2.5.7 and 2.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Added railsexpress patches for Ruby 2.6.3 [\#4747](https://github.com/rvm/rvm/pull/4747), 2.6.6, 2.5.6 and 2.4.6 [\#4772](https://github.com/rvm/rvm/pull/4772)
 * Fix string corruption bug on railsexpress ruby 2.6.4 [\#4778](https://github.com/rvm/rvm/pull/4778)
 * Fix string corruption bug by default for ruby 2.6.4 [\#4780](https://github.com/rvm/rvm/pull/4780)
+* Added railsexpress patches for Ruby 2.6.5, 2.5.7 and 2.4.9 [\#4799](https://github.com/rvm/rvm/pull/4799)
 
 #### Binaries:
 * Ubuntu 18.04 x64 binaries

--- a/patchsets/ruby/2.4.9/railsexpress
+++ b/patchsets/ruby/2.4.9/railsexpress
@@ -1,0 +1,3 @@
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.4.9/railsexpress/01-skip-broken-tests.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.4.9/railsexpress/02-improve-gc-stats.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.4.9/railsexpress/03-display-more-detailed-stack-trace.patch

--- a/patchsets/ruby/2.5.7/railsexpress
+++ b/patchsets/ruby/2.5.7/railsexpress
@@ -1,0 +1,3 @@
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.5.7/railsexpress/01-fix-broken-tests-caused-by-ad.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.5.7/railsexpress/02-improve-gc-stats.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.5.7/railsexpress/03-more-detailed-stacktrace.patch

--- a/patchsets/ruby/2.6.5/railsexpress
+++ b/patchsets/ruby/2.6.5/railsexpress
@@ -1,0 +1,4 @@
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.6.5/railsexpress/01-fix-broken-tests-caused-by-ad.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.6.5/railsexpress/02-improve-gc-stats.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.6.5/railsexpress/03-more-detailed-stacktrace.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.6.5/railsexpress/04-malloc-trim.patch

--- a/patchsets/ruby/2.6/head/railsexpress
+++ b/patchsets/ruby/2.6/head/railsexpress
@@ -1,4 +1,4 @@
 https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.6/head/railsexpress/01-fix-broken-tests-caused-by-ad.patch
 https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.6/head/railsexpress/02-improve-gc-stats.patch
 https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.6/head/railsexpress/03-more-detailed-stacktrace.patch
-https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.6/head/railsexpress/04-04-malloc-trim.patch.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.6/head/railsexpress/04-malloc-trim.patch


### PR DESCRIPTION
Railsexpress patches for 2.4.9, 2.5.7 and 2.6.5