### PR TITLE
Ubuntu 18.04 binaries for 2.4.10, 2.5.8, 2.6.6 and 2.7.1 (#4904)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
   * Ruby 2.4.7, 2.5.6, 2.6.4 [\#4788](https://github.com/rvm/rvm/issues/4788)
   * Ruby 2.4.9, 2.5.7, 2.6.5 [\#4795](https://github.com/rvm/rvm/issues/4795)
   * Ruby 2.7.0 [\#4856](https://github.com/rvm/rvm/issues/4856)
+  * Ruby 2.4.10, 2.5.8, 2.6.6, 2.7.1 [\#4904](https://github.com/rvm/rvm/issues/4904)
 
 ## [1.29.9](https://github.com/rvm/rvm/releases/tag/1.29.9)
 10 July 2019 - [Full Changelog](https://github.com/rvm/rvm/compare/1.29.8...1.29.9)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@
 
 * Added railsexpress patches for Ruby 2.5.8, 2.6.6 and 2.7.1 [\#4900](https://github.com/rvm/rvm/pull/4900)
 
+#### Binaries
+
+* Ubuntu 18.04 x64 binaries
+  * Ruby 2.4.10, 2.5.8, 2.6.6, 2.7.1 [\#4904](https://github.com/rvm/rvm/issues/4904)
+
 
 ## [1.29.10](https://github.com/rvm/rvm/releases/tag/1.29.10)
 25 March 2020 - [Full Changelog](https://github.com/rvm/rvm/compare/1.29.9...1.29.10)
@@ -65,7 +70,6 @@
   * Ruby 2.4.7, 2.5.6, 2.6.4 [\#4788](https://github.com/rvm/rvm/issues/4788)
   * Ruby 2.4.9, 2.5.7, 2.6.5 [\#4795](https://github.com/rvm/rvm/issues/4795)
   * Ruby 2.7.0 [\#4856](https://github.com/rvm/rvm/issues/4856)
-  * Ruby 2.4.10, 2.5.8, 2.6.6, 2.7.1 [\#4904](https://github.com/rvm/rvm/issues/4904)
 
 ## [1.29.9](https://github.com/rvm/rvm/releases/tag/1.29.9)
 10 July 2019 - [Full Changelog](https://github.com/rvm/rvm/compare/1.29.8...1.29.9)

--- a/config/md5
+++ b/config/md5
@@ -649,6 +649,7 @@ https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.4.5.tar
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.4.6.tar.bz2=389cebcb7f816e9fcdd612e1364c6da2
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.4.7.tar.bz2=b7bfb61cc723a5051951d96bda3304b7
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.4.9.tar.bz2=a2d22f0e8c88878d48ab8ce4dd082e81
+https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.4.10.tar.bz2=c62b3457b2162e0ebc85e4b7f3941949
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.5.1.tar.bz2=70f37aa2d14341e6e9af7b8d1b9c4936
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.5.2.tar.bz2=8f56be7a98c12dda9cf920878b3c6c21
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.5.3.tar.bz2=07ebf2f5577eed6dea2ea87228d5623f
@@ -656,13 +657,16 @@ https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.5.4.tar
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.5.5.tar.bz2=bea688b485a0a904d3f737f92317a8fa
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.5.6.tar.bz2=7e8ccadf6baa8c9177bbd8dcb99bfe89
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.5.7.tar.bz2=ffd69059aa6a31b91ecee817fcfe8b68
+https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.5.8.tar.bz2=3f2b59843b96bc2e4a9bbd953c33fea4
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.6.0.tar.bz2=a602d4c9b1a51905363c5cdfffa297b7
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.6.1.tar.bz2=873616df4527b304c03a143001710ea6
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.6.2.tar.bz2=92f97f02261d800bf4e047a1ecce82b6
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.6.3.tar.bz2=37929d238ccb7955d5b5abf645eb86ab
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.6.4.tar.bz2=2fba68f2976e827df4fd8abcdc182263
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.6.5.tar.bz2=160cb36e600df0265b20401330b9b5a8
+https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.6.6.tar.bz2=ea85f316610e2fab7494aca4ed923c11
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.7.0.tar.bz2=ec1f46977ad59ab2d19b0e5b2e0a52db
+https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.7.1.tar.bz2=e4a3b51c9ebae6a59a46862c47a27b34
 ironruby-1.0.zip=7a92888837b3507355ed391dbfc0ab83
 ironruby-1.1.3.zip=4f2af6253a459cc054d6c55956e514a9
 jruby-bin-1.3.1.tar.gz=4a95db8fc93ed7219663fbede98b6117

--- a/config/remote
+++ b/config/remote
@@ -616,6 +616,7 @@ https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.4.5.tar
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.4.6.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.4.7.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.4.9.tar.bz2
+https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.4.10.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.5.1.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.5.2.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.5.3.tar.bz2
@@ -623,10 +624,13 @@ https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.5.4.tar
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.5.5.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.5.6.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.5.7.tar.bz2
+https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.5.8.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.6.0.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.6.1.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.6.2.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.6.3.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.6.4.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.6.5.tar.bz2
+https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.6.6.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.7.0.tar.bz2
+https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.7.1.tar.bz2

--- a/config/sha512
+++ b/config/sha512
@@ -644,6 +644,7 @@ https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.4.5.tar
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.4.6.tar.bz2=5f60bde5843fdc0b05bb852a2f1b30ce085dbcf7acaf105d5af951398b845c766113ff3740d44585ce3814b4953c004230eb4dc2ce8746b6236ea4b7a1d1cb10
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.4.7.tar.bz2=929a03725dba7de8d7eee3fe8987b858b9b9d6d377beee710af5c3e84b02501996444aa7b2c1db458aefc3e765da17cd17ac30fb0b4d77ab1e54239e72fa2a63
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.4.9.tar.bz2=c15a46ba1e89cc41523a21eec90d4e3af5b9739d27c2f2b51047f2c1db832e2773cbc04871a176f71e7124eb3f7b53262e40a1baab87262f8811a8d69d8e5358
+https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.4.10.tar.bz2=b83334e272e78995b699de28bff67accfc151cc7fb193d5c5746fcf06087643564b3a0b538cb64f50706642a620dba2cc54191357321852db42cc8c5648270df
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.5.1.tar.bz2=31e9f176ba61480b33b7761d2a19119a200ad61c8f85145f736eb196de50babaf278d023b274274c6a31f2173c5d022bb93e0f8d46a88223659d8ebcf6f5e278
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.5.2.tar.bz2=75d25fa6dc81ce8a62d02adc2e163e7c222c5946116c4880cec19460e2309457ee1a11a8eac94243ee8437514bfbba9ebee939218b6ccc7e5c1f15b673d432e7
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.5.3.tar.bz2=84c93c85aa3733f2ac82e695c19e714ad4afd096edd6abda8a4915311d1f604453fc3fdc290c6ae1f9055d305ef400f8f8f152c5e15eb230baf7cfd5e192b7fb
@@ -651,13 +652,16 @@ https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.5.4.tar
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.5.5.tar.bz2=f55d2ff7f2eae4d30fbc14226c928d1caff21db1f2cd559d3caeb0c07a7a3f034fa369d95f783e6f38cecb493d99aa1928def9d8574698e3edea3d33515749f4
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.5.6.tar.bz2=06b12b2a1e85248311cf55620499806078b3b67110fb45dad9cb11cbaf1e230ce8a0da23c7de0a5abfccdeada8eb799f038b1a09980ee9572ec415e24fcf8c76
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.5.7.tar.bz2=49128b7845954f1f04502a484f17d5c0c6ecf8990047f5a383b2752ea9e09839e5994b210c2f60307d44ffa8b440472116fa1231ea899caf639e1b8a72f7f97c
+https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.5.8.tar.bz2=24290aab4e0d48719659f8c1153d2b08020f17ae845e9ac6d6b6d3203e4a5b19061e907a214e8d4390277584ff4b46dd4a0113c6b201fa37e8a95c42fab5aea5
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.6.0.tar.bz2=1be48c38da41f462c23d516f465ed34e2fe90c6fd53ee06f1efc9107077d9937413bee589d5d3384aee5c09da7087fa84864a50089bd1cf3c385ba3399e9b0a2
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.6.1.tar.bz2=b7e1204e0e501312828ca0e30b77434b2d8d94581627196f0195ba93fb10a11046d44942393bd8a261585c564bc721313152a9087aa56b57b433ed14cc7922be
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.6.2.tar.bz2=e91a187a9e726ed26ddfaf09cc49473c8379545e2265934fcd1a1fa78ba99f9a119fe2c3c8247eab583389c3af7ec40a0e71da19f6ecc17ffc086759cebaaa15
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.6.3.tar.bz2=77d9be5bbcd115131ec7c842a4449729d1515bf2106a6a235472dc96b58a56873c2d0fe6a3b824dd15ad00194b30e72a75813d8b4e10ee11cc793973130e2401
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.6.4.tar.bz2=a2e5409a1a88557bef747ca9b1ea65ac90e430500a8f9370023b4314cb5d1e0679a1b03761980ab2e933ac3521188e2151e521408e33cb4dde5f0bf802d81a41
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.6.5.tar.bz2=ed6288a4d81a740d722b43925db8f22f794cc704bf834a1f9c844e2072baceb8938547abb8f4fb1a50f92c34a8616904fc2679a44bf4adec4e78ce00e8456b45
+https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.6.6.tar.bz2=08cda5ff00b9297b46d1fb620301066b21240951924337b8b87d27526e55024e61121e51d9b35feea2ac5eed4027658b39ff487195140e7abe9158181c3349af
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.7.0.tar.bz2=cada908be34428bc2f302bad6ebd778a2c7a8e979476e00e45c9444b65d7f48f397b838549d56ceb91f0e5593ffd663e9facc4ea5f5c6a4aecda85a5a1136496
+https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.7.1.tar.bz2=06cb5f2f0c0941802119dbdf34995446d6d69ee59eed9a5e9d7f9e7f0e14de440a9e77eee330357fa305e81ee39a6868651c740ebc91bb9a2085a74b33685f4c
 jruby-bin-1.7.0.tar.gz=1e466a3f8d52b553c9def09827fda4b8433576b0262c40ee505602754521a00defd821d5ead5052be52baf281c6cb080fd03a8b15c628a0ee67b4e417633e5e2
 jruby-bin-1.7.1.tar.gz=ef28381ca30664cf450f9d3df9927530db771d30e86ebcf535af38e1a7e26724ae2bcfe8487cd2eb349bf609a733a25528aae14beab4d13d298b5604ac7353cc
 jruby-bin-1.7.2.tar.gz=8155c81eea6743951db7383bd9f6b1750614927c9c0b25a6574f6d64898bb3ada2f626c6e0df6c5486561a03cc7d472fc12fe804ce66a3972d2fe02e3f407100


### PR DESCRIPTION
Fixes #4904. Binaries already uploaded.

Changes proposed in this pull request:
* Ubuntu 18.04 x64 binaries for  2.4.10, 2.5.8, 2.6.6 and 2.7.1

