### PR TITLE
Use libssl-1.0 to install Ruby 1.8 on Debian 9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 #### Bug fixes
 
-...
+* Use libssl-1.0 to install Ruby 1.8 on Debian 9 [\#4920](https://github.com/rvm/rvm/pull/4920)
 
 #### Changes
 

--- a/scripts/functions/requirements/debian
+++ b/scripts/functions/requirements/debian
@@ -96,7 +96,7 @@ requirements_debian_define_libssl()
   # starting from Debian 9 (Stretch)
 
   case "$1" in
-    (ruby-2.3*|ruby-2.2*|ruby-2.1*|ruby-2.0*|ruby-1.9*)
+    (ruby-2.3*|ruby-2.2*|ruby-2.1*|ruby-2.0*|ruby-1.9*|ruby-1.8*)
       if
         __rvm_version_compare ${_system_version} -ge 9
       then


### PR DESCRIPTION


Changes proposed in this pull request:
* Use an old version 1.8* in Debian 9 using lib SSL 1.0
