### PR TITLE
Use ruby.git master instead of trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Do not install `rubygems-bundler` by default on TruffleRuby to make `ruby -S bundle` work [\#4766](https://github.com/rvm/rvm/pull/4766)
 * Fixes checksums for Ruby 2.6.4 [\#4769](https://github.com/rvm/rvm/pull/4769), 2.4.7 and 2.5.6 [\#4771](https://github.com/rvm/rvm/pull/4771)
 * Update TruffleRuby dependencies [\#4815](https://github.com/rvm/rvm/pull/4815)
+* Use ruby.git master instead of trunk [\#4840](https://github.com/rvm/rvm/pull/4840)
 
 #### Changes
 * Installer now reports which URL(s) have failed to fetch version information and when version fetching has completely failed [\#4731](https://github.com/rvm/rvm/pull/4731)

--- a/scripts/functions/manage/base_fetch
+++ b/scripts/functions/manage/base_fetch
@@ -149,7 +149,7 @@ __rvm_fetch_ruby_head_git()
                 rvm_ruby_repo_branch="ruby_${rvm_ruby_release_version:-1}_${rvm_ruby_major_version}"
               fi
             else
-              rvm_ruby_repo_branch="trunk" # NOTE: Ruby Core team maps 'trunk' as HEAD
+              rvm_ruby_repo_branch="master" # NOTE: Ruby Core team maps 'master' as HEAD
             fi
           fi
           ;;


### PR DESCRIPTION
Changes proposed in this pull request:
* Use ruby.git master instead of trunk
  * In May, ruby.git's trunk branch was renamed to master. Currently trunk was mirrored from master, but it'll be deleted on Jan 1st, 2020. https://bugs.ruby-lang.org/issues/15843
  * Therefore rvm should stop referring to ruby.git's trunk branch.