### PR TITLE
Update TruffleRuby dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Add Termux support [\#4749](https://github.com/rvm/rvm/pull/4749)
 
 #### New interpreters
-* Add support for TruffleRuby 19.3.0.
+* Add support for TruffleRuby 19.3.0
 * Add support for Rubinius 4.4 and 4.5 [\#4735](https://github.com/rvm/rvm/pull/4735), 4.6 [\#4779](https://github.com/rvm/rvm/pull/4779)
 * Add support for JRuby 9.2.8.0 [\#4756](https://github.com/rvm/rvm/pull/4756), 9.2.9.0 [\#4812](https://github.com/rvm/rvm/pull/4812) 
 * Add support for TruffleRuby 19.2.0 [\#4761](https://github.com/rvm/rvm/pull/4761), 19.2.0.1 [\#4784](https://github.com/rvm/rvm/pull/4784)
@@ -44,7 +44,7 @@
 * Use remote .sha512 and .md5 if available (Rubinius) [\#4650](https://github.com/rvm/rvm/pull/4650)
 
 #### New interpreters
-* Add support for TruffleRuby 19.1.0.
+* Add support for TruffleRuby 19.1.0
 * Add support for TruffleRuby 19.0.0 [\#4689](https://github.com/rvm/rvm/pull/4689)
 * Add support for Rubinius 4.1 [\#4706](https://github.com/rvm/rvm/pull/4706), 4.2 [\#4714](https://github.com/rvm/rvm/pull/4714), 4.3 [\#4727](https://github.com/rvm/rvm/pull/4727)
 * Add support for Ruby 2.7.0 Preview 1 [\#4709](https://github.com/rvm/rvm/pull/4709)
@@ -177,7 +177,7 @@
 * Use --no-ri or --no-document depending on ruby version [\#4492](https://github.com/rvm/rvm/pull/4492)
 
 #### Upgraded Ruby interpreters:
-* Add support for TruffleRuby 1.0.0-rc3 [\#4419](https://github.com/rvm/rvm/pull/4419), 1.0.0-rc5 [\#4440](https://github.com/rvm/rvm/pull/4440), 1.0.0-rc6 [\#4452](https://github.com/rvm/rvm/pull/4452), 1.0.0-rc7 [\#4466](https://github.com/rvm/rvm/pull/4466), 1.0.0-rc8 [\#4489](https://github.com/rvm/rvm/pull/4489), 1.0.0-rc9 [\#4489](https://github.com/rvm/rvm/pull/4489), and 1.0.0-rc10 [\#4512](https://github.com/rvm/rvm/pull/4512).
+* Add support for TruffleRuby 1.0.0-rc3 [\#4419](https://github.com/rvm/rvm/pull/4419), 1.0.0-rc5 [\#4440](https://github.com/rvm/rvm/pull/4440), 1.0.0-rc6 [\#4452](https://github.com/rvm/rvm/pull/4452), 1.0.0-rc7 [\#4466](https://github.com/rvm/rvm/pull/4466), 1.0.0-rc8 [\#4489](https://github.com/rvm/rvm/pull/4489), 1.0.0-rc9 [\#4489](https://github.com/rvm/rvm/pull/4489), and 1.0.0-rc10 [\#4512](https://github.com/rvm/rvm/pull/4512)
 * Add support for Ruby 2.3.8, 2.4.5, 2.5.2, 2.5.3 [\#4474](https://github.com/rvm/rvm/pull/4474), 2.6.0-preview3 [\#4490](https://github.com/rvm/rvm/pull/4490), and 2.6.0-rc1 [\#4513](https://github.com/rvm/rvm/pull/4513)
 * Add support for JRuby 9.2.1.0 [\#4491](https://github.com/rvm/rvm/pull/4491), 9.2.2.0 [\#4495](https://github.com/rvm/rvm/pull/4495), 9.2.3.0 [\#4496](https://github.com/rvm/rvm/pull/4496), 9.2.4.0 [\#4504](https://github.com/rvm/rvm/pull/4504), 9.2.4.1 [\#4509](https://github.com/rvm/rvm/pull/4509), and 9.2.5.0 [\#4514](https://github.com/rvm/rvm/pull/4514)
 * Add support for mruby 1.4.1 [\4517](https://github.com/rvm/rvm/pull/4517) and 2.0.0 [\4516](https://github.com/rvm/rvm/pull/4516)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Adds a check and returns if \_\_rvm\_remove\_from\_path is called with "/\*" [\#4759](https://github.com/rvm/rvm/issues/4759)
 * Do not install `rubygems-bundler` by default on TruffleRuby to make `ruby -S bundle` work [\#4766](https://github.com/rvm/rvm/pull/4766)
 * Fixes checksums for Ruby 2.6.4 [\#4769](https://github.com/rvm/rvm/pull/4769), 2.4.7 and 2.5.6 [\#4771](https://github.com/rvm/rvm/pull/4771)
+* Update TruffleRuby dependencies [\#4815](https://github.com/rvm/rvm/pull/4815)
 
 #### Changes
 * Installer now reports which URL(s) have failed to fetch version information and when version fetching has completely failed [\#4731](https://github.com/rvm/rvm/pull/4731)

--- a/scripts/functions/requirements/arch
+++ b/scripts/functions/requirements/arch
@@ -103,7 +103,7 @@ requirements_arch_define()
       requirements_check clang35 llvm35 llvm35-libs patch curl zlib readline autoconf automake diffutils make libtool bison
       ;;
     (truffleruby*)
-      requirements_check zlib clang llvm make
+      requirements_check zlib make gcc libxml2
       requirements_arch_define_openssl "$1"
       ;;
     (ruby-2.3*|ruby-2.2*|ruby-2.1*|ruby-2.0*|ruby-1.9*)

--- a/scripts/functions/requirements/centos
+++ b/scripts/functions/requirements/centos
@@ -207,7 +207,7 @@ requirements_centos_define()
       ;;
 
     (truffleruby*)
-      requirements_check zlib-devel clang llvm make
+      requirements_check zlib-devel make gcc libxml2
       requirements_${_system_name_lowercase}_define_openssl $1
       ;;
 

--- a/scripts/functions/requirements/debian
+++ b/scripts/functions/requirements/debian
@@ -185,7 +185,7 @@ requirements_debian_define()
     (truffleruby*)
       requirements_debian_define_base
       requirements_${_system_name_lowercase}_define_libssl "$1"
-      requirements_check clang llvm
+      requirements_check make gcc libxml2
       ;;
 
     (*)

--- a/scripts/functions/requirements/dragonfly
+++ b/scripts/functions/requirements/dragonfly
@@ -38,7 +38,7 @@ requirements_dragonfly_define()
       ;;
 
     (truffleruby*)
-      requirements_check openssl llvm40
+      requirements_check openssl gmake gcc libxml2
       ;;
 
     (ir*)

--- a/scripts/functions/requirements/fedora_dnf
+++ b/scripts/functions/requirements/fedora_dnf
@@ -65,7 +65,7 @@ requirements_fedora_define()
       ;;
 
     (truffleruby*)
-      requirements_check zlib-devel clang llvm make
+      requirements_check zlib-devel make gcc libxml2
       requirements_fedora_define_openssl "$1"
       ;;
 

--- a/scripts/functions/requirements/gentoo
+++ b/scripts/functions/requirements/gentoo
@@ -45,7 +45,7 @@ requirements_gentoo_define()
       ;;
 
     (truffleruby*)
-      requirements_check sys-libs/zlib dev-libs/openssl net-misc/curl sys-devel/clang sys-devel/llvm sys-devel/make
+      requirements_check sys-libs/zlib dev-libs/openssl net-misc/curl sys-devel/make sys-devel/gcc dev-libs/libxml2
       ;;
 
     (ir*)

--- a/scripts/functions/requirements/opensuse
+++ b/scripts/functions/requirements/opensuse
@@ -97,7 +97,7 @@ requirements_opensuse_define()
       ;;
 
     (truffleruby*)
-      requirements_check zlib-devel libopenssl-devel llvm-clang llvm make
+      requirements_check zlib-devel libopenssl-devel make gcc libxml2
       ;;
 
     (*)

--- a/scripts/functions/requirements/osx_brew
+++ b/scripts/functions/requirements/osx_brew
@@ -274,7 +274,6 @@ requirements_osx_brew_define_gcc()
             ;;
 
         (truffleruby*)
-            brew_libs_conf+=( llvm@4 )
             ;;
 
         (*)

--- a/scripts/functions/requirements/osx_fink
+++ b/scripts/functions/requirements/osx_fink
@@ -181,7 +181,6 @@ requirements_osx_fink_define()
 
     (truffleruby*)
       requirements_osx_fink_libs_default "$1"
-      requirements_check clang50 llvm50
       ;;
 
     (*-head)

--- a/scripts/functions/requirements/osx_port
+++ b/scripts/functions/requirements/osx_port
@@ -139,7 +139,7 @@ requirements_osx_port_define()
       ;;
 
     (truffleruby*)
-      requirements_check openssl llvm-4.0
+      requirements_check openssl
       ;;
 
     (ruby*head)

--- a/scripts/functions/requirements/pclinuxos
+++ b/scripts/functions/requirements/pclinuxos
@@ -75,7 +75,7 @@ requirements_pclinuxos_define()
       ;;
 
     (truffleruby*)
-      requirements_check clang clang-devel llvm llvm-devel lib64openssl-devel zlib zlib-devel make
+      requirements_check lib64openssl-devel zlib zlib-devel make gcc libxml2
       ;;
 
     (*-head)

--- a/update-truffleruby.rb
+++ b/update-truffleruby.rb
@@ -34,5 +34,5 @@ insert_after "config/known_strings", /^truffleruby/, ["truffleruby-#{version}\n"
   insert_after "config/#{algorithm}", /^truffleruby/, digests
 }
 
-changelog_entry = ["* Add support for TruffleRuby #{version}.\n"]
+changelog_entry = ["* Add support for TruffleRuby #{version}\n"]
 insert_after "CHANGELOG.md", /# New interpreters/, changelog_entry, last: false


### PR DESCRIPTION
* TruffleRuby 19.3+ uses an internal LLVM toolchain and no longer depends on LLVM.
* The full dependencies are listed at
  https://github.com/oracle/truffleruby/blob/master/README.md#dependencies
* Previous versions of TruffleRuby detect if LLVM is missing and print
  a nice error message, so it is not an issue to remove the dependency
  for older versions.

Fixes https://github.com/oracle/truffleruby/issues/1820.