### PR TITLE
Railsexpress patches for 2.5.8, 2.6.6 and 2.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@
 
 ...
 
+#### Changes
+
+* Added railsexpress patches for Ruby 2.5.8, 2.6.6 and 2.7.1 [\#4900](https://github.com/rvm/rvm/pull/4900)
+
+
 ## [1.29.10](https://github.com/rvm/rvm/releases/tag/1.29.10)
 25 March 2020 - [Full Changelog](https://github.com/rvm/rvm/compare/1.29.9...1.29.10)
 

--- a/patchsets/ruby/2.5.8/railsexpress
+++ b/patchsets/ruby/2.5.8/railsexpress
@@ -1,0 +1,3 @@
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.5.8/railsexpress/01-fix-broken-tests-caused-by-ad.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.5.8/railsexpress/02-improve-gc-stats.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.5.8/railsexpress/03-more-detailed-stacktrace.patch

--- a/patchsets/ruby/2.6.6/railsexpress
+++ b/patchsets/ruby/2.6.6/railsexpress
@@ -1,0 +1,4 @@
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.6.6/railsexpress/01-fix-broken-tests-caused-by-ad.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.6.6/railsexpress/02-improve-gc-stats.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.6.6/railsexpress/03-more-detailed-stacktrace.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.6.6/railsexpress/04-malloc-trim.patch

--- a/patchsets/ruby/2.7.1/railsexpress
+++ b/patchsets/ruby/2.7.1/railsexpress
@@ -1,0 +1,4 @@
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.7.1/railsexpress/01-fix-broken-tests-caused-by-ad.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.7.1/railsexpress/02-improve-gc-stats.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.7.1/railsexpress/03-more-detailed-stacktrace.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.7.1/railsexpress/04-malloc-trim.patch

--- a/patchsets/ruby/2.7/head/railsexpress
+++ b/patchsets/ruby/2.7/head/railsexpress
@@ -1,3 +1,4 @@
 https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.7/head/railsexpress/01-fix-broken-tests-caused-by-ad.patch
 https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.7/head/railsexpress/02-improve-gc-stats.patch
 https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.7/head/railsexpress/03-more-detailed-stacktrace.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.7/head/railsexpress/04-malloc-trim.patch


### PR DESCRIPTION
Railsexpress patches for 2.5.8, 2.6.6 and 2.7.1.

Can you please merge?