### PR TITLE
Recognize `3*` as CRuby version number

### DIFF
--- a/scripts/functions/selector_parse
+++ b/scripts/functions/selector_parse
@@ -235,8 +235,8 @@ __rvm_ruby_string_parse_()
     [[ -z "${rvm_ruby_interpreter}" && -n "${rvm_ruby_version}" ]]
   then
     case "${rvm_ruby_version}" in
-      (1.[5-7]*|9*) rvm_ruby_interpreter=jruby ;;
-      (1.[8-9]*|2*) rvm_ruby_interpreter=ruby  ;;
+      (1.[5-7]*|9*)    rvm_ruby_interpreter=jruby ;;
+      (1.[8-9]*|2*|3*) rvm_ruby_interpreter=ruby  ;;
     esac
     if [[ -n "${rvm_ruby_interpreter}" ]]
     then rvm_ruby_string="${rvm_ruby_interpreter}-${rvm_ruby_string}"


### PR DESCRIPTION
Changes proposed in this pull request:
* Recognize glob `3*` as a valid version string for CRuby, allowing:

      rvm use 3.0.0-preview1 --binary --fuzzy --install


## Current Behavior

```sh-session
$ rvm use 3.0.0-preview1 --binary --fuzzy --install
Unknown ruby interpreter version (do not know how to handle): 3.0.0-preview1.
```

## Behavior with this PR

```sh-session
$ rvm use 3.0.0-preview1 --binary --fuzzy --install
Required ruby-3.0.0-preview1 is not installed - installing.
Searching for binary rubies, this might take some time.
Found remote file https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/16.04/x86_64/ruby-3.0.0-preview1.tar.bz2
Checking requirements for ubuntu.
Requirements installation successful.
ruby-3.0.0-preview1 - #configure
ruby-3.0.0-preview1 - #download
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 21.4M  100 21.4M    0     0  14.3M      0  0:00:01  0:00:01 --:--:-- 14.4M
No checksum for downloaded archive, recording checksum in user configuration.
ruby-3.0.0-preview1 - #validate archive
ruby-3.0.0-preview1 - #extract
ruby-3.0.0-preview1 - #validate binary
ruby-3.0.0-preview1 - #setup
ruby-3.0.0-preview1 - #gemset created /home/travis/.rvm/gems/ruby-3.0.0-preview1@global
ruby-3.0.0-preview1 - #importing gemset /home/travis/.rvm/gemsets/global.gems..................................
ruby-3.0.0-preview1 - #generating global wrappers........
Error running 'run_gem_wrappers regenerate',
please read /home/travis/.rvm/log/1601410482_ruby-3.0.0-preview1/gemset.wrappers.global.log
Error loading RubyGems plugin "/home/travis/.rvm/rubies/ruby-3.0.0-preview1/lib/ruby/gems/3.0.0/plugins/executable-hooks_plugin.rb": cannot load such file -- /usr/local/rvm/rubies/ruby-3.0.0-preview1/lib/ruby/gems/3.0.0/gems/executable-hooks-1.6.0/lib/rubygems_plugin.rb (LoadError)
Error loading RubyGems plugin "/home/travis/.rvm/rubies/ruby-3.0.0-preview1/lib/ruby/gems/3.0.0/plugins/gem-wrappers_plugin.rb": cannot load such file -- /usr/local/rvm/rubies/ruby-3.0.0-preview1/lib/ruby/gems/3.0.0/gems/gem-wrappers-1.4.0/lib/rubygems_plugin.rb (LoadError)
ruby-3.0.0-preview1 - #uninstalling gem rubygems-bundler-1.4.5.
ruby-3.0.0-preview1 - #gemset created /home/travis/.rvm/gems/ruby-3.0.0-preview1
ruby-3.0.0-preview1 - #importing gemset /home/travis/.rvm/gemsets/default.gems..............
ruby-3.0.0-preview1 - #generating default wrappers........
Error running 'run_gem_wrappers regenerate',
please read /home/travis/.rvm/log/1601410483_ruby-3.0.0-preview1/gemset.wrappers.default.log
Using /home/travis/.rvm/gems/ruby-3.0.0-preview1
```

(You can _probably_ ignore the default wrapper generation error.)
Make sure that your pull request includes entry in the [CHANGELOG](CHANGELOG.md).