### PR TITLE
Add support for truffleruby-head

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 #### New features
 * Improve JRuby install time [\#4807](https://github.com/rvm/rvm/pull/4807)
 * Add Termux support [\#4749](https://github.com/rvm/rvm/pull/4749)
+* Add support for `truffleruby-head` [\#4871](https://github.com/rvm/rvm/pull/4871)
 
 #### New interpreters
 * Add support for TruffleRuby 19.3.1

--- a/rvm-test/long/truffleruby_comment_test.sh
+++ b/rvm-test/long/truffleruby_comment_test.sh
@@ -1,3 +1,4 @@
+## Test the latest TruffleRuby release
 rvm install truffleruby # status=0; match!=/Already installed/; match=/compiling c-extensions/
 rvm truffleruby do ruby -v # status=0; match=/truffleruby/
 rvm truffleruby do rake --version # status=0; match=/rake, version/
@@ -10,7 +11,12 @@ rvm truffleruby do ruby -ropen-uri -e 'puts open("https://rubygems.org/") { |f| 
 # status=0; match=/RubyGems.org/
 rvm remove truffleruby # status=0; match=/removing.+truffleruby/
 
+## Test installing truffleruby-head
+rvm install truffleruby-head # status=0; match!=/Already installed/
+rvm truffleruby-head do ruby -v # status=0; match=/truffleruby/
+rvm remove truffleruby-head # status=0
+
 ## Test that the right version is installed (#4633)
 rvm install truffleruby-1.0.0-rc13 # status=0; match!=/Already installed/
 rvm truffleruby-1.0.0-rc13 do ruby -v # status=0; match=/truffleruby 1.0.0-rc13/
-rvm remove truffleruby-1.0.0-rc13
+rvm remove truffleruby-1.0.0-rc13 # status=0

--- a/scripts/functions/manage/base_fetch
+++ b/scripts/functions/manage/base_fetch
@@ -20,6 +20,9 @@ __rvm_fetch_ruby()
     [[ -z "${rvm_ruby_tag:-}" && -z "${rvm_ruby_revision:-}" && -z "${rvm_ruby_sha:-}"  && -z "${rvm_ruby_repo_tag:-}" ]]
   then
     __rvm_fetch_ruby_package || return $?
+  elif [[ "${rvm_ruby_interpreter}" == "truffleruby" ]]; then
+    # Always use __rvm_fetch_ruby_package() for TruffleRuby, building from the repository is not supported in RVM
+    __rvm_fetch_ruby_package || return $?
   else
     \typeset result=0
 
@@ -79,7 +82,7 @@ __rvm_fetch_ruby_package()
         return 198
         ;;
       (maglev|rubinius|rbx|truffleruby)
-        true # Should already be set from selector
+        true # Should already be set from scripts/functions/selector_interpreters
         ;;
       (*)
         rvm_ruby_url="$(__rvm_db "${rvm_ruby_interpreter}_url")/${rvm_ruby_package_file}.${rvm_archive_extension}"

--- a/scripts/functions/selector_interpreters
+++ b/scripts/functions/selector_interpreters
@@ -244,13 +244,13 @@ __rvm_truffleruby_set_version()
 __rvm_truffleruby_set_rvm_ruby_url()
 {
   case "${_system_type}" in
-    "Linux") platform="linux" ;;
-    "Darwin") platform="macos" ;;
+    Linux) platform="linux" ;;
+    Darwin) platform="macos" ;;
     *) rvm_error "TruffleRuby does not support ${_system_type} currently." ;;
   esac
 
   case "${_system_arch}" in
-    "x86_64") arch=amd64 ;;
+    x86_64) arch=amd64 ;;
     *) rvm_error "TruffleRuby does not support ${_system_arch} currently." ;;
   esac
 

--- a/scripts/functions/selector_interpreters
+++ b/scripts/functions/selector_interpreters
@@ -235,8 +235,14 @@ __rvm_select_interpreter_jruby()
 
 __rvm_truffleruby_set_version()
 {
-  rvm_ruby_version="${rvm_ruby_version:-$(__rvm_db "truffleruby_version")}"
-  truffleruby_version="${rvm_ruby_version}${rvm_ruby_patch_level:+-}${rvm_ruby_patch_level:-}"
+  if (( ${rvm_head_flag:=0} == 1 ))
+  then
+    rvm_ruby_version="head"
+    truffleruby_version="head"
+  else
+    rvm_ruby_version="${rvm_ruby_version:-$(__rvm_db "truffleruby_version")}"
+    truffleruby_version="${rvm_ruby_version}${rvm_ruby_patch_level:+-}${rvm_ruby_patch_level:-}"
+  fi
 
   true # for OSX
 }
@@ -255,8 +261,19 @@ __rvm_truffleruby_set_rvm_ruby_url()
   esac
 
   rvm_ruby_package_name="truffleruby-${truffleruby_version}"
-  rvm_ruby_package_file="${rvm_ruby_package_name}-${platform}-${arch}"
-  rvm_ruby_url="${rvm_ruby_repo_url:-$(__rvm_db "truffleruby_url")/vm-${truffleruby_version}/${rvm_ruby_package_file}.tar.gz}"
+
+  if (( ${rvm_head_flag:=0} == 1 )); then
+    case "$platform" in
+      linux) platform="ubuntu-18.04" ;;
+      macos) platform="macos-latest" ;;
+    esac
+
+    rvm_ruby_package_file="${rvm_ruby_package_name}-${platform}"
+    rvm_ruby_url="${rvm_ruby_repo_url:-https://github.com/ruby/truffleruby-dev-builder/releases/latest/download/${rvm_ruby_package_file}.tar.gz}"
+  else
+    rvm_ruby_package_file="${rvm_ruby_package_name}-${platform}-${arch}"
+    rvm_ruby_url="${rvm_ruby_repo_url:-$(__rvm_db "truffleruby_url")/vm-${truffleruby_version}/${rvm_ruby_package_file}.tar.gz}"
+  fi
 
   true # for OSX
 }


### PR DESCRIPTION
* Uses the latest nightly build, which is automatically built.
* I checked in Docker and it works well with `rvm install truffleruby-head`.

cc @gogainda @deepj

Ref: https://github.com/oracle/truffleruby/issues/1483 https://github.com/oracle/truffleruby/issues/1903