### PR TITLE
Fixes for Issue #3790 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Do not install `rubygems-bundler` by default on TruffleRuby to make `ruby -S bundle` work [\#4766](https://github.com/rvm/rvm/pull/4766)
 * Fixes checksums for Ruby 2.6.4 [\#4769](https://github.com/rvm/rvm/pull/4769), 2.4.7 and 2.5.6 [\#4771](https://github.com/rvm/rvm/pull/4771)
 * Update TruffleRuby dependencies [\#4815](https://github.com/rvm/rvm/pull/4815)
+* Provides for a workaround for people with @ in the their username.
 
 #### Changes
 * Installer now reports which URL(s) have failed to fetch version information and when version fetching has completely failed [\#4731](https://github.com/rvm/rvm/pull/4731)

--- a/rvm-test/Gemfile
+++ b/rvm-test/Gemfile
@@ -1,3 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'tf'

--- a/rvm-test/fast/rvm_gemset_separator_comment_test.sh
+++ b/rvm-test/fast/rvm_gemset_separator_comment_test.sh
@@ -1,0 +1,3 @@
+source "$rvm_path/scripts/rvm"
+
+

--- a/rvm-test/gemset_separator_tests/alias_comment_test.sh
+++ b/rvm-test/gemset_separator_tests/alias_comment_test.sh
@@ -1,0 +1,33 @@
+source "$rvm_path/scripts/rvm"
+
+rvm use 2.3.4 --install
+rvm use 2.4.0 --install
+rvm gemset create test_gemset
+
+rvm alias create default 2.4.0$RVM_GEMSET_SEPARATOR$test_gemset # status=0
+ls -l $rvm_path/environments/default       # status=0; match=/2.4.0$RVM_GEMSET_SEPARATOR$test_gemset/
+rvm alias list                             # match=/^default => ruby-2.4.0$RVM_GEMSET_SEPARATOR$test_gemset$/
+rvm alias delete default                   # status=0
+ls -l $rvm_path/environments/default       # status!=0
+
+rvm alias create ruby-test-default 2.4.0$RVM_GEMSET_SEPARATOR$test_gemset # status=0
+ls -l $rvm_path/environments/ruby-test-default       # status=0
+rvm alias list                                       # match=/^ruby-test-default => ruby-2.4.0$RVM_GEMSET_SEPARATOR$test_gemset$/
+rvm alias list names                                 # match=/^ruby-test-default$/
+rvm alias delete ruby-test-default                   # status=0
+ls -l $rvm_path/environments/ruby-test-default       # status!=0
+
+rvm --force gemset delete test_gemset
+
+: overwrite existing aliases
+rvm alias create veve 2.3.4  # status=0
+ls -l $rvm_path/environments/veve # status=0; match=/2.3.4/
+ls -l $rvm_path/wrappers/veve     # status=0; match=/2.3.4/
+rvm alias list                    # match=/^veve => ruby-2.3.4$/
+rvm alias create veve 2.4.0       # status=0
+ls -l $rvm_path/environments/veve # status=0; match=/2.4.0/
+ls -l $rvm_path/wrappers/veve     # status=0; match=/2.4.0/
+rvm alias list                    # match=/^veve => ruby-2.4.0$/
+rvm alias delete veve             # status=0
+ls -l $rvm_path/environments/veve # status!=0
+rvm alias list                    # match!=/^veve => /

--- a/rvm-test/gemset_separator_tests/current_and_list_comment_test.sh
+++ b/rvm-test/gemset_separator_tests/current_and_list_comment_test.sh
@@ -1,0 +1,31 @@
+source "$rvm_path/scripts/rvm"
+rvm try_install 2.4.0
+rvm try_install 2.3.4
+rvm try_install 2.4.1
+
+: separate default/current
+rvm use 2.4.0$RVM_GEMSET_SEPARATOR$abc-test --create --default
+# status=0
+# match=/Using .*ruby-2.4.0 with gemset abc-test/
+rvm current
+# match=/ruby-2.4.0$RVM_GEMSET_SEPARATOR$abc-test/
+
+rvm use 2.3.4$RVM_GEMSET_SEPARATOR$abc-test --create
+# status=0
+# match=/Using .*ruby-2.3.4 with gemset abc-test/
+rvm current
+# match=/ruby-2.3.4$RVM_GEMSET_SEPARATOR$abc-test/
+
+rvm list
+# match=/^ \* ruby-2.4.0/
+# match=/^=> ruby-2.3.4/
+
+: default == current
+rvm use 2.4.1$RVM_GEMSET_SEPARATOR$abc-test --create --default
+# status=0
+# match=/Using .*ruby-2.4.1 with gemset abc-test/
+rvm current
+# match=/ruby-2.4.1$RVM_GEMSET_SEPARATOR$abc-test/
+
+rvm list
+# match=/^=\* ruby-2.4.1/

--- a/rvm-test/gemset_separator_tests/do_comment_test.sh
+++ b/rvm-test/gemset_separator_tests/do_comment_test.sh
@@ -1,0 +1,83 @@
+source "$rvm_path/scripts/rvm"
+
+rvm use 2.3.4 --install # status=0
+rvm gemset create test1 # status=0
+rvm gemset create test2 # status=0
+rvm use 2.4.0 --install # status=0
+
+: do
+rvm 8.9.9 do rvm gemdir # status=1; match=/is not installed/
+rvm 2.3.4 do rvm gemdir # status=0; match=/2.3.4/
+rvm 2.3.4$RVM_GEMSET_SEPARATOR$test0 do rvm gemdir # status=2; match=/Gemset .* does not exist/
+rvm 2.3.4$RVM_GEMSET_SEPARATOR$test1 do rvm gemdir # status=0; match=/2.3.4$RVM_GEMSET_SEPARATOR$test1/
+rvm 2.3.4$RVM_GEMSET_SEPARATOR$test2 do rvm gemdir # status=0; match=/2.3.4$RVM_GEMSET_SEPARATOR$test2/
+
+rvm 2.3.4$RVM_GEMSET_SEPARATOR$global,2.3.4 do rvm gemdir # status=0; match=/2.3.4$RVM_GEMSET_SEPARATOR$global$/; match=/2.3.4$/
+
+rvm --force gemset delete test1 # status=0
+rvm --force gemset delete test2 # status=0
+
+: FIXME: The following tests have awful duplication due to https://github.com/mpapis/tf/issues/6
+
+: -----------------------------------------------------------------
+: do in directory with no version
+
+true TMPDIR:${TMPDIR:=/tmp}:
+d=$TMPDIR/test-rvm-do-in
+mkdir -p $d
+
+: absolute directory
+rvm in $d do rvm info ruby  # status=1; match=/Could not determine which Ruby to use/
+rvm in $d do ruby --version # status=1; match=/Could not determine which Ruby to use/
+
+: relative directory
+cd $TMPDIR
+rvm in test-rvm-do-in do rvm info ruby  # status=1; match=/Could not determine which Ruby to use/
+rvm in test-rvm-do-in do ruby --version # status=1; match=/Could not determine which Ruby to use/
+
+: current directory
+cd $d
+rvm in . do rvm info ruby  # status=1; match=/Could not determine which Ruby to use/
+rvm in . do ruby --version # status=1; match=/Could not determine which Ruby to use/
+rvm    . do rvm info ruby  # status=1; match=/Could not determine which Ruby to use/
+rvm    . do ruby --version # status=1; match=/Could not determine which Ruby to use/
+
+: -----------------------------------------------------------------
+mkdir -p $d/2.3.4
+echo "2.3.4" > $d/2.3.4/.ruby-version
+
+: absolute directory
+rvm in $d/2.3.4 do rvm info ruby  # status=0; match=/version: *"2.3.4/
+rvm in $d/2.3.4 do ruby --version # status=0; match=/^ruby 2.3.4/
+
+: relative directory
+cd $d
+rvm in 2.3.4 do rvm info ruby  # status=0; match=/version: *"2.3.4/
+rvm in 2.3.4 do ruby --version # status=0; match=/^ruby 2.3.4/
+
+: current directory
+cd $d/2.3.4
+rvm . do rvm info ruby  # status=0; match=/version: *"2.3.4/
+rvm . do ruby --version # status=0; match=/^ruby 2.3.4/
+
+: -----------------------------------------------------------------
+ver=2.4.0
+mkdir -p $d/2.4.0
+echo "2.4.0" > $d/2.4.0/.ruby-version
+
+: absolute directory
+rvm in $d/2.4.0 do rvm info ruby  # status=0; match=/version: *"2.4.0/
+rvm in $d/2.4.0 do ruby --version # status=0; match=/^ruby 2.4.0/
+
+: relative directory
+cd $d
+rvm in 2.4.0 do rvm info ruby  # status=0; match=/version: *"2.4.0/
+rvm in 2.4.0 do ruby --version # status=0; match=/^ruby 2.4.0/
+
+: current directory
+cd $d/2.4.0
+rvm . do rvm info ruby  # status=0; match=/version: *"2.4.0/
+rvm . do ruby --version # status=0; match=/^ruby 2.4.0/
+
+## cleanup
+rm -rf $d

--- a/rvm-test/gemset_separator_tests/env_comment_test.sh
+++ b/rvm-test/gemset_separator_tests/env_comment_test.sh
@@ -1,0 +1,7 @@
+source "$rvm_path/scripts/rvm"
+
+rvm use 2.4.0 --install
+
+rvm env 2.4.0           # match=/2.4.0/; match=/GEM_HOME=/; match=/GEM_PATH=/
+rvm env 2.4.0 --path    # match=/2.4.0/; match=/environments/
+rvm env 2.4.0 -- --path # match=/2.4.0/; match=/environments/

--- a/rvm-test/gemset_separator_tests/exports_comment_test.sh
+++ b/rvm-test/gemset_separator_tests/exports_comment_test.sh
@@ -1,0 +1,9 @@
+source "$rvm_path/scripts/rvm"
+
+export TEST_VAR=2     # env[TEST_VAR]=/^2$/
+rvm export TEST_VAR=3 # env[TEST_VAR]=/^3$/
+rvm unexport          # env[TEST_VAR]=/^2$/
+
+unset TEST_VAR        # env[TEST_VAR]=/^$/
+rvm export TEST_VAR=3 # env[TEST_VAR]=/^3$/
+rvm unexport          # env[TEST_VAR]=/^$/

--- a/rvm-test/gemset_separator_tests/gem-bundle_comment_test.sh
+++ b/rvm-test/gemset_separator_tests/gem-bundle_comment_test.sh
@@ -1,0 +1,21 @@
+source "$rvm_path/scripts/rvm"
+
+: setup/pretest
+export BUNDLE_GEMFILE=${TMPDIR:-/tmp}/Gemfile
+touch ${BUNDLE_GEMFILE}
+rvm alias delete default
+rvm use 2.3.4 --install
+rvm $RVM_GEMSET_SEPARATOR$global do gem uninstall bundler
+rvm gemset create gemtest
+rvm gemset use gemtest # status=0
+
+: test
+## this only happens after installing rvm: match=/Gem bundler is not installed/
+bundle config             # status=127
+gem install bundler --pre # status=0
+bundle config             # status=0 ; match=/Settings are listed in order of priority/
+
+: reset
+rvm gemset use default
+rvm --force gemset delete gemtest # status=0
+rm -f ${BUNDLE_GEMFILE}

--- a/rvm-test/gemset_separator_tests/gemfile_comment_test.sh
+++ b/rvm-test/gemset_separator_tests/gemfile_comment_test.sh
@@ -1,0 +1,47 @@
+source "$rvm_path/scripts/rvm"
+
+: settings
+true TMPDIR:${TMPDIR:=/tmp}:
+d=$TMPDIR/test-rvmrc
+f_rvmrc=$d/.rvmrc
+f_gemfile=$d/sub/Gemfile
+
+: prepare1
+rvm use 2.3.4 --install
+rvm gemset create gemfile
+rvm gemset create rvmrc
+mkdir -p $d/sub
+printf "rvm use 2.3.4$RVM_GEMSET_SEPARATOR$rvmrc\n"   > $f_rvmrc
+
+: test1
+rvm current           # match=/^ruby-2.3.4$/
+rvm_current_rvmrc=""
+rvm rvmrc load $d/sub # status=0; match=/Using .*ruby-2.3.4.*rvmrc/
+rvm current           # match=/^ruby-2.3.4$RVM_GEMSET_SEPARATOR$rvmrc$/
+
+: prepare2
+rvm use 2.3.4
+printf "source :rubygems\n\ngem 'haml'\n" > $f_gemfile
+
+: test2
+rvm current           # match=/^ruby-2.3.4$/
+rvm_current_rvmrc=""
+rvm rvmrc load $d/sub # status=0; match=/Using .*ruby-2.3.4.*rvmrc/
+rvm current           # match=/^ruby-2.3.4$RVM_GEMSET_SEPARATOR$rvmrc$/
+
+: prepare3
+rvm use 2.3.4
+## escape # -> \x23
+printf "source :rubygems\n\x23ruby=2.3.4\n\x23ruby-gemset=gemfile\ngem 'haml'\n" > $f_gemfile
+
+: test3
+rvm current           # match=/^ruby-2.3.4$/
+rvm_current_rvmrc=""
+rvm rvmrc load $d/sub # status=0; match!=/Using .*ruby-2.3.4.*rvmrc/
+rvm current           # match=/^ruby-2.3.4$RVM_GEMSET_SEPARATOR$gemfile$/
+
+: clean
+rvm use 2.3.4
+rvm --force gemset delete gemfile
+rvm --force gemset delete rvmrc
+rm -rf $d

--- a/rvm-test/gemset_separator_tests/gemset-copy_comment_test.sh
+++ b/rvm-test/gemset_separator_tests/gemset-copy_comment_test.sh
@@ -1,0 +1,9 @@
+source "$rvm_path/scripts/rvm"
+
+rvm use 2.4.0 --install
+
+:
+rvm gemset copy 2.4.0 2.4.0$RVM_GEMSET_SEPARATOR$testset # status=0; match=/Copying gemset/; match[stderr]=/^$/
+rvm gemset list                     # status=0; match=/ testset$/
+rvm gemset --force delete testset   # status=0; match=/Removing gemset testset/
+rvm gemset list                     # status=0; match!=/ testset$/

--- a/rvm-test/gemset_separator_tests/gemsets_comment_test.sh
+++ b/rvm-test/gemset_separator_tests/gemsets_comment_test.sh
@@ -1,6 +1,5 @@
 source "$rvm_path/scripts/rvm"
 
-export RVM_GEMSET_SEPARATOR='@@'
 rvm use 2.4.0 --install
 
 : create/use/rename/delete
@@ -45,7 +44,7 @@ rm -rf $d
 rvm use 2.4.0
 rvm gemset create test_gemset
 rvm gemset use test_gemset               # status=0 ; match=/Using /
-rvm gemdir                               # match=/@@test_gemset$/
+rvm gemdir                               # match=/$RVM_GEMSET_SEPARATOR$test_gemset$/
 gem install haml
 rvm gemset export haml.gems              # status=0; match=/Exporting /
 [[ -f haml.gems ]]                       # status=0
@@ -55,7 +54,7 @@ rvm gemset import haml.gems              # status=0; match=/Installing /
 rm haml.gems
 gem list                                 # match=/haml/
 rvm gemset use default                   # status=0 ; match=/Using /
-rvm --force --debug gemset empty test_gemset # status=0 ; match=/GEM_HOME=.*ruby-2.4.0@@test_gemset/
+rvm --force --debug gemset empty test_gemset # status=0 ; match=/GEM_HOME=.*ruby-2.4.0$RVM_GEMSET_SEPARATOR$test_gemset/
 rvm gemset use test_gemset               # status=0 ; match=/Using /
 gem list                                 # match!=/haml/
 echo yes | rvm gemset delete test_gemset # status=0
@@ -84,4 +83,3 @@ rvm current                              # match!=/unknown_gemset/
 
 : default
 rvm gemset list                          # match=/default/
-

--- a/rvm-test/gemset_separator_tests/globalcache_comment_test.sh
+++ b/rvm-test/gemset_separator_tests/globalcache_comment_test.sh
@@ -1,0 +1,39 @@
+source "$rvm_path/scripts/rvm"
+
+rvm use 2.3.4 --install                           # status=0; env[GEM_HOME]=/2.3.4/
+rvm --force gemset globalcache disable
+rvm gemset globalcache enabled                    # match=/Disabled/
+
+[[ -L "$rvm_path/gems/cache" ]]                   # status!=0
+
+rvm gemset globalcache enable                     # status=0; match=/ global cache /
+rvm gemset globalcache enabled                    # status=0; match=/Enabled/
+rvm gemset list                                   # status=0; match!=/ testset$/
+
+rvm gemset create testset                         # status=0; match=/gemset created/
+rvm gemset list                                   # status=0; match=/ testset$/
+
+[[ -L "$rvm_path/gems/cache" ]]                   # status!=0
+[[ -d "$rvm_path/gems/cache" ]]                   # status=0
+
+rvm gemset copy 2.3.4$RVM_GEMSET_SEPARATOR$testset 2.3.4$RVM_GEMSET_SEPARATOR$testset2
+# status=0
+# match=/Copying gemset/
+# match!=/Unknown file type/
+# match!=/cannot overwrite directory/
+# match!=/with non-directory/
+# match!=/Error running/
+# match[stderr]=/^$/
+rvm gemset list                                   # status=0; match=/ testset2$/
+
+rvm gemset --force delete testset                 # status=0; match=/Removing gemset testset/
+rvm gemset --force delete testset2                # status=0; match=/Removing gemset testset2/
+
+rvm system                                        # status=0
+
+[[ -L "$rvm_path/gems/cache" ]]                   # status!=0
+[[ -d "$rvm_path/gems/cache" ]]                   # status=0
+[[ -d "$rvm_path/gems/cache/cache" ]]             ## status!=0 ... need more testing for this
+
+rvm --force gemset globalcache disable            # status=0;  match=/Removing the global cache/
+rvm gemset globalcache enabled                    # status!=0; match=/Disabled/

--- a/rvm-test/gemset_separator_tests/remote_comment_test.sh
+++ b/rvm-test/gemset_separator_tests/remote_comment_test.sh
@@ -1,0 +1,29 @@
+source "$rvm_path/scripts/rvm"
+
+: prepare
+true TMPDIR:${TMPDIR:=/tmp}:
+d=$TMPDIR/test-remote
+mkdir $d
+pushd $d
+rvm use 2.3.4 --install # status=0
+rvm list
+# match=/ruby-2.3.4/
+
+: tast packaging
+rvm prepare 2.3.4           # status=0
+[[ -f ruby-2.3.4.tar.bz2 ]] # status=0
+
+: remove it
+rvm remove --gems 2.3.4     # status=0
+rvm list
+# match!=/ruby-2.3.4/
+
+: get local ruby
+rvm mount -r ruby-2.3.4.tar.bz2 # status=0
+rvm list
+# match=/ruby-2.3.4/
+rvm use 2.3.4 # status=0; match[stderr]=/^$/
+
+: clean
+popd
+rm -rf $d

--- a/rvm-test/gemset_separator_tests/ruby-version_comment_test.sh
+++ b/rvm-test/gemset_separator_tests/ruby-version_comment_test.sh
@@ -1,0 +1,61 @@
+source "$rvm_path/scripts/rvm"
+
+: prepare
+true TMPDIR:${TMPDIR:=/tmp}:
+d=$TMPDIR/test-ruby-version
+f=$d/.ruby-version
+g=$d/.ruby-gemset
+e=$d/.ruby-env
+mkdir -p $d
+cd $d
+rvm use --install 2.4.1
+rvm use --install 2.4.0
+rvm use --install 2.3.4
+
+## simple
+: short version
+echo "2.4.0" > $f           # env[GEM_HOME]=/2.3.4/
+rvm use .                   # env[GEM_HOME]=/2.4.0/
+
+: ruby version
+rvm use 2.3.4
+echo "ruby-2.4.0" > $f      # env[GEM_HOME]=/2.3.4/
+rvm use .                   # env[GEM_HOME]=/2.4.0/
+
+: patch version
+rvm use 2.3.4
+echo "2.4.1" > $f      # env[GEM_HOME]=/2.3.4/
+rvm use .                   # env[GEM_HOME]=/2.4.1/
+
+: full version
+rvm use 2.3.4
+echo "ruby-2.4.1" > $f # env[GEM_HOME]=/2.3.4/
+rvm use .                   # env[GEM_HOME]=/2.4.1/
+
+: gemset
+rvm use 2.3.4
+echo "veve" > $g            # env[GEM_HOME]=/2.3.4/
+rvm use .                   # env[GEM_HOME]=/2.4.1$RVM_GEMSET_SEPARATOR$veve/
+rm -f $g
+
+: environment
+rvm use 2.3.4
+echo "test_me=3" > $e
+rvm use .                   # env[GEM_HOME]=/2.4.1/; env[test_me]=/^3$/
+rvm use 2.3.4               # env[GEM_HOME]=/2.3.4/; env[test_me]=/^$/
+
+: environment spaces
+rvm use 2.3.4
+echo 'test_space=test me' > $e
+rvm use .                   # env[GEM_HOME]=/2.4.1/; env[test_space]=/^test me$/
+rvm use 2.3.4               # env[GEM_HOME]=/2.3.4/; env[test_space]=/^$/
+
+: environment quotes and spaces
+rvm use 2.3.4
+echo 'test_space="test me"' > $e
+rvm use .                   # env[GEM_HOME]=/2.4.1/; env[test_space]=/^test me$/
+rvm use 2.3.4               # env[GEM_HOME]=/2.3.4/; env[test_space]=/^$/
+
+: clean
+cd ..
+rm -rf $d

--- a/rvm-test/gemset_separator_tests/rvm-prompt_comment_test.sh
+++ b/rvm-test/gemset_separator_tests/rvm-prompt_comment_test.sh
@@ -1,0 +1,14 @@
+source "$rvm_path/scripts/rvm"
+
+command rvm install 2.4.1
+command rvm install 2.4.0
+command rvm install 2.3.4
+
+rvm 1.9.1 do rvm-prompt      # match=/Ruby (ruby-)?1.9.1(-p[[:digit:]]+)? is not installed./
+rvm 2.4.0 do rvm-prompt      # match=/^ruby-2.4.0$/
+rvm 2.3.4 do rvm-prompt i    # match=/^ruby$/
+rvm 2.3.4 do rvm-prompt i v  # match=/^ruby-2.3.4$/
+rvm 2.3.4 do rvm-prompt v    # match=/^2.3.4$/
+rvm system do rvm-prompt     # match=/^$/
+rvm system do rvm-prompt s v # match=/^system$/
+rvm 2.4.1 do rvm-prompt s v  # match=/^2.4.1$/

--- a/rvm-test/gemset_separator_tests/rvm-shell_comment_test.sh
+++ b/rvm-test/gemset_separator_tests/rvm-shell_comment_test.sh
@@ -1,0 +1,33 @@
+source "$rvm_path/scripts/rvm"
+
+: prepare
+d=${TMPDIR:=/tmp}/test-rvm-shell/ # status=0
+mkdir -p $d                       # status=0
+echo "rvm current" > $d/rvm-shell-rvm-current-script.sh # status=0
+chmod +x $d/rvm-shell-rvm-current-script.sh
+rvm use 2.3.4 --install
+rvm use system
+
+: Test1
+echo "rvm use 2.3.4$RVM_GEMSET_SEPARATOR$acme --create" > $d/.rvmrc     # status=0
+ls -ld $d/.rvmrc
+rvm rvmrc trust $d/.rvmrc                               # status=0
+rvm $d do rvm current                                   # match=/ruby-2.3.4$RVM_GEMSET_SEPARATOR$acme/
+rvm-shell --path $d -c "rvm current"                    # match=/ruby-2.3.4$RVM_GEMSET_SEPARATOR$acme/
+rvm $d do $d/rvm-shell-rvm-current-script.sh            # match=/ruby-2.3.4$RVM_GEMSET_SEPARATOR$acme/
+rvm-shell --path $d $d/rvm-shell-rvm-current-script.sh  # match=/ruby-2.3.4$RVM_GEMSET_SEPARATOR$acme/
+rvm use $d                                              # env[GEM_HOME]=/ruby-2.3.4$RVM_GEMSET_SEPARATOR$acme$/
+rvm use system
+
+: Test2
+echo "rvm 2.3.4$RVM_GEMSET_SEPARATOR$acme --create" > $d/.rvmrc         # status=0
+ls -ld $d/.rvmrc
+rvm rvmrc trust $d/.rvmrc                               # status=0
+rvm $d do rvm current                                   # match=/ruby-2.3.4$RVM_GEMSET_SEPARATOR$acme/
+rvm-shell --path $d -c "rvm current"                    # match=/ruby-2.3.4$RVM_GEMSET_SEPARATOR$acme/
+rvm $d do $d/rvm-shell-rvm-current-script.sh            # match=/ruby-2.3.4$RVM_GEMSET_SEPARATOR$acme/
+rvm-shell --path $d $d/rvm-shell-rvm-current-script.sh  # match=/ruby-2.3.4$RVM_GEMSET_SEPARATOR$acme/
+rvm $d                                                  # env[GEM_HOME]=/ruby-2.3.4$RVM_GEMSET_SEPARATOR$acme$/
+
+: Cleaning
+rm -rf $d # status=0

--- a/rvm-test/gemset_separator_tests/rvm_gemset_separator_comment_test.sh
+++ b/rvm-test/gemset_separator_tests/rvm_gemset_separator_comment_test.sh
@@ -1,6 +1,6 @@
 source "$rvm_path/scripts/rvm"
 
-export RVM_GEMSET_SEPARATOR='@@'
+export RVM_GEMSET_SEPARATOR='$RVM_GEMSET_SEPARATOR$$RVM_GEMSET_SEPARATOR$'
 rvm use 2.4.0 --install
 
 : create/use/rename/delete
@@ -45,7 +45,7 @@ rm -rf $d
 rvm use 2.4.0
 rvm gemset create test_gemset
 rvm gemset use test_gemset               # status=0 ; match=/Using /
-rvm gemdir                               # match=/@@test_gemset$/
+rvm gemdir                               # match=/$RVM_GEMSET_SEPARATOR$$RVM_GEMSET_SEPARATOR$test_gemset$/
 gem install haml
 rvm gemset export haml.gems              # status=0; match=/Exporting /
 [[ -f haml.gems ]]                       # status=0
@@ -55,7 +55,7 @@ rvm gemset import haml.gems              # status=0; match=/Installing /
 rm haml.gems
 gem list                                 # match=/haml/
 rvm gemset use default                   # status=0 ; match=/Using /
-rvm --force --debug gemset empty test_gemset # status=0 ; match=/GEM_HOME=.*ruby-2.4.0@@test_gemset/
+rvm --force --debug gemset empty test_gemset # status=0 ; match=/GEM_HOME=.*ruby-2.4.0$RVM_GEMSET_SEPARATOR$$RVM_GEMSET_SEPARATOR$test_gemset/
 rvm gemset use test_gemset               # status=0 ; match=/Using /
 gem list                                 # match!=/haml/
 echo yes | rvm gemset delete test_gemset # status=0

--- a/rvm-test/gemset_separator_tests/rvmrc-create_comment_test.sh
+++ b/rvm-test/gemset_separator_tests/rvmrc-create_comment_test.sh
@@ -1,0 +1,59 @@
+source "$rvm_path/scripts/rvm"
+
+: prepare
+true TMPDIR:${TMPDIR:=/tmp}:
+d=$TMPDIR/test-rvmrc
+mkdir $d
+pushd $d
+command rvm install 2.4.1
+rvm 2.4.1 do rvm gemset reset_env
+rvm use 2.3.4 --install
+
+: .rvmrc generated
+rvm rvmrc create 2.4.1
+[ -f .rvmrc ]         # status=0
+rvm current           # match=/2.3.4/
+rvm rvmrc trust .rvmrc
+rvm rvmrc load .rvmrc # env[GEM_HOME]=/2.4.1$/ ; env[PATH]=/2.4.1/
+rvm current           # match=/2.4.1/
+
+: .rvmrc with use
+rvm_current_rvmrc=""
+echo "rvm use 2.3.4" > .rvmrc
+rvm rvmrc trust .
+rvm rvmrc load .
+rvm current           # match=/2.3.4/
+
+: .rvmrc without use
+rvm_current_rvmrc=""
+echo "rvm 2.4.0" > .rvmrc
+rvm rvmrc trust
+rvm rvmrc load
+rvm current           # match=/2.4.0/
+
+rm -f .rvmrc
+rvm use 2.3.4
+
+: .versions.conf
+rvm rvmrc create 2.4.0 .versions.conf
+[ -f .versions.conf ] # status=0
+rvm current           # match=/2.3.4/
+rvm rvmrc load .
+rvm current           # match=/2.4.0/
+
+rm -f .versions.conf
+rvm use 2.3.4
+
+: .ruby-version
+rvm rvmrc create 2.4.0 .ruby-version
+[ -f .ruby-version ]  # status=0
+rvm current           # match=/2.3.4/
+rvm rvmrc load .
+rvm current           # match=/2.4.0/
+
+rm -f .ruby-version
+rvm use 2.3.4
+
+: clean
+popd
+rm -rf $d

--- a/rvm-test/gemset_separator_tests/rvmrc-warning_comment_test.sh
+++ b/rvm-test/gemset_separator_tests/rvmrc-warning_comment_test.sh
@@ -1,0 +1,42 @@
+source "$rvm_path/scripts/rvm"
+
+: prepare
+unset __rvmrc_warning_path
+true TMPDIR:${TMPDIR:=/tmp}:
+d=$TMPDIR/test-rvmrc-warning
+f=$d/Gemfile
+mkdir -p $d
+touch $f
+mv $rvm_path/user/rvmrc_ignored $d/rvmrc_ignored
+
+: single file
+rvm rvmrc warning list      # match!=/Gemfile/
+rvm --debug rvmrc warning check  $f # status=1 ; match=/is not ignored/
+rvm rvmrc warning ignore $f # status=0
+rvm rvmrc warning check  $f # status=0 ; match=/is ignored/
+rvm rvmrc warning list      # match=/test-rvmrc-warning/Gemfile/
+rvm rvmrc warning reset  $f # status=0
+rvm rvmrc warning check  $f # status=1 ; match=/is not ignored/
+rvm rvmrc warning list      # match!=/Gemfile/
+
+: all files
+rvm rvmrc warning check  allGemfiles # status=1 ; match=/is not ignored/
+rvm rvmrc warning ignore allGemfiles # status=0
+rvm rvmrc warning check  $f          # status=0 ; match=/is ignored/
+rvm rvmrc warning check  allGemfiles # status=0 ; match=/is ignored/
+rvm rvmrc warning list               # match=/allGemfiles/
+rvm rvmrc warning reset  allGemfiles # status=0
+rvm rvmrc warning check  $f          # status=1 ; match=/is not ignored/
+rvm rvmrc warning check  allGemfiles # status=1 ; match=/is not ignored/
+rvm rvmrc warning list               # match!=/Gemfile/
+
+: single + all
+rvm rvmrc warning ignore $f          # status=0
+rvm rvmrc warning ignore allGemfiles # status=0
+rvm rvmrc warning list               # match=/allGemfiles/ ; match=/test-rvmrc-warning/Gemfile/
+rvm rvmrc warning check  $f          # status=0 ; match=/is ignored/
+rvm rvmrc warning check  allGemfiles # status=0 ; match=/is ignored/
+
+: clean
+mv -f $d/rvmrc_ignored $rvm_path/user/rvmrc_ignored
+rm -rf $d

--- a/rvm-test/gemset_separator_tests/rvmrc_comment_test.sh
+++ b/rvm-test/gemset_separator_tests/rvmrc_comment_test.sh
@@ -1,0 +1,82 @@
+source "$rvm_path/scripts/rvm"
+rvm_scripts_path="$rvm_path/scripts" rvm_project_rvmrc=cd source "$rvm_path/scripts/cd"
+
+: prepare
+true TMPDIR:${TMPDIR:=/tmp}:
+d=$TMPDIR/test-rvmrc
+f=$d/.rvmrc
+mkdir -p $d
+echo "echo loading-rvmrc" > $f
+rvm use 2.4.0 --install # status=0
+rvm use 2.4.1 --install # status=0
+
+## simple
+: trust
+rvm rvmrc trust $d     # match=/ as trusted$/
+rvm rvmrc trusted $d   # match=/is currently trusted/
+
+: untrust
+rvm rvmrc untrust $d   # match=/ as untrusted$/
+rvm rvmrc trusted $d   # match=/is currently untrusted/
+
+: reset
+rvm rvmrc reset $d     # match=/^Reset/
+rvm rvmrc trusted $d   # match=/contains unreviewed changes/
+
+## spaces
+ds="$d/with spaces"
+mkdir -p "$ds"
+echo "echo loading-rvmrc" > "$ds/.rvmrc"
+rvm rvmrc trust "$ds"     # match=/ as trusted$/
+rvm rvmrc trusted "$ds"   # match=/is currently trusted/
+rvm rvmrc reset "$ds"     # match=/^Reset/
+
+## brackets
+ds="$d/with(brackets)"
+mkdir -p "$ds"
+echo "echo loading-rvmrc" > "$ds/.rvmrc"
+rvm rvmrc trust "$ds"     # match=/ as trusted$/
+rvm rvmrc trusted "$ds"   # match=/is currently trusted/
+rvm rvmrc reset "$ds"     # match=/^Reset/
+
+: prepare for load/cd test
+rvm alias create default 2.4.1
+rvm alias list            # match=/default => ruby-2.4.1/
+export rvm_project_rvmrc_default=1
+
+## load default
+builtin cd
+rvm use 2.4.0
+rvm rvmrc load            # env[GEM_HOME]!=/^$/
+
+## load ruby
+cd
+rvm use 2.4.0
+echo "rvm use 2.4.1" > "$d/.rvmrc"
+rvm rvmrc trust "$d"      # match=/ as trusted$/
+cd "$d"                   # env[GEM_HOME]=/2.4.1$/
+
+## load ruby$RVM_GEMSET_SEPARATOR$gemset
+cd
+rvm use 2.4.0
+echo "rvm use 2.4.1$RVM_GEMSET_SEPARATOR$vee --create" > "$d/.rvmrc"
+rvm rvmrc trust "$d"      # match=/ as trusted$/
+cd "$d"                   # env[GEM_HOME]=/2.4.1$RVM_GEMSET_SEPARATOR$vee$/
+
+## load $RVM_GEMSET_SEPARATOR$gemset
+cd
+rvm use 2.4.0
+echo "rvm use $RVM_GEMSET_SEPARATOR$vee --create" > "$d/.rvmrc"
+rvm rvmrc trust "$d"      # match=/ as trusted$/
+cd "$d"                   # env[GEM_HOME]=/2.4.0$RVM_GEMSET_SEPARATOR$vee$/
+
+## load $RVM_GEMSET_SEPARATOR$gemset after system
+cd
+rvm use system
+echo "rvm use $RVM_GEMSET_SEPARATOR$vee --create" > "$d/.rvmrc"
+rvm rvmrc trust "$d"      # match=/ as trusted$/
+cd "$d"                   # env[GEM_HOME]=/2.4.1$RVM_GEMSET_SEPARATOR$vee$/
+
+: clean
+rvm alias delete default  # status=0
+rm -rf $d

--- a/rvm-test/gemset_separator_tests/use_comment_test.sh
+++ b/rvm-test/gemset_separator_tests/use_comment_test.sh
@@ -1,0 +1,13 @@
+source "$rvm_path/scripts/rvm"
+
+command rvm install 2.3.4
+command rvm install 2.4.0
+
+rvm use 8.9.9           # status=1; match!=/Using /; env[GEM_HOME]!=/8.9.9/ ; match=/Unknown ruby interpreter version/
+rvm reset               # env[GEM_HOME]=/^$/
+rvm current             # match=/system/
+rvm use 2.3.4      # status=0; match=/Using / ; env[GEM_HOME]=/2.3.4/
+rvm current             # match=/2.3.4/
+command rvm use 2.4.0   # status=0; match!=/Using /; env[GEM_HOME]!=/2.4.0/ ; match=/RVM is not a function/
+rvm use 2.4.0           # status=0; match=/Using / ; env[GEM_HOME]=/2.4.0/
+rvm use 1.9.1           # status=1; env[rvm_recommended_ruby]=/rvm install ruby-1.9.1/

--- a/rvm-test/gemset_separator_tests/versions.conf_comment_test.sh
+++ b/rvm-test/gemset_separator_tests/versions.conf_comment_test.sh
@@ -1,0 +1,51 @@
+rvm_reload_flag=1 source "$rvm_path/scripts/rvm"
+
+: prepare
+true TMPDIR:${TMPDIR:=/tmp}:
+d=$TMPDIR/test-versions-conf
+mcd(){ mkdir -p $1 ; cd $1 ; }
+mcd $d
+rm -f */*
+
+: generate
+mcd $d/a
+rvm use 2.4.0$RVM_GEMSET_SEPARATOR$versions-conf-a --create --versions-conf --install
+rvm current             # match=/^ruby-2.4.0$RVM_GEMSET_SEPARATOR$versions-conf-a$/
+[[ -f .versions.conf ]] # status=0
+
+mcd $d/b
+rvm use 2.3.4$RVM_GEMSET_SEPARATOR$versions-conf-b --create --versions-conf --install
+rvm current             # match=/^ruby-2.3.4$RVM_GEMSET_SEPARATOR$versions-conf-b$/
+[[ -f .versions.conf ]] # status=0
+
+: test
+rvm rvmrc load $d/a
+rvm current         # match=/^ruby-2.4.0$RVM_GEMSET_SEPARATOR$versions-conf-a$/
+rvm rvmrc load $d/b
+rvm current         # match=/^ruby-2.3.4$RVM_GEMSET_SEPARATOR$versions-conf-b$/
+
+: test bundler without flag of doom
+mcd $d/b ## on travis cd hook is disabled ?
+rvm rvmrc load $d/b
+gem list # match!=/haml/
+printf "ruby-gem-install=bundler\nruby-bundle-install=true\n" >> .versions.conf
+printf "source :rubygems\n\ngem 'haml'\n" > Gemfile
+rvm_current_rvmrc=""
+rvm rvmrc load . # match!=/Installing haml/
+gem list # match!=/haml/; match=/bundler/
+
+: test bundler with flag of doom
+mcd $d/b ## on travis cd hook is disabled ?
+rvm rvmrc load $d/b
+gem list # match!=/haml/
+printf "ruby-gem-install=bundler\nruby-bundle-install=true\n" >> .versions.conf
+printf "source :rubygems\n\ngem 'haml'\n" > Gemfile
+rvm_current_rvmrc=""
+rvm_autoinstall_bundler_flag=1
+rvm rvmrc load . # match=/Installing haml/
+gem list # match=/haml/; match=/bundler/
+
+: clean
+rvm 2.4.0 do rvm --force gemset delete versions-conf-a
+rvm 2.3.4 do rvm --force gemset delete versions-conf-b
+rm -rf $d

--- a/rvm-test/gemset_separator_tests/wrapper_comment_test.sh
+++ b/rvm-test/gemset_separator_tests/wrapper_comment_test.sh
@@ -1,0 +1,48 @@
+source "$rvm_path/scripts/rvm"
+
+: prepare
+true TMPDIR:${TMPDIR:=/tmp}:
+d=$TMPDIR/test-wrappers
+mkdir $d
+pushd $d
+rvm install 2.4.0 # status=0
+rvm use --install 2.3.4 # status=0
+rvm 2.3.4$RVM_GEMSET_SEPARATOR$global do gem install rake -v "<10.2"
+
+: help
+rvm wrapper      # status!=0; match=/Usage/
+rvm wrapper help # status=0;  match=/Usage/
+
+: show
+rvm wrapper show
+# status=0
+# match=/Wrappers path: .*/gems/ruby-2.3.4\/wrappers/
+# match=/Environment file: .*/gems/ruby-2.3.4/environment/
+# match=/Executables: .*, rake, /
+
+: show rake
+rvm wrapper show rake
+# status=0
+# match=/.*/gems/ruby-2.3.4\/wrappers\/rake/
+
+: for file
+echo 'echo "$GEM_HOME"' > $d/custom-script
+chmod +x $d/custom-script
+rvm 2.4.0 do rvm wrapper $d/custom-script # status=0
+wrapper_script=`rvm 2.4.0 do rvm wrapper show custom-script`
+# status=0
+# env[wrapper_script]=/.*/gems/ruby-2.4.0\/wrappers\/custom-script/
+$wrapper_script
+# status=0
+# match=/.*/gems/ruby-2.4.0\Z/
+# env[GEM_HOME]=/.*/gems/ruby-2.3.4\Z/
+
+: regenerate
+rm -f $GEM_HOME/wrappers/rake
+rvm wrapper show rake   # status!=0
+rvm wrapper regenerate  # status=0
+rvm wrapper show rake   # status=0
+
+: clean
+popd
+rm -rf $d

--- a/rvm-test/run_gemset_separator_tests.sh
+++ b/rvm-test/run_gemset_separator_tests.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# This prepocess the gemset_separator_tests for running with tf.
+# The tests inside rvm-test/gemset_separator_tests are copies of the the tests in rvm-test/fast with all
+# the '@' replaced with a $RVM_GEMSET_SEPARATOR$ so you can test with differnt gemset separators.
+#
+# Please run this from the root directory of the project since it uses relative paths
+# bash rvm-test/run_gemset_separator_tests.sh
+# sed 's/\$RVM_GEMSET_SEPARATOR\$/'$RVM_GEMSET_SEPARATOR'/g'
+echo "Preprocessing tests..."
+export RVM_GEMSET_SEPARATOR='@@'
+if [[ ! -d  rvm-test/gemset_separator_tests_preprocessed ]]
+then
+  mkdir rvm-test/gemset_separator_tests_preprocessed
+fi
+for entry in rvm-test/gemset_separator_tests/*
+do
+  file="$(basename -- $entry)"
+  sed 's/\$RVM_GEMSET_SEPARATOR\$/'$RVM_GEMSET_SEPARATOR'/g' "$entry" > rvm-test/gemset_separator_tests_preprocessed/${file}
+done
+tf rvm-test/gemset_separator_tests_preprocessed/*

--- a/scripts/cli
+++ b/scripts/cli
@@ -841,6 +841,13 @@ __rvm_parse_args()
 
 rvm()
 {
+  if
+    [[ $RVM_GEMSET_SEPARATOR ]]
+  then
+    rvm_gemset_separator=$RVM_GEMSET_SEPARATOR
+  else
+    rvm_gemset_separator="${rvm_gemset_separator:-"@"}"
+  fi
   \typeset result current_result
   rvm_ruby_args=()
 
@@ -987,7 +994,7 @@ rvm()
             [[ "${GEM_HOME:-""}" == "${GEM_HOME%%${rvm_gemset_separator:-@}*}${rvm_gemset_separator:-@}${rvm_gemset_name}" ]]
           then
             rvm_delete_flag=0
-            __rvm_use "@default"
+            __rvm_use "${rvm_gemset_separator:-@}default"
           fi
           unset gem_prefix
         elif
@@ -998,7 +1005,7 @@ rvm()
           if
             [[ "${GEM_HOME:-""}" == "${GEM_HOME%%${rvm_gemset_separator:-@}*}${rvm_gemset_separator:-@}${_from}" ]]
           then
-            __rvm_use "@${_to}"
+            __rvm_use "${rvm_gemset_separator:-@}${_to}"
           fi
         fi
       fi

--- a/scripts/cli
+++ b/scripts/cli
@@ -105,7 +105,7 @@ __rvm_parse_args()
             __rvm_file_env_check_unload
             if
               [[ -n "${next_token:-}" && ! -d "${next_token:-}" &&
-                "${next_token:-}" != "-"* && "${next_token:-}" != "@"*
+                "${next_token:-}" != "-"* && "${next_token:-}" != "${rvm_gemset_separator:-@}"*
               ]]
             then
               rvm_ruby_interpreter="$next_token"

--- a/scripts/docs
+++ b/scripts/docs
@@ -106,7 +106,7 @@ update_rdoc()
 
 install_rdoc_data()
 {
-  __rvm_use ${rvm_docs_ruby_string%%@*}@global
+  __rvm_use ${rvm_docs_ruby_string%%${rvm_gemset_separator:-@}*}${rvm_gemset_separator:-@}global
   update_rdoc
   gem list rdoc-data | __rvm_grep "^rdoc" || gem install rdoc-data
   rdoc-data --install

--- a/scripts/functions/environment
+++ b/scripts/functions/environment
@@ -81,7 +81,7 @@ __rvm_ensure_has_environment_files()
   __gem_home="${rvm_ruby_gem_home}"
   file_name="${__gem_home}/environment"
   __path=""
-  if [[ "${__gem_home##*@}" != "global" ]]
+  if [[ "${__gem_home##*${rvm_gemset_separator:-'@'}}" != "global" ]]
   then __path+="${__gem_home}/bin:"
   fi
   __path+="${rvm_ruby_global_gems_path}/bin:${rvm_ruby_home}/bin"

--- a/scripts/functions/gemset
+++ b/scripts/functions/gemset
@@ -86,7 +86,7 @@ gemset_create()
     if
       (( ${rvm_skip_gemsets_flag:-0} == 0 ))
     then
-      __rvm_with "${rvm_ruby_string}${gemset:+@}${gemset}" gemset_initial ${gemset:-default}
+      __rvm_with "${rvm_ruby_string}${gemset:+${rvm_gemset_separator:-@}}${gemset}" gemset_initial ${gemset:-default}
     fi
   done
 
@@ -344,7 +344,7 @@ gemset_initial()
       rvm_debug "$rvm_ruby_string - #gemset definition does not exist ${_iterator}/$1.gems"
     fi
   done
-  
+
   __rvm_log_command "gemset.wrappers.$1" \
     "$rvm_ruby_string - #generating ${1} wrappers" \
     run_gem_wrappers regenerate 2>/dev/null || true
@@ -425,7 +425,7 @@ __rvm_initial_gemsets_create_without_rubygems()
 __rvm_initial_gemsets_create_gemsets()
 {
   gemset_create "global" &&
-  __rvm_with "${rvm_ruby_string}@global" __rvm_remove_without_gems &&
+  __rvm_with "${rvm_ruby_string}${rvm_gemset_separator:-@}global" __rvm_remove_without_gems &&
   gemset_create ""
 }
 

--- a/scripts/functions/installer
+++ b/scripts/functions/installer
@@ -1367,7 +1367,7 @@ update_gemsets_install_rvm()
 
   # rvm /gems
   paths=($(
-    __rvm_find "$rvm_path/gems" -maxdepth 1 "${name_opt}" '*@global'
+    __rvm_find "$rvm_path/gems" -maxdepth 1 "${name_opt}" "*${rvm_gemset_separator:-@}global"
   ))
 
   for _gem in rvm gem-wrappers
@@ -1379,7 +1379,7 @@ update_gemsets_install_rvm()
       for _iterator in "${paths[@]}"
       do
         # skip unless this ruby is installed
-        installed="${_iterator%@global}"
+        installed="${_iterator%${rvm_gemset_separator:-@}global}"
         installed="${installed/\/gems\//\/rubies\//}/bin"
         installed="${installed//\\/}"
         [[ -x "${installed}/ruby" ]] || continue
@@ -1411,7 +1411,7 @@ update_gemsets_install_rvm()
         for _iterator in "${missing[@]}"
         do
           installed="${_iterator#*=}"
-          installed="${installed%@global}"
+          installed="${installed%${rvm_gemset_separator:-@}global}"
           for __gem_home in "${installed}"{,@*}
           do
             if [[ "${__gem_home}" == *"@*" ]]

--- a/scripts/functions/rubygems
+++ b/scripts/functions/rubygems
@@ -267,7 +267,7 @@ rubygems_setup()
 
   \typeset -a __command
   __command=(
-    GEM_HOME="$rvm_gems_path/${rvm_ruby_string}@global" GEM_PATH="" "${rvm_ruby_binary}" -d "${rvm_src_path}/$rvm_gem_package_name/setup.rb"
+    GEM_HOME="$rvm_gems_path/${rvm_ruby_string}${rvm_gemset_separator:-@}global" GEM_PATH="" "${rvm_ruby_binary}" -d "${rvm_src_path}/$rvm_gem_package_name/setup.rb"
   )
   if [[ ${rvm_debug_flag:-0} == 1 || ${rvm_trace_flag:-0} == 1 ]]
   then __command+=( --verbose )

--- a/scripts/functions/rvmrc_set
+++ b/scripts/functions/rvmrc_set
@@ -11,8 +11,8 @@ __rvm_set_versions_conf()
   fi
 
   identifier=$(__rvm_env_string)
-  gemset=${identifier#*@}
-  identifier=${identifier%@*}
+  gemset=${identifier#*${rvm_gemset_separator}}
+  identifier=${identifier%${rvm_gemset_separator}*}
 
   printf "%b" "ruby=$identifier
 " >> .versions.conf
@@ -46,7 +46,7 @@ __rvm_set_ruby_version()
         \command \mv .ruby-gemset .ruby-gemset.$(__rvm_date +%m.%d.%Y-%H:%M:%S)
         rvm_warn ".ruby-gemset is not empty, moving aside to preserve."
       fi
-      echo "${__version##*@}" > .ruby-gemset
+      echo "${__version##*${rvm_gemset_separator}}" > .ruby-gemset
       ;;
     (*)
       if

--- a/scripts/functions/selector
+++ b/scripts/functions/selector
@@ -281,7 +281,7 @@ __rvm_ruby_string_installed()
     -d "${__ruby_inst_dir}"
   ]] &&
   [[ -z "${rvm_gemset_name}" || ${rvm_create_flag:-0} -eq 1 ||
-    -d "${__ruby_inst_dir}${rvm_gemset_separator}${rvm_gemset_name}"
+    -d "${__ruby_inst_dir}${rvm_gemset_separator:-@}${rvm_gemset_name}"
   ]]
 }
 
@@ -311,10 +311,10 @@ __rvm_ruby_string()
     ${rvm_expanding_aliases:=0} ${rvm_head_flag:=0}
 
   if
-    [[ "$rvm_ruby_string" == *"${rvm_gemset_separator}"* ]]
+    [[ "$rvm_ruby_string" == *"${rvm_gemset_separator:-@}"* ]]
   then
-    rvm_gemset_name="${rvm_ruby_string/*${rvm_gemset_separator}/}"
-    rvm_ruby_string="${rvm_ruby_string/${rvm_gemset_separator}*/}"
+    rvm_gemset_name="${rvm_ruby_string/*${rvm_gemset_separator:-@}/}"
+    rvm_ruby_string="${rvm_ruby_string/${rvm_gemset_separator:-@}*/}"
   fi
   # known ruby aliases
   if
@@ -347,10 +347,10 @@ __rvm_ruby_string()
       rvm_ruby_string="system"
     fi
     if
-      [[ "$rvm_ruby_string" == *"${rvm_gemset_separator}"* ]]
+      [[ "$rvm_ruby_string" == *"${rvm_gemset_separator:-@}"* ]]
     then
-      rvm_gemset_name="${rvm_ruby_string/*${rvm_gemset_separator}/}"
-      rvm_ruby_string="${rvm_ruby_string/${rvm_gemset_separator}*/}"
+      rvm_gemset_name="${rvm_ruby_string/*${rvm_gemset_separator:-@}/}"
+      rvm_ruby_string="${rvm_ruby_string/${rvm_gemset_separator:-@}*/}"
     fi
   fi
   if
@@ -500,7 +500,7 @@ __rvm_ruby_strings_exist()
     rvm_gemset_name=""
     rvm_verbose_flag=0 __rvm_use "${rvm_ruby_string}" >/dev/null 2>&1 || return $?
     true rvm_gemset_name:${rvm_gemset_name:=${rvm_expected_gemset_name}}
-    printf "%b" "${rvm_ruby_string}${rvm_gemset_name:+@}${rvm_gemset_name:-}\n"
+    printf "%b" "${rvm_ruby_string}${rvm_gemset_name:+${rvm_gemset_separator:-@}}${rvm_gemset_name:-}\n"
   done
   unset rvm_ruby_string
 }

--- a/scripts/functions/selector_gemsets
+++ b/scripts/functions/selector_gemsets
@@ -36,9 +36,9 @@ __rvm_gemset_select_cli_validation()
     rvm_gemset_name="${rvm_gemset_name#*${rvm_gemset_separator:-"@"}}"
   fi
 
-  if [[ -z "${rvm_ruby_string:-}" && -n "${GEM_HOME:-}" && -n "${GEM_HOME%@*}" ]]
+  if [[ -z "${rvm_ruby_string:-}" && -n "${GEM_HOME:-}" && -n "${GEM_HOME%${rvm_gemset_separator:-@}*}" ]]
   then
-    rvm_ruby_string="${GEM_HOME%@*}"
+    rvm_ruby_string="${GEM_HOME%${rvm_gemset_separator:-@}*}"
     rvm_ruby_string="${rvm_ruby_string##*/}"
   fi
 
@@ -76,7 +76,7 @@ __rvm_gemset_select_only()
 
   if [[ -n "${rvm_gemset_name}" ]]
   then
-    rvm_env_string="${rvm_ruby_string}@${rvm_gemset_name}"
+    rvm_env_string="${rvm_ruby_string}${rvm_gemset_separator:-@}${rvm_gemset_name}"
   else
     rvm_env_string=${rvm_ruby_string}
   fi
@@ -146,7 +146,7 @@ __rvm_gemset_use_ensure()
 {
   if
     [[ ! -d "$rvm_ruby_gem_home" ]] ||
-    [[ -n "${rvm_expected_gemset_name}" && ! -d "${rvm_ruby_gem_home%@*}@${rvm_expected_gemset_name}" ]]
+    [[ -n "${rvm_expected_gemset_name}" && ! -d "${rvm_ruby_gem_home%${rvm_gemset_separator}*}${rvm_gemset_separator}${rvm_expected_gemset_name}" ]]
   then
     if
       (( ${rvm_gemset_create_on_use_flag:=0} == 1 || ${rvm_create_flag:=0} == 1 ))

--- a/scripts/gemsets
+++ b/scripts/gemsets
@@ -308,7 +308,7 @@ gemset_copy()
   )
   destination_path=$(
     __rvm_select "$destination_ruby" > /dev/null 2>&1
-    echo $rvm_ruby_gem_home${rvm_expected_gemset_name:+@}${rvm_expected_gemset_name:-}
+    echo $rvm_ruby_gem_home${rvm_expected_gemset_name:+${rvm_gemset_separator:-@}}${rvm_expected_gemset_name:-}
   )
   if
     [[ -z "$source_path" || ! -d "$source_path" ]]
@@ -648,7 +648,7 @@ case "$action" in
     gemset_export "$@"
     ;;
   empty)
-    __rvm_use "${1:+@}${1:-${GEM_HOME##*/}}"
+    __rvm_use "${1:+${rvm_gemset_separator:-@}}${1:-${GEM_HOME##*/}}"
     gemset_$action "$@"
     ;;
   create|initial|list)

--- a/scripts/gemsets
+++ b/scripts/gemsets
@@ -371,7 +371,7 @@ gemset_rename()
     return 1
   fi
   source_path="$(
-    rvm_use_flag=0 rvm_silence_logging=1 rvm_gemset_name=${source_name} __rvm_use "${rvm_ruby_string}@${source_name}" 1>&2 ;
+    rvm_use_flag=0 rvm_silence_logging=1 rvm_gemset_name=${source_name} __rvm_use "${rvm_ruby_string}${rvm_gemset_separator}${source_name}" 1>&2 ;
     gem env gemdir
   )"
   if

--- a/scripts/mount
+++ b/scripts/mount
@@ -226,7 +226,7 @@ external_mount()
   echo "Mounting '${rvm_ruby_string}' from '${prefix_path}' with 'bin/${ruby_path##*/}'"
 
   external_mount_link_default_binaries
-  mkdir -p "$rvm_gems_path/$rvm_ruby_string" "$rvm_gems_path/$rvm_ruby_string@global"
+  mkdir -p "$rvm_gems_path/$rvm_ruby_string" "$rvm_gems_path/$rvm_ruby_string${rvm_gemset_separator:-@}global"
 
   __rvm_select "$rvm_ruby_string"
   __rvm_fix_rbconfig "$rvm_rubies_path/$rvm_ruby_string"


### PR DESCRIPTION
Fixes #3790 .

This provides for a workaround with users who have @ in their username.  

It does this by:
*  making available an environment variable where a user can set their own gem separator  RVM_GEM_SEPARATOR
* replacing instances where @ is used with the variable rvm_gem_separator

A simple unit test is provided in rvm-test/fast and a more robust set of tests provided in rvm-test/gemset_separator_tests.  The test runner,rvm-test/fast/rvm_gemset_separator_comment_test.sh, allows you test different gemset separators. Right now it tests only '@@' and all the tests pass. 
