### PR TITLE
Ruby 2.3.8 should be able to use openssl 1.0

### DIFF
--- a/scripts/functions/requirements/osx_brew
+++ b/scripts/functions/requirements/osx_brew
@@ -307,7 +307,7 @@ requirements_osx_brew_define_openssl()
 
   case "$1" in
     (ruby-2.3*|ruby-2.2*|ruby-2.1*|ruby-2.0*|ruby-1.9*|ruby-1.8*)
-      brew_openssl_package="openssl"
+      brew_openssl_package="https://raw.githubusercontent.com/Homebrew/homebrew-core/8c9b113bc6812dc74c598c8f860017e42fba8d78/Formula/openssl.rb"
       ;;
 
     (ree-1.8*)


### PR DESCRIPTION
Fixes # 4781.

Changes proposed in this pull request:
* Force openssl to use 1.0.2t
* Instead of 1.1
*

Make sure that your pull request includes entry in the [CHANGELOG](CHANGELOG.md).