### PR TITLE
Add few built-in command aliases to improve consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 * Added railsexpress patches for Ruby 2.5.8, 2.6.6 and 2.7.1 [\#4900](https://github.com/rvm/rvm/pull/4900)
 * Add ruby-3 to the list of available binary builds [\#4984](https://github.com/rvm/rvm/pull/4984)
 * Recognize `3*` as CRuby version number [\#4987](https://github.com/rvm/rvm/pull/4987)
+* Alias `rvm gemset remove` as `rvm gemset delete`
+* Alias `rvm gemset move` as `rvm gemset rename` 
+* Alias `rvm delete` as `rvm remove`
 
 #### Bug fixes
 

--- a/help/gemset.md
+++ b/help/gemset.md
@@ -6,7 +6,7 @@ Usage:
 
 Actions:
 
-    copy, create, delete, dir, empty, export, gemdir, globalcache, import, install, list, list_all, name, pristine, rename, unpack, update, use
+    copy, create, delete (alias: remove), dir, empty, export, gemdir, globalcache, import, install, list, list_all, name, pristine, rename (alias: move), unpack, update, use
 
 Description:
 

--- a/help/index.txt
+++ b/help/index.txt
@@ -8,7 +8,7 @@ Usage:
     rvm list known          # list available interpreters
     rvm install <version>   # install ruby interpreter
     rvm use <version>       # switch to specified ruby interpreter
-    rvm remove <version>    # remove ruby interpreter
+    rvm remove <version>    # remove ruby interpreter (alias: delete)
     rvm get <version>       # upgrade rvm: stable, master
 
 Available commands:
@@ -25,7 +25,7 @@ Available commands:
       patchset                # tools related to managing ruby patchsets
       pkg                     # install a dependency package
       reinstall               # reinstall ruby and run gem pristine on all gems
-      remove                  # remove ruby and downloaded sources
+      remove                  # remove ruby and downloaded sources (alias: delete)
       requirements            # installs dependencies for building ruby
       uninstall               # uninstall ruby, keeping it's sources
       upgrade                 # upgrade to another ruby version, migrating gems

--- a/man/man1/rvm.1
+++ b/man/man1/rvm.1
@@ -242,6 +242,11 @@ Uninstall one or many ruby versions, leaves their sources\&.
 Uninstall one or many ruby versions and remove their sources\&.
 .RE
 .PP
+\fBdelete\fR
+.RS 4
+Same as remove\&.
+.RE
+.PP
 \fBwrapper\fR
 .RS 4
 Generates a set of wrapper executables for a given ruby with the specified ruby and gemset combination\&. Used under the hood for passenger support and the like\&.

--- a/scripts/cli
+++ b/scripts/cli
@@ -139,8 +139,8 @@ __rvm_parse_args()
               (help)
                 true
                 ;;
-              (use|delete)
-                [[ "delete" != "$next_token" ]] || rvm_delete_flag=1
+              (use|delete|remove)
+                [[ "delete" != "$next_token" ]] || [[ "remove" != "$next_token" ]] || rvm_delete_flag=1
                 [[ "use"    != "$next_token" ]] || rvm_action+="_$next_token"
 
                 case "$rvm_gemset_name" in
@@ -206,7 +206,7 @@ __rvm_parse_args()
           gem|rake|ruby)
             [[ "$rvm_token" == "ruby" ]] &&
             case $rvm_action in
-              install|reinstall|use|remove)
+              install|reinstall|use|delete|remove)
                 rvm_ruby_string=ruby
                 rvm_ruby_strings=ruby
                 continue
@@ -242,7 +242,7 @@ __rvm_parse_args()
             done
             ;;
 
-          rm|remove)
+          rm|remove|delete)
             rvm_action="remove"
             rvm_remove_flag=1
             ;;
@@ -991,7 +991,7 @@ rvm()
           fi
           unset gem_prefix
         elif
-          [[ "${rvm_ruby_args[*]}" == rename* ]]
+          [[ "${rvm_ruby_args[*]}" == rename* ]] || [[ "${rvm_ruby_args[*]}" == move* ]]
         then
           \typeset _command _from _to
           read _command _from _to <<<"${rvm_ruby_args[*]}"
@@ -1013,7 +1013,7 @@ rvm()
       __rvm_do
       ;;
 
-    remove)
+    delete|remove)
       export rvm_path
       if [[ -n "${rvm_ruby_strings}" ]]
       then __rvm_run_wrapper manage "$rvm_action" "${rvm_ruby_strings//*-- }"

--- a/scripts/extras/completion.bash
+++ b/scripts/extras/completion.bash
@@ -124,7 +124,7 @@ _rvm_use ()
 _rvm_gemset ()
 {
   \typeset subcommand subcommands
-  subcommands="import export create copy rename empty delete name dir list list_all gemdir install pristine clear use update unpack globalcache"
+  subcommands="import export create copy rename move empty delete remove name dir list list_all gemdir install pristine clear use update unpack globalcache"
   subcommand="$(__rvm_subcommand "$subcommands")"
 
   if [[ -z "$subcommand" ]]; then

--- a/scripts/functions/manage/base
+++ b/scripts/functions/manage/base
@@ -97,7 +97,7 @@ __rvm_manage_rubies()
     # explicit all && not install
     if
       (( ${rvm_force_flag:-0} == 0 )) &&
-      [[ "$action" == "reinstall" || "$action" == "remove" || "$action" == "uninstall" ]]
+      [[ "$action" == "reinstall" || "$action" == "delete" || "$action" == "remove" || "$action" == "uninstall" ]]
     then
       __rvm_ask_for "Are you SURE you wish to '$action' all rubies?" yes || return $?
     fi

--- a/scripts/gemsets
+++ b/scripts/gemsets
@@ -247,6 +247,11 @@ gemset_delete()
     gemset_delete_task "$rvm_gemset_name" "$ruby_at_gemset" "$gemdir"
 }
 
+gemset_remove()
+{
+  gemset_delete $1
+}
+
 gemset_empty()
 {
   \typeset gemdir entry
@@ -398,6 +403,11 @@ gemset_rename()
     rvm_error "Gems directory does not exist for $source_path ($source_path)"
     return 1
   fi
+}
+
+gemset_move()
+{
+  gemset_rename $1 $2
 }
 
 gemset_unpack()
@@ -593,7 +603,7 @@ rvm_sticky_flag=1
 
 gemset_actions_with_gem=(
   gemdir gempath gemhome home path version export dump import
-  load pristine copy install initial prune rename update unpack
+  load pristine copy install initial prune rename move update unpack
 )
 if
   [[ " ${gemset_actions_with_gem[*]} " == *" $action "* ]] &&
@@ -656,7 +666,7 @@ case "$action" in
     rvm_gemset_name="${rvm_gemset_name:-${rvm_expected_gemset_name:-}}"
     gemset_$action "$@"
     ;;
-  copy|delete|dir|globalcache|list_all|list_strings|pristine|prune|rename|update|unpack|reset_env)
+  copy|delete|dir|globalcache|list_all|list_strings|move|pristine|prune|rename|remove|update|unpack|reset_env)
     gemset_$action "$@"
     ;;
   name|string)


### PR DESCRIPTION
Changes proposed in this pull request:
* Alias `rvm gemset remove` as `rvm gemset delete`
* Alias `rvm gemset move` as `rvm gemset rename`
* Alias `rvm delete` as `rvm remove`
