### PR TITLE
Run all JRuby commands from gemset down using --dev flag.  This reduces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 [Full Changelog](https://github.com/rvm/rvm/compare/1.29.9...HEAD)
 
 #### New features
+* Improve JRuby install time [\#4807](https://github.com/rvm/rvm/pull/4807)
 * Add Termux support [\#4749](https://github.com/rvm/rvm/pull/4749)
 
 #### New interpreters

--- a/scripts/functions/gemset
+++ b/scripts/functions/gemset
@@ -321,6 +321,9 @@ gemset_initial()
 {
   \typeset gemsets gemset _iterator paths
 
+  SAVED_JRUBY_OPTS=$JRUBY_OPTS
+  export JRUBY_OPTS=--dev
+
   true ${rvm_gemsets_path:="$rvm_path/gemsets"}
 
   [[ -d "$rvm_gems_path/${rvm_ruby_string}/cache" ]] ||
@@ -344,6 +347,8 @@ gemset_initial()
   __rvm_log_command "gemset.wrappers.$1" \
     "$rvm_ruby_string - #generating ${1} wrappers" \
     run_gem_wrappers regenerate 2>/dev/null || true
+
+   export JRUBY_OPTS=$SAVED_JRUBY_OPTS
 }
 
 run_gem_wrappers()

--- a/scripts/functions/gemset
+++ b/scripts/functions/gemset
@@ -319,9 +319,9 @@ gemset_import()
 # Loads the default gemsets for the current interpreter and gemset.
 gemset_initial()
 {
-  \typeset gemsets gemset _iterator paths saved_jruby_opts
+  \typeset gemsets gemset _iterator paths _jruby_opts
 
-  saved_jruby_opts=$JRUBY_OPTS
+  _jruby_opts=$JRUBY_OPTS
   export JRUBY_OPTS="${JRUBY_OPTS} --dev"
 
   true ${rvm_gemsets_path:="$rvm_path/gemsets"}
@@ -344,11 +344,12 @@ gemset_initial()
       rvm_debug "$rvm_ruby_string - #gemset definition does not exist ${_iterator}/$1.gems"
     fi
   done
+  
   __rvm_log_command "gemset.wrappers.$1" \
     "$rvm_ruby_string - #generating ${1} wrappers" \
     run_gem_wrappers regenerate 2>/dev/null || true
 
-   export JRUBY_OPTS=${saved_jruby_opts}
+   export JRUBY_OPTS=${_jruby_opts}
 }
 
 run_gem_wrappers()

--- a/scripts/functions/gemset
+++ b/scripts/functions/gemset
@@ -319,10 +319,10 @@ gemset_import()
 # Loads the default gemsets for the current interpreter and gemset.
 gemset_initial()
 {
-  \typeset gemsets gemset _iterator paths
+  \typeset gemsets gemset _iterator paths saved_jruby_opts
 
-  SAVED_JRUBY_OPTS=$JRUBY_OPTS
-  export JRUBY_OPTS=--dev
+  saved_jruby_opts=$JRUBY_OPTS
+  export JRUBY_OPTS="${JRUBY_OPTS} --dev"
 
   true ${rvm_gemsets_path:="$rvm_path/gemsets"}
 
@@ -348,7 +348,7 @@ gemset_initial()
     "$rvm_ruby_string - #generating ${1} wrappers" \
     run_gem_wrappers regenerate 2>/dev/null || true
 
-   export JRUBY_OPTS=$SAVED_JRUBY_OPTS
+   export JRUBY_OPTS=${saved_jruby_opts}
 }
 
 run_gem_wrappers()


### PR DESCRIPTION
Run all JRuby commands from gemset down using --dev flag. This reduces gemset install
time substantially (50.9s -> 40.5s locally).  The rationale
for this change is that short-running JRuby processes should use --dev because
it disables a bunch of optimizations and essentially just runs using the
startup interpreter.  This hurts eventual performance but it also speeds up
short-lived processes.

I do not think I did this quite right but I put it in as a starting point.
mpapis helped me find the proper place but I need guidance on proper code
itself.