### PR TITLE
Do not warn if using a development version newer than the latest release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Fixes checksums for Ruby 2.6.4 [\#4769](https://github.com/rvm/rvm/pull/4769), 2.4.7 and 2.5.6 [\#4771](https://github.com/rvm/rvm/pull/4771)
 * Update TruffleRuby dependencies [\#4815](https://github.com/rvm/rvm/pull/4815)
 * Use ruby.git master instead of trunk [\#4840](https://github.com/rvm/rvm/pull/4840)
+* Fix RVM version check when using a version newer than the latest release [#4872](https://github.com/rvm/rvm/pull/4872)
 
 #### Changes
 * Installer now reports which URL(s) have failed to fetch version information and when version fetching has completely failed [\#4731](https://github.com/rvm/rvm/pull/4731)

--- a/scripts/functions/cli
+++ b/scripts/functions/cli
@@ -180,6 +180,9 @@ __rvm_cli_autoupdate_version_old()
   online_version="$( __rvm_version_remote )"
   version_release="$(\command \cat "$rvm_path/RELEASE" 2>/dev/null)"
   : version_release:"${version_release:=master}"
+  if [[ "${online_version}-next" == "${rvm_version%% *}" ]]; then # development version newer than latest release
+    return 1
+  fi
   [[ -s "$rvm_path/VERSION" && -n "${online_version:-}" ]] && __rvm_version_compare "${rvm_version%% *}" -lt "${online_version:-}" || return $?
 }
 


### PR DESCRIPTION
* Previously, using latest RVM would show:
```
Warning, new version of rvm available '1.29.9', you are using older version '1.29.9-next'.
You can disable this warning with:   echo rvm_autoupdate_flag=0 >> ~/.rvmrc
You can enable auto-update with:     echo rvm_autoupdate_flag=2 >> ~/.rvmrc
You can update manually with:        rvm get VERSION                         (e.g. 'rvm get stable')
```

Which seems clearly a bug.