### PR TITLE
Added ruby 2.7.2 x64 binaries for linux systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,52 +28,66 @@
     * Ruby 2.4.10, 2.5.8, 2.6.6, 2.7.1 [\#4921](https://github.com/rvm/rvm/issues/4921)
     * Ruby 2.1.0-2.1.10, 2.2.0-2.2.10, 2.3.0-2.3.8, 2.4.0-2.4.9, 2.5.0-2.5.8, 2.6.0-2.6.5, 2.7.0 [\#4921](https://github.com/rvm/rvm/issues/4921)
     * Ruby 3.0.0-preview1 [\#4985](https://github.com/rvm/rvm/pull/4985)
+    * Ruby 2.7.2 [\#4989](https://github.com/rvm/rvm/pull/4989)
   * Ubuntu 19.04 x64 binaries
     * Ruby 2.4.0-2.4.10, 2.5.0-2.5.8, 2.6.0-2.6.6, 2.7.0, 2.7.1 [\#4935](https://github.com/rvm/rvm/issues/4935)
     * Ruby 3.0.0-preview1 [\#4985](https://github.com/rvm/rvm/pull/4985)
+    * Ruby 2.7.2 [\#4989](https://github.com/rvm/rvm/pull/4989)
   * Ubuntu 18.04 x64 binaries
     * Ruby 2.4.10, 2.5.8, 2.6.6, 2.7.1 [\#4904](https://github.com/rvm/rvm/issues/4904)
     * Ruby 2.4.8 [\#4916](https://github.com/rvm/rvm/issues/4916)
     * Ruby 2.1.0-2.1.10, 2.2.0-2.2.9, 2.3.0-2.3.6, 2.4.0-2.4.3 [\#4916](https://github.com/rvm/rvm/issues/4916)
     * Ruby 2.5.0 [\#4931](https://github.com/rvm/rvm/issues/4931)
     * Ruby 3.0.0-preview1 [\#4985](https://github.com/rvm/rvm/pull/4985)
+    * Ruby 2.7.2 [\#4989](https://github.com/rvm/rvm/pull/4989)
   * Ubuntu 16.04 x64 binaries
     * Ruby 2.1.0-2.1.4, 2.1.6-2.1.8, 2.1.10, 2.2.0-2.2.4, 2.3.8, 2.4.5-2.4.10, 2.5.2-2.5.8, 2.6.0-2.6.6, 2.7.0-2.7.1 [\#4932](https://github.com/rvm/rvm/issues/4932)
     * Ruby 3.0.0-preview1 [\#4985](https://github.com/rvm/rvm/pull/4985)
+    * Ruby 2.7.2 [\#4989](https://github.com/rvm/rvm/pull/4989)
   * Ubuntu 14.04 x64 binaries
     * Ruby 2.1.0-2.1.1, 2.1.4, 2.1.6-2.1.10, 2.2.2-2.2.10, 2.3.0-2.3.8, 2.4.0-2.4.10, 2.5.0-2.5.8, 2.6.0-2.6.6, 2.7.0-2.7.1 [\#4933](https://github.com/rvm/rvm/issues/4933)
     * Ruby 3.0.0-preview1 [\#4985](https://github.com/rvm/rvm/pull/4985)
+    * Ruby 2.7.2 [\#4989](https://github.com/rvm/rvm/pull/4989)
   * Ubuntu 12.04 x64 binaries
     * Ruby 2.4.0-2.4.10, 2.5.0-2.5.8, 2.6.0-2.6.6, 2.7.0, 2.7.1 [\#4935](https://github.com/rvm/rvm/issues/4935)
 * Debian
   * Debian 10 x64 binaries
     * Ruby 2.4.0-2.4.10, 2.5.0-2.5.8, 2.6.0-2.6.6, 2.7.0, 2.7.1 [\#4935](https://github.com/rvm/rvm/issues/4935)
     * Ruby 3.0.0-preview1 [\#4985](https://github.com/rvm/rvm/pull/4985)
+    * Ruby 2.7.2 [\#4989](https://github.com/rvm/rvm/pull/4989)
   * Debian 9 x64 binaries
     * Ruby 2.4.0-2.4.10, 2.5.0-2.5.8, 2.6.0-2.6.6, 2.7.0, 2.7.1 [\#4935](https://github.com/rvm/rvm/issues/4935)
     * Ruby 3.0.0-preview1 [\#4985](https://github.com/rvm/rvm/pull/4985)
+    * Ruby 2.7.2 [\#4989](https://github.com/rvm/rvm/pull/4989)
   * Debian 8 x64 binaries
     * Ruby 2.4.0-2.4.10, 2.5.0-2.5.8, 2.6.0-2.6.6, 2.7.0, 2.7.1 [\#4935](https://github.com/rvm/rvm/issues/4935)
     * Ruby 3.0.0-preview1 [\#4985](https://github.com/rvm/rvm/pull/4985)
+    * Ruby 2.7.2 [\#4989](https://github.com/rvm/rvm/pull/4989)
 * CentOS
   * CentOS 6 x64 binaries
     * Ruby 2.4.0-2.4.10, 2.5.0-2.5.8, 2.6.0-2.6.6, 2.7.0, 2.7.1 [\#4935](https://github.com/rvm/rvm/issues/4935)
+    * Ruby 2.7.2 [\#4989](https://github.com/rvm/rvm/pull/4989)
   * CentOS 7 x64 binaries
     * Ruby 2.4.0-2.4.10, 2.5.0-2.5.8, 2.6.0-2.6.6, 2.7.0, 2.7.1 [\#4935](https://github.com/rvm/rvm/issues/4935)
     * Ruby 3.0.0-preview1 [\#4985](https://github.com/rvm/rvm/pull/4985)
+    * Ruby 2.7.2 [\#4989](https://github.com/rvm/rvm/pull/4989)
   * CentOS 8 x64 binaries
     * Ruby 2.4.0-2.4.10, 2.5.0-2.5.8, 2.6.0-2.6.6, 2.7.0, 2.7.1 [\#4936](https://github.com/rvm/rvm/issues/4936)
     * Ruby 3.0.0-preview1 [\#4985](https://github.com/rvm/rvm/pull/4985)
+    * Ruby 2.7.2 [\#4989](https://github.com/rvm/rvm/pull/4989)
 * Amazon Linux
   * Amazon Linux 2018.03 x64 binaries
     * Ruby 2.4.0-2.4.10, 2.5.0-2.5.8, 2.6.0-2.6.6, 2.7.0, 2.7.1 [\#4935](https://github.com/rvm/rvm/issues/4935)
     * Ruby 3.0.0-preview1 [\#4985](https://github.com/rvm/rvm/pull/4985)
+    * Ruby 2.7.2 [\#4989](https://github.com/rvm/rvm/pull/4989)
   * Amazon Linux 2 x64 binaries
     * Ruby 2.4.0-2.4.10, 2.5.0-2.5.8, 2.6.0-2.6.6, 2.7.0, 2.7.1 [\#4935](https://github.com/rvm/rvm/issues/4935)
     * Ruby 3.0.0-preview1 [\#4985](https://github.com/rvm/rvm/pull/4985)
+    * Ruby 2.7.2 [\#4989](https://github.com/rvm/rvm/pull/4989)
 * Oracle Linux 7 x64 binaries
   * Ruby 2.4.0-2.4.10, 2.5.0-2.5.8, 2.6.0-2.6.6, 2.7.0, 2.7.1 [\#4935](https://github.com/rvm/rvm/issues/4935)
   * Ruby 3.0.0-preview1 [\#4985](https://github.com/rvm/rvm/pull/4985)
+  * Ruby 2.7.2 [\#4989](https://github.com/rvm/rvm/pull/4989)
 
 ## [1.29.10](https://github.com/rvm/rvm/releases/tag/1.29.10)
 25 March 2020 - [Full Changelog](https://github.com/rvm/rvm/compare/1.29.9...1.29.10)

--- a/config/md5
+++ b/config/md5
@@ -1,3 +1,4 @@
+https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/20.04/x86_64/ruby-2.7.2.tar.bz2=cb9796eaedbae6afa86330c268aba062
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/20.04/x86_64/ruby-3.0.0-preview1.tar.bz2=f7d1bca0326323071f0abfc9bdd8d544
 apache-maven-3.5.0-bin.tar.gz=35c39251d2af99b6624d40d801f6ff02
 curl-7_19_7.tar.gz=ecb2e37e45c9933e2a963cabe03670ab
@@ -61,6 +62,7 @@ https://rvm_io.global.ssl.fastly.net/binaries/amazon/2/x86_64/ruby-2.6.5.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/amazon/2/x86_64/ruby-2.6.6.tar.bz2=cfedd64441560cccf85a09eaa2d9b959
 https://rvm_io.global.ssl.fastly.net/binaries/amazon/2/x86_64/ruby-2.7.0.tar.bz2=d3c56ac789644b86c90f6a05391a53d6
 https://rvm_io.global.ssl.fastly.net/binaries/amazon/2/x86_64/ruby-2.7.1.tar.bz2=1801df87bbf59615878c7462ff8b1bed
+https://rvm_io.global.ssl.fastly.net/binaries/amazon/2/x86_64/ruby-2.7.2.tar.bz2=0db424c01ac7b124c5f50aac4b1fb0a1
 https://rvm_io.global.ssl.fastly.net/binaries/amazon/2/x86_64/ruby-3.0.0-preview1.tar.bz2=8f1f825a5c1f05100f054d2bc60ac5bf
 https://rvm_io.global.ssl.fastly.net/binaries/amazon/2013.03/x86_64/ruby-1.9.3-p448.tar.bz2=fa4a24991caa2a8e0ee1c221d4430345
 https://rvm_io.global.ssl.fastly.net/binaries/amazon/2013.03/x86_64/ruby-2.0.0-p247.tar.bz2=bb907c7719fb96aae77b8f540a64c1b9
@@ -93,6 +95,7 @@ https://rvm_io.global.ssl.fastly.net/binaries/amazon/2018.03/x86_64/ruby-2.6.5.t
 https://rvm_io.global.ssl.fastly.net/binaries/amazon/2018.03/x86_64/ruby-2.6.6.tar.bz2=d0ed8d03f5b1f651b6bfd3cebe26c912
 https://rvm_io.global.ssl.fastly.net/binaries/amazon/2018.03/x86_64/ruby-2.7.0.tar.bz2=c388a64e20b73ef05866a2b66ceeaf78
 https://rvm_io.global.ssl.fastly.net/binaries/amazon/2018.03/x86_64/ruby-2.7.1.tar.bz2=80c8b14ea582515ea4b1e518040ecc94
+https://rvm_io.global.ssl.fastly.net/binaries/amazon/2018.03/x86_64/ruby-2.7.2.tar.bz2=d1c7e0cae96cb5857f90cf2b6dec78b6
 https://rvm_io.global.ssl.fastly.net/binaries/amazon/2018.03/x86_64/ruby-3.0.0-preview1.tar.bz2=d2218ea099475456c12252f4f9cabd2b
 https://rvm_io.global.ssl.fastly.net/binaries/arch/libc-2.15/x86_64/ruby-1.9.3-p194.tar.bz2=384ea18aef77b95e49df6f3944fc3e11
 https://rvm_io.global.ssl.fastly.net/binaries/arch/libc-2.15/x86_64/ruby-1.9.3-p286.tar.bz2=e7ee7c1a6dc913f6e7fad3ba03e459da
@@ -179,6 +182,7 @@ https://rvm_io.global.ssl.fastly.net/binaries/centos/6/x86_64/ruby-2.6.5.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/centos/6/x86_64/ruby-2.6.6.tar.bz2=df3a62cc09b9be8410cabcf24a34e71b
 https://rvm_io.global.ssl.fastly.net/binaries/centos/6/x86_64/ruby-2.7.0.tar.bz2=57652298608551ab9ee5b6dcb46ca65a
 https://rvm_io.global.ssl.fastly.net/binaries/centos/6/x86_64/ruby-2.7.1.tar.bz2=06beae98d67b20202351ac02324ca6d9
+https://rvm_io.global.ssl.fastly.net/binaries/centos/6/x86_64/ruby-2.7.2.tar.bz2=813896b63509355f3691827276f16822
 https://rvm_io.global.ssl.fastly.net/binaries/centos/7/x86_64/ruby-2.4.0.tar.bz2=d0758dfc415f00ed9d03f8c0a3a8f034
 https://rvm_io.global.ssl.fastly.net/binaries/centos/7/x86_64/ruby-2.4.1.tar.bz2=2314a6ef42ddbed234e754d456479b90
 https://rvm_io.global.ssl.fastly.net/binaries/centos/7/x86_64/ruby-2.4.2.tar.bz2=fe832d44821625255603b3a1feb9d217
@@ -208,6 +212,7 @@ https://rvm_io.global.ssl.fastly.net/binaries/centos/7/x86_64/ruby-2.6.5.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/centos/7/x86_64/ruby-2.6.6.tar.bz2=f2066744834ea77335bf52ffdcbb7174
 https://rvm_io.global.ssl.fastly.net/binaries/centos/7/x86_64/ruby-2.7.0.tar.bz2=ab0ac481cc438e4bc3dd127baadb90fc
 https://rvm_io.global.ssl.fastly.net/binaries/centos/7/x86_64/ruby-2.7.1.tar.bz2=af38afb8573af59144ca70df2a3bf0b2
+https://rvm_io.global.ssl.fastly.net/binaries/centos/7/x86_64/ruby-2.7.2.tar.bz2=e57be086b20e8246fed27b5efe1d9304
 https://rvm_io.global.ssl.fastly.net/binaries/centos/7/x86_64/ruby-3.0.0-preview1.tar.bz2=b0546d3b6c222f6c97545e079c9234e4
 https://rvm_io.global.ssl.fastly.net/binaries/centos/8/x86_64/ruby-2.4.0.tar.bz2=9633d1229122c7f484f73033f6223f75
 https://rvm_io.global.ssl.fastly.net/binaries/centos/8/x86_64/ruby-2.4.1.tar.bz2=2daa47a66fe068be061274fbea0d135d
@@ -238,6 +243,7 @@ https://rvm_io.global.ssl.fastly.net/binaries/centos/8/x86_64/ruby-2.6.5.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/centos/8/x86_64/ruby-2.6.6.tar.bz2=2ee192cf53e1e5f5d5d011d89db7a511
 https://rvm_io.global.ssl.fastly.net/binaries/centos/8/x86_64/ruby-2.7.0.tar.bz2=a046e64db4f7a60898e22f1694c36362
 https://rvm_io.global.ssl.fastly.net/binaries/centos/8/x86_64/ruby-2.7.1.tar.bz2=302691bc2e32ce8f24f2c0dfc48509cd
+https://rvm_io.global.ssl.fastly.net/binaries/centos/8/x86_64/ruby-2.7.2.tar.bz2=b0d287890b00a85c4d66180ed097598e
 https://rvm_io.global.ssl.fastly.net/binaries/centos/8/x86_64/ruby-3.0.0-preview1.tar.bz2=93134fce505ca84212eb768120a48e63
 https://rvm_io.global.ssl.fastly.net/binaries/debian/6/i386/ruby-1.9.3-p429.tar.bz2=048c2ab350edf5e10de5b889a4e2928a
 https://rvm_io.global.ssl.fastly.net/binaries/debian/6/i386/ruby-1.9.3-p448.tar.bz2=aeba37b8f72df75352f0aeda32e0be73
@@ -350,6 +356,7 @@ https://rvm_io.global.ssl.fastly.net/binaries/debian/8/x86_64/ruby-2.6.5.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/debian/8/x86_64/ruby-2.6.6.tar.bz2=dd62bafdf288fc117bba81bea236b6de
 https://rvm_io.global.ssl.fastly.net/binaries/debian/8/x86_64/ruby-2.7.0.tar.bz2=5882ff4755ad757bcec35aa45ad4ec2b
 https://rvm_io.global.ssl.fastly.net/binaries/debian/8/x86_64/ruby-2.7.1.tar.bz2=239f45c247285e3d86ead9e9a06cea4a
+https://rvm_io.global.ssl.fastly.net/binaries/debian/8/x86_64/ruby-2.7.2.tar.bz2=fc657e12d17981119f9a949fb7bd0429
 https://rvm_io.global.ssl.fastly.net/binaries/debian/8/x86_64/ruby-3.0.0-preview1.tar.bz2=3f576f1bb3a7c5a817937b57fc2225c5
 https://rvm_io.global.ssl.fastly.net/binaries/debian/9/x86_64/ruby-2.4.0.tar.bz2=fa6614d9e1da65fe019ad5f30a2750e5
 https://rvm_io.global.ssl.fastly.net/binaries/debian/9/x86_64/ruby-2.4.1.tar.bz2=45f0cc2188dc73a547702eb2caeec1b4
@@ -380,6 +387,7 @@ https://rvm_io.global.ssl.fastly.net/binaries/debian/9/x86_64/ruby-2.6.5.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/debian/9/x86_64/ruby-2.6.6.tar.bz2=49a475e58b67ee419965c3fc7ae6e5d0
 https://rvm_io.global.ssl.fastly.net/binaries/debian/9/x86_64/ruby-2.7.0.tar.bz2=f4e179729f25b4da8301080ec2d63209
 https://rvm_io.global.ssl.fastly.net/binaries/debian/9/x86_64/ruby-2.7.1.tar.bz2=01e093c928caca77b85cedff64af1d2e
+https://rvm_io.global.ssl.fastly.net/binaries/debian/9/x86_64/ruby-2.7.2.tar.bz2=a3f9c556acf9ce24b9c228eaf0ce1a5b
 https://rvm_io.global.ssl.fastly.net/binaries/debian/9/x86_64/ruby-3.0.0-preview1.tar.bz2=8bedca44418065773deb8711b563cebe
 https://rvm_io.global.ssl.fastly.net/binaries/debian/10/x86_64/ruby-2.4.0.tar.bz2=e311fd7d62b273b17e467c24afd46656
 https://rvm_io.global.ssl.fastly.net/binaries/debian/10/x86_64/ruby-2.4.1.tar.bz2=4521f00ffdba4e33972ff591e853b79f
@@ -410,6 +418,7 @@ https://rvm_io.global.ssl.fastly.net/binaries/debian/10/x86_64/ruby-2.6.5.tar.bz
 https://rvm_io.global.ssl.fastly.net/binaries/debian/10/x86_64/ruby-2.6.6.tar.bz2=49709ad68580a768a6df34e06f009005
 https://rvm_io.global.ssl.fastly.net/binaries/debian/10/x86_64/ruby-2.7.0.tar.bz2=6633798a074e9926bdcccc36cdd4c792
 https://rvm_io.global.ssl.fastly.net/binaries/debian/10/x86_64/ruby-2.7.1.tar.bz2=5d41b77af4c99af1acd188942ff05153
+https://rvm_io.global.ssl.fastly.net/binaries/debian/10/x86_64/ruby-2.7.2.tar.bz2=627fcabc6fdadb4619d52fd250d94474
 https://rvm_io.global.ssl.fastly.net/binaries/debian/10/x86_64/ruby-3.0.0-preview1.tar.bz2=c4336ba12aa3863f760e419863026b37
 https://rvm_io.global.ssl.fastly.net/binaries/fedora/17/x86_64/ruby-1.9.3-p429.tar.bz2=e8b54fd757dfd0ff485113be66b2088d
 https://rvm_io.global.ssl.fastly.net/binaries/fedora/17/x86_64/ruby-1.9.3-p448.tar.bz2=32deef7f911a26115175cd8f82ed8f4e
@@ -586,6 +595,7 @@ https://rvm_io.global.ssl.fastly.net/binaries/oracle/7/x86_64/ruby-2.6.5.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/oracle/7/x86_64/ruby-2.6.6.tar.bz2=cc67163e8b3fd4b37665e345ee26106d
 https://rvm_io.global.ssl.fastly.net/binaries/oracle/7/x86_64/ruby-2.7.0.tar.bz2=fbe7994459d18e6852a1e5af46b1cd31
 https://rvm_io.global.ssl.fastly.net/binaries/oracle/7/x86_64/ruby-2.7.1.tar.bz2=387c28826a4be5d8b60e856971ffdf75
+https://rvm_io.global.ssl.fastly.net/binaries/oracle/7/x86_64/ruby-2.7.2.tar.bz2=b5c970be1e67ed72b4476cb3fd34346f
 https://rvm_io.global.ssl.fastly.net/binaries/oracle/7/x86_64/ruby-3.0.0-preview1.tar.bz2=9eb48cd2e2092bf01cb0e35663473a22
 https://rvm_io.global.ssl.fastly.net/binaries/osx/10.10/x86_64/ruby-2.0.0-p451.tar.bz2=72740441714ea5732c219efe3a4a17a0
 https://rvm_io.global.ssl.fastly.net/binaries/osx/10.10/x86_64/ruby-2.0.0-p481.tar.bz2=4f5ab89e550cbd446c4457b5ba7c17d0
@@ -931,6 +941,7 @@ https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/14.04/x86_64/ruby-2.6.5.tar
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/14.04/x86_64/ruby-2.6.6.tar.bz2=93efb782a5126fd9f9b3cdf408203c69
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/14.04/x86_64/ruby-2.7.0.tar.bz2=bfd780adf595bae1b62a3d1bb4509673
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/14.04/x86_64/ruby-2.7.1.tar.bz2=2aca144193ecdad128c588bb3ec50ca2
+https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/14.04/x86_64/ruby-2.7.2.tar.bz2=b28af0400378c66a257ab7e2bdc45722
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/14.04/x86_64/ruby-3.0.0-preview1.tar.bz2=79aa27d2147989874a01c1093695a805
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/14.10/x86_64/ruby-1.9.3-p551.tar.bz2=89eb6e2329dcc59375570836a41fb26d
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/14.10/x86_64/ruby-2.0.0-p598.tar.bz2=9f33e9eb6b8f8c30515ccd17394d4300
@@ -998,6 +1009,7 @@ https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/16.04/x86_64/ruby-2.6.5.tar
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/16.04/x86_64/ruby-2.6.6.tar.bz2=dc58b8ee61b3f42047c6006f2688169f
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/16.04/x86_64/ruby-2.7.0.tar.bz2=bccd28da6673bff560d6c4f04471b791
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/16.04/x86_64/ruby-2.7.1.tar.bz2=34f47de95284ad5b14f8faf22247e4c7
+https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/16.04/x86_64/ruby-2.7.2.tar.bz2=554222ac3cd1788afaf5029e01b7cfcb
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/16.04/x86_64/ruby-3.0.0-preview1.tar.bz2=e6aef74993bfa500c421fae1034dd3b6
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/16.10/x86_64/ruby-1.9.3-p551.tar.bz2=a04478dbac501036026226018b865129
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/16.10/x86_64/ruby-2.0.0-p648.tar.bz2=3987aa6e901a5982c30403cfafee4908
@@ -1094,6 +1106,7 @@ https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.6.5.tar
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.6.6.tar.bz2=ea85f316610e2fab7494aca4ed923c11
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.7.0.tar.bz2=ec1f46977ad59ab2d19b0e5b2e0a52db
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.7.1.tar.bz2=e4a3b51c9ebae6a59a46862c47a27b34
+https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.7.2.tar.bz2=d4ffdd35e8d4790d17271dddd3f37aa1
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-3.0.0-preview1.tar.bz2=bac846895e3f3bd235871b0ccf17a366
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/19.10/x86_64/ruby-2.4.0.tar.bz2=494942e29d7fc3bdd211239ba6eefe5a
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/19.10/x86_64/ruby-2.4.1.tar.bz2=ba2a1245e0901efdb51e77d84328dd7f
@@ -1124,6 +1137,7 @@ https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/19.10/x86_64/ruby-2.6.5.tar
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/19.10/x86_64/ruby-2.6.6.tar.bz2=3784961ef35311274cac83b4f4ec3056
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/19.10/x86_64/ruby-2.7.0.tar.bz2=73063f321a567b5eb12cb82975c5260a
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/19.10/x86_64/ruby-2.7.1.tar.bz2=c90d33cb17de38c68af149d72788da78
+https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/19.10/x86_64/ruby-2.7.2.tar.bz2=508e6114231bfa467f38cd09ec1f1392
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/19.10/x86_64/ruby-3.0.0-preview1.tar.bz2=c419f043e0160195e01c7e7bd5f1c00b
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/20.04/x86_64/ruby-2.1.0.tar.bz2=3597c93169b75494017e8a107aadc12d
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/20.04/x86_64/ruby-2.1.1.tar.bz2=fd11d47796e7c08a0760c8c2afbb78fc

--- a/config/remote
+++ b/config/remote
@@ -27,6 +27,7 @@ https://rvm_io.global.ssl.fastly.net/binaries/amazon/2/x86_64/ruby-2.6.5.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/amazon/2/x86_64/ruby-2.6.6.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/amazon/2/x86_64/ruby-2.7.0.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/amazon/2/x86_64/ruby-2.7.1.tar.bz2
+https://rvm_io.global.ssl.fastly.net/binaries/amazon/2/x86_64/ruby-2.7.2.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/amazon/2/x86_64/ruby-3.0.0-preview1.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/amazon/2013.03/x86_64/ruby-1.9.3-p448.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/amazon/2013.03/x86_64/ruby-2.0.0-p247.tar.bz2
@@ -59,6 +60,7 @@ https://rvm_io.global.ssl.fastly.net/binaries/amazon/2018.03/x86_64/ruby-2.6.5.t
 https://rvm_io.global.ssl.fastly.net/binaries/amazon/2018.03/x86_64/ruby-2.6.6.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/amazon/2018.03/x86_64/ruby-2.7.0.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/amazon/2018.03/x86_64/ruby-2.7.1.tar.bz2
+https://rvm_io.global.ssl.fastly.net/binaries/amazon/2018.03/x86_64/ruby-2.7.2.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/amazon/2018.03/x86_64/ruby-3.0.0-preview1.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/arch/libc-2.15/x86_64/ruby-1.9.3-p194.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/arch/libc-2.15/x86_64/ruby-1.9.3-p286.tar.bz2
@@ -145,6 +147,7 @@ https://rvm_io.global.ssl.fastly.net/binaries/centos/6/x86_64/ruby-2.6.5.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/centos/6/x86_64/ruby-2.6.6.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/centos/6/x86_64/ruby-2.7.0.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/centos/6/x86_64/ruby-2.7.1.tar.bz2
+https://rvm_io.global.ssl.fastly.net/binaries/centos/6/x86_64/ruby-2.7.2.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/centos/7/x86_64/ruby-2.4.0.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/centos/7/x86_64/ruby-2.4.1.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/centos/7/x86_64/ruby-2.4.2.tar.bz2
@@ -174,6 +177,7 @@ https://rvm_io.global.ssl.fastly.net/binaries/centos/7/x86_64/ruby-2.6.5.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/centos/7/x86_64/ruby-2.6.6.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/centos/7/x86_64/ruby-2.7.0.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/centos/7/x86_64/ruby-2.7.1.tar.bz2
+https://rvm_io.global.ssl.fastly.net/binaries/centos/7/x86_64/ruby-2.7.2.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/centos/7/x86_64/ruby-3.0.0-preview1.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/centos/8/x86_64/ruby-2.4.0.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/centos/8/x86_64/ruby-2.4.1.tar.bz2
@@ -204,6 +208,7 @@ https://rvm_io.global.ssl.fastly.net/binaries/centos/8/x86_64/ruby-2.6.5.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/centos/8/x86_64/ruby-2.6.6.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/centos/8/x86_64/ruby-2.7.0.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/centos/8/x86_64/ruby-2.7.1.tar.bz2
+https://rvm_io.global.ssl.fastly.net/binaries/centos/8/x86_64/ruby-2.7.2.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/centos/8/x86_64/ruby-3.0.0-preview1.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/debian/6/i386/ruby-1.9.3-p429.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/debian/6/i386/ruby-1.9.3-p448.tar.bz2
@@ -316,6 +321,7 @@ https://rvm_io.global.ssl.fastly.net/binaries/debian/8/x86_64/ruby-2.6.5.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/debian/8/x86_64/ruby-2.6.6.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/debian/8/x86_64/ruby-2.7.0.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/debian/8/x86_64/ruby-2.7.1.tar.bz2
+https://rvm_io.global.ssl.fastly.net/binaries/debian/8/x86_64/ruby-2.7.2.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/debian/8/x86_64/ruby-3.0.0-preview1.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/debian/9/x86_64/ruby-2.4.0.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/debian/9/x86_64/ruby-2.4.1.tar.bz2
@@ -346,6 +352,7 @@ https://rvm_io.global.ssl.fastly.net/binaries/debian/9/x86_64/ruby-2.6.5.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/debian/9/x86_64/ruby-2.6.6.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/debian/9/x86_64/ruby-2.7.0.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/debian/9/x86_64/ruby-2.7.1.tar.bz2
+https://rvm_io.global.ssl.fastly.net/binaries/debian/9/x86_64/ruby-2.7.2.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/debian/9/x86_64/ruby-3.0.0-preview1.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/debian/10/x86_64/ruby-2.4.0.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/debian/10/x86_64/ruby-2.4.1.tar.bz2
@@ -376,6 +383,7 @@ https://rvm_io.global.ssl.fastly.net/binaries/debian/10/x86_64/ruby-2.6.5.tar.bz
 https://rvm_io.global.ssl.fastly.net/binaries/debian/10/x86_64/ruby-2.6.6.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/debian/10/x86_64/ruby-2.7.0.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/debian/10/x86_64/ruby-2.7.1.tar.bz2
+https://rvm_io.global.ssl.fastly.net/binaries/debian/10/x86_64/ruby-2.7.2.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/debian/10/x86_64/ruby-3.0.0-preview1.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/fedora/17/x86_64/ruby-1.9.3-p429.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/fedora/17/x86_64/ruby-1.9.3-p448.tar.bz2
@@ -552,6 +560,7 @@ https://rvm_io.global.ssl.fastly.net/binaries/oracle/7/x86_64/ruby-2.6.5.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/oracle/7/x86_64/ruby-2.6.6.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/oracle/7/x86_64/ruby-2.7.0.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/oracle/7/x86_64/ruby-2.7.1.tar.bz2
+https://rvm_io.global.ssl.fastly.net/binaries/oracle/7/x86_64/ruby-2.7.2.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/oracle/7/x86_64/ruby-3.0.0-preview1.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/osx/10.10/x86_64/ruby-2.0.0-p451.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/osx/10.10/x86_64/ruby-2.0.0-p481.tar.bz2
@@ -897,6 +906,7 @@ https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/14.04/x86_64/ruby-2.6.5.tar
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/14.04/x86_64/ruby-2.6.6.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/14.04/x86_64/ruby-2.7.0.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/14.04/x86_64/ruby-2.7.1.tar.bz2
+https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/14.04/x86_64/ruby-2.7.2.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/14.04/x86_64/ruby-3.0.0-preview1.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/14.10/x86_64/ruby-1.9.3-p551.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/14.10/x86_64/ruby-2.0.0-p598.tar.bz2
@@ -964,6 +974,7 @@ https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/16.04/x86_64/ruby-2.6.5.tar
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/16.04/x86_64/ruby-2.6.6.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/16.04/x86_64/ruby-2.7.0.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/16.04/x86_64/ruby-2.7.1.tar.bz2
+https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/16.04/x86_64/ruby-2.7.2.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/16.04/x86_64/ruby-3.0.0-preview1.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/16.10/x86_64/ruby-1.9.3-p551.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/16.10/x86_64/ruby-2.0.0-p648.tar.bz2
@@ -1060,6 +1071,7 @@ https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.6.5.tar
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.6.6.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.7.0.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.7.1.tar.bz2
+https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.7.2.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-3.0.0-preview1.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/19.10/x86_64/ruby-2.4.0.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/19.10/x86_64/ruby-2.4.1.tar.bz2
@@ -1090,6 +1102,7 @@ https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/19.10/x86_64/ruby-2.6.5.tar
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/19.10/x86_64/ruby-2.6.6.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/19.10/x86_64/ruby-2.7.0.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/19.10/x86_64/ruby-2.7.1.tar.bz2
+https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/19.10/x86_64/ruby-2.7.2.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/19.10/x86_64/ruby-3.0.0-preview1.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/20.04/x86_64/ruby-2.1.0.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/20.04/x86_64/ruby-2.1.1.tar.bz2
@@ -1151,4 +1164,5 @@ https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/20.04/x86_64/ruby-2.6.5.tar
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/20.04/x86_64/ruby-2.6.6.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/20.04/x86_64/ruby-2.7.0.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/20.04/x86_64/ruby-2.7.1.tar.bz2
+https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/20.04/x86_64/ruby-2.7.2.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/20.04/x86_64/ruby-3.0.0-preview1.tar.bz2

--- a/config/sha512
+++ b/config/sha512
@@ -1,3 +1,4 @@
+https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/20.04/x86_64/ruby-2.7.2.tar.bz2=c46611007b444662c36a9a388044602273a33e6d39ed308ff5a7b48e087a1f6cf77e5bf7a8a79ef7566c4e374fc4ea172daf3c2fc5fa1b91466aca8e148f1451
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/20.04/x86_64/ruby-3.0.0-preview1.tar.bz2=13c43c5da6a4b8d9b801f0cbc41f56417076544eb65d9db0db8c85785e1a2ad717516cf86f95e185d4f367547cf79bef0610e63ce3881b12a38edbc56368cae1
 GemStone-27184.Darwin-i386.tar.gz=02126a9fc4a8d32fd797bc2c95ecf451bc9f400857d1fef26257e404328bf5b224335cf7499a322daf74776a26070f08462b0fad8f58e62950f0c640f6aaa62b
 GemStone-27184.Linux-x86_64.tar.gz=55eabbb0378784a734ac5af3d42fd80c0793ef4cca4dc9572c51198292d2dab5159191d82429c6a00e7193b1e3ade41f845373a2bfc056edc0f8eb496034347f
@@ -56,6 +57,7 @@ https://rvm_io.global.ssl.fastly.net/binaries/amazon/2/x86_64/ruby-2.6.5.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/amazon/2/x86_64/ruby-2.6.6.tar.bz2=b9a2d61e8f85bb8780871fbe051b6226bf179f670fdb197642002489fb23a6e2b90eccecc0effe1ab593d36b0059b69ba5045d5e55d58c1a712091caaa3e2fdf
 https://rvm_io.global.ssl.fastly.net/binaries/amazon/2/x86_64/ruby-2.7.0.tar.bz2=68a719597f42f974819708a48bd3a45e0d76d92b3bcda3fd3d87c1100c9209027c4973d607ef3d2e5cfee3be4bb70846b300f74452945c2d9f16be28e18b5065
 https://rvm_io.global.ssl.fastly.net/binaries/amazon/2/x86_64/ruby-2.7.1.tar.bz2=3817ab89d3beefbba2caa41a02282b22c04b666a312594d0b2a37acd69828a20a9caa308c5f7f2da8b6d4e1a081a3697498719934b178fd8c793166cdfe5ddb5
+https://rvm_io.global.ssl.fastly.net/binaries/amazon/2/x86_64/ruby-2.7.2.tar.bz2=4a24d4baaf4f0e0ca1adad5a76b5eb98955ae5445653bdbc12e0754ad518219a23059b714504df1487efec30642948a3f5727ea5c513ca9de1234974c7439392
 https://rvm_io.global.ssl.fastly.net/binaries/amazon/2/x86_64/ruby-3.0.0-preview1.tar.bz2=ab84066d5959735f175b0e5ec98b4ecc0f2aef0323bcd750c3889da327c164f06fb5f42b2b29f1835820260852e9fc7eaf99bcd0191336e259f1c34918d563cd
 https://rvm_io.global.ssl.fastly.net/binaries/amazon/2013.03/x86_64/ruby-1.9.3-p448.tar.bz2=2e7bc5f6d501928f01de2a6d9035f56f40678d410bc0629ef00e0e70565b49991c4570f19c34faa1bfef2ad4cb460e4c28ee2eaf5c0696a403d0847f17d4c22a
 https://rvm_io.global.ssl.fastly.net/binaries/amazon/2013.03/x86_64/ruby-2.0.0-p247.tar.bz2=6929240b591970249153fd7cb9aae47821a3efe60cdda3bfacc334cd7301635d6b71bdbd5e122b5e17d02559b6bad8711ecfbf38aa6f947ed28b5b1154a38efd
@@ -88,6 +90,7 @@ https://rvm_io.global.ssl.fastly.net/binaries/amazon/2018.03/x86_64/ruby-2.6.5.t
 https://rvm_io.global.ssl.fastly.net/binaries/amazon/2018.03/x86_64/ruby-2.6.6.tar.bz2=f0d1631e6999c22516975f5d937d3f5a7eab5d6b41d2ae1805a5ba53d271dc4f1d91221b2f05d3547914af71de5b4f7dad324ed874b673efac583ac9ec8990ce
 https://rvm_io.global.ssl.fastly.net/binaries/amazon/2018.03/x86_64/ruby-2.7.0.tar.bz2=24e047cf668d25b92293ee548951f983d8c1bb001e9c7e7e7044023970b64a9fb33f480eb68ec601a58746785d931c9561ac32506aecfb3a3bb7d8b2374b7a32
 https://rvm_io.global.ssl.fastly.net/binaries/amazon/2018.03/x86_64/ruby-2.7.1.tar.bz2=b1005864d9941ff5a6c66b3d08235781a13960b62cacf27b72aaea02ddb0854a4753281526e89ad06826d469b673d9d5f3a2079b5f19c003486716ce17b52b91
+https://rvm_io.global.ssl.fastly.net/binaries/amazon/2018.03/x86_64/ruby-2.7.2.tar.bz2=4c5ecf9c0f63b5dbe25d4723a5588d68ed7c44dc93bbb9428fca5a6369e709079f02047e0ffc2318557a3e2d54b8cdedf5dec817cca063b87e37f71725900f9b
 https://rvm_io.global.ssl.fastly.net/binaries/amazon/2018.03/x86_64/ruby-3.0.0-preview1.tar.bz2=5447a46dfc35b786ac92f992c356db94f43e6d7dc9cef550ad6689a5b2a14b2dcdf63d4837887c2923542efdffd00d20d951b15a5abf1a5557adaf5f5b060717
 https://rvm_io.global.ssl.fastly.net/binaries/arch/libc-2.15/x86_64/ruby-1.9.3-p194.tar.bz2=289f3921543eb096b0d50a2ce7f8655176f6f4dbc8a52aa1342b5238e33f36c9dc78948e4144f41eeca616920ba3422adb0a17d216ec7d2cfaae51f570c1f9b3
 https://rvm_io.global.ssl.fastly.net/binaries/arch/libc-2.15/x86_64/ruby-1.9.3-p286.tar.bz2=29d827ca2241fe8b6ee2b6e5bf454820594c4631f46748e8cb4402052b848b43b3f2095d97f57aeb84815193af0e191f80b0f4967aeeaacf9109af1386f17295
@@ -174,6 +177,7 @@ https://rvm_io.global.ssl.fastly.net/binaries/centos/6/x86_64/ruby-2.6.5.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/centos/6/x86_64/ruby-2.6.6.tar.bz2=98a32d7bd78edce70b76d90c9e1953f2e25ef52d99425eb7be7d708c54c8564ee73700187ce3da5f9c470d25dee72a0152fc46a7d3957da20e408ddeadc0498e
 https://rvm_io.global.ssl.fastly.net/binaries/centos/6/x86_64/ruby-2.7.0.tar.bz2=8d20da9561db37893841cae98ed3252e3fe19c81e49e02b4775c87fe015df9c25c1cd9a15e92c47f436665a1b139c272725f13ad52074018a9ab5ae63343d407
 https://rvm_io.global.ssl.fastly.net/binaries/centos/6/x86_64/ruby-2.7.1.tar.bz2=b1559a30c2140d4110897d86e118276262668f07a8c341a3e85e615c703e69ce7a25bc5579a266bc091dac6235c5b0c608fdd32db83c3f7601585711d8e99e28
+https://rvm_io.global.ssl.fastly.net/binaries/centos/6/x86_64/ruby-2.7.2.tar.bz2=b375e5f4ba4774c31e35a8be92bee2a2c779ab159d2426e7cddfe3ceacc2b5b9b8be2585e7b9d613ad2b4906dc0312d93312a7edcce161aa2c523a4f7722f2a7
 https://rvm_io.global.ssl.fastly.net/binaries/centos/7/x86_64/ruby-2.4.0.tar.bz2=6b03d4817def6fbfcc12ce39ff97435984c22804f6488a1177eb0782b070f6a72fa080daa3f563741b7185c79b73c34b25778e6c68ab6646e86a6c131351ebce
 https://rvm_io.global.ssl.fastly.net/binaries/centos/7/x86_64/ruby-2.4.1.tar.bz2=9b49faee96730806942a104e1c128ae29f6949608f81075a5d430d33996fd5fe4ae6c1ee9ab0ac41e8cefc8efdcf50e8d315fa3e8c5e228e19d83e03aa4db7db
 https://rvm_io.global.ssl.fastly.net/binaries/centos/7/x86_64/ruby-2.4.2.tar.bz2=cefe856736de3893a0caa763f120ef9a06e7ece608c486553e4228f820872e733d412ef047d9e6262b54fc59e066b5682f07dae5ddaf01a5b08836a9808fa9e2
@@ -203,6 +207,7 @@ https://rvm_io.global.ssl.fastly.net/binaries/centos/7/x86_64/ruby-2.6.5.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/centos/7/x86_64/ruby-2.6.6.tar.bz2=1aedf80e0ed1c8251cec75ce9fcd20c734969787f49b188a86634edd654a4942187da222d693cea35f86d9195c576ef0aabf400eb921f0897ee630a71397aa2f
 https://rvm_io.global.ssl.fastly.net/binaries/centos/7/x86_64/ruby-2.7.0.tar.bz2=e9ed50ef02387e544fcddea115fcef88354b481d4e706713de804bc97c470dcb31eafe3ffb4a29d47122e6739652e85bc93a0eb03ec37d3f414d5f2a10c74cd8
 https://rvm_io.global.ssl.fastly.net/binaries/centos/7/x86_64/ruby-2.7.1.tar.bz2=90d337be14eda27893fb12e09fa8785c49071d358f846b22addaa4161116124ed3d0b9672a4272734a6580443530b6fae5073da4ba4ed0334dc847d1f4453698
+https://rvm_io.global.ssl.fastly.net/binaries/centos/7/x86_64/ruby-2.7.2.tar.bz2=0c3a7832b789730b5b456473734611ce862c2813dd1b274a18b70e0dd00c82628f59e5284c99cda518d58682581cae707a67418f798fd4322ab60840b4a91bf5
 https://rvm_io.global.ssl.fastly.net/binaries/centos/7/x86_64/ruby-3.0.0-preview1.tar.bz2=22b5d90fd1445ca6379e549788c17f77a9c38557483e6399e74dd9e46b2254aa594b70a8479915317d727ea6028c56b5b41ee703061d3f372c412fc58073d621
 https://rvm_io.global.ssl.fastly.net/binaries/centos/8/x86_64/ruby-2.4.0.tar.bz2=6601387c5a961f0daa477ff3f1a418dc24a508384a9ee121c22785ef2e03899fe11fc5494866febf2394672279ce9417ceb803e439d2edce88f9f072a334eda8
 https://rvm_io.global.ssl.fastly.net/binaries/centos/8/x86_64/ruby-2.4.1.tar.bz2=707476a427d7a46538c10a3d0593952ecb8e1184f8e792099eff108f4a18622bfb86294049f81a2e99ee6c4ff1a0374c23e0e558cd85740c90cab70c9e2857e7
@@ -233,6 +238,7 @@ https://rvm_io.global.ssl.fastly.net/binaries/centos/8/x86_64/ruby-2.6.5.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/centos/8/x86_64/ruby-2.6.6.tar.bz2=6abaadf131996baecf0d9cb7abcef0c600f69e5dfccdbc1baa9476894526a80ce3ba5f1a0e3a33968da3bf918b18670b1d9e62a63afdfdb0f59025b961b57936
 https://rvm_io.global.ssl.fastly.net/binaries/centos/8/x86_64/ruby-2.7.0.tar.bz2=8cc6cd133408f91b010f9d43bf75efed758cb2661bc1f2e81aa0594f67bc8b66a88cf269d7292f695652fa91564806ec2dfd656669f3a349d585c801c0dc04a6
 https://rvm_io.global.ssl.fastly.net/binaries/centos/8/x86_64/ruby-2.7.1.tar.bz2=83c718094b6d16659b69267083f9cda1973a3702f972d4e64a95b934d26495c2d851fd325e2f03172d18317313aae10fb23c01fff1eaaab1673342b027fdd614
+https://rvm_io.global.ssl.fastly.net/binaries/centos/8/x86_64/ruby-2.7.2.tar.bz2=f5f263321172620a653f9429b7d7e8e0f24a131887fc55668e201be65a7cac847d2e164924fc38bcc1dbe09cb41816cb0b375f2de390d241ecabf1af90102b36
 https://rvm_io.global.ssl.fastly.net/binaries/centos/8/x86_64/ruby-3.0.0-preview1.tar.bz2=a76916fa6ca3313f986c15e0b015a878251949fcbb8dd440246de16b0c183673c6d07dafe927414df7c4fb7b89c56b8212851cf69bd79c93e0c76a1c420bbc15
 https://rvm_io.global.ssl.fastly.net/binaries/debian/6/i386/ruby-1.9.3-p429.tar.bz2=4d70cef193c653d47192e42ffaefdcf7f1e31f10ae19e6925ed8b36d2ca2593dec79bb52a43fb56a489c614c4c0d2c609d0d182126cd5deee4a2bb1ff98fe309
 https://rvm_io.global.ssl.fastly.net/binaries/debian/6/i386/ruby-1.9.3-p448.tar.bz2=6a4e742f09b038521741bbc4d9a5a65b050b978ecc056f2779b4f45d00dfb700629b3d1ac929a5b53b99ab4c86cc3fad91f152932d575af8e6167e303aa5ccc7
@@ -345,6 +351,7 @@ https://rvm_io.global.ssl.fastly.net/binaries/debian/8/x86_64/ruby-2.6.5.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/debian/8/x86_64/ruby-2.6.6.tar.bz2=b3df19a3ce52e1bce62ea016cb75d383a81a70268d37ffca104830394d365ddce57d21fe17a6a7fde180f336598f5486c3e716f32cffecf7d24b13de782fa9eb
 https://rvm_io.global.ssl.fastly.net/binaries/debian/8/x86_64/ruby-2.7.0.tar.bz2=7a8159f2667265be96a54689b48836778cf1d433caf8b737d55d52fce3ce4d50da101b41b9c5927a22d659b4861772efe7d44d2a0c76c1757b8244efa95c9bc2
 https://rvm_io.global.ssl.fastly.net/binaries/debian/8/x86_64/ruby-2.7.1.tar.bz2=1b673bc33abc96e0abda406d1e028a80f287e0b99e73aa4d0ec0591709177bf2f9d75f3ec94bafae4e24e23f056848bfa9741486eec0d6599f34911304792ebd
+https://rvm_io.global.ssl.fastly.net/binaries/debian/8/x86_64/ruby-2.7.2.tar.bz2=705b0f7002807e2db0db6f38f0eb9fe4d6012d6d1673c19a363c29a034551102fb92cb7e13efb90c0559acae9a45bad5ea13c50e0af35b0dc1776b8d917fd802
 https://rvm_io.global.ssl.fastly.net/binaries/debian/8/x86_64/ruby-3.0.0-preview1.tar.bz2=b0c2665b89fed26095bab8e7bf54f2b4718b05a3e4c6c612c9e36785c432ea46e43eea584c2123df5f9f18e2ce51db3a4425c56f371def69cfa8e7e1d6bd0b2a
 https://rvm_io.global.ssl.fastly.net/binaries/debian/9/x86_64/ruby-2.4.0.tar.bz2=e9cd5b3bcdfadf36bb6f9fa836cb24386af680f583c15954cea969ea12b8932aa2cc5f304e73a18d4d6524d6202e0055864f535aa40cb028ea6b026653368b62
 https://rvm_io.global.ssl.fastly.net/binaries/debian/9/x86_64/ruby-2.4.1.tar.bz2=4cf75eabe008e882ceff21c09b47b0f22b2ad34c55ca51bbd1b316532e21baaeebaa273cc69537d4f379ae3f37187b3ae48f249c09ca5cadb06174ca1f3958df
@@ -375,6 +382,7 @@ https://rvm_io.global.ssl.fastly.net/binaries/debian/9/x86_64/ruby-2.6.5.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/debian/9/x86_64/ruby-2.6.6.tar.bz2=b137c1039798987cb4dcc4de1aa2cef4798dd7725bbfa395744214b288c63468bcc667ba480b98d532da362ceb9f90a61a3c200716fe435677caf72b0453d1ea
 https://rvm_io.global.ssl.fastly.net/binaries/debian/9/x86_64/ruby-2.7.0.tar.bz2=5148d6ae9ef2c17ab9cf8974565bfb89dd2c20b787339f51ca410ea687914596be250a80ce7f42c7b0add297d1f1e67e8818e84eaa798ec40e6862ac65840f27
 https://rvm_io.global.ssl.fastly.net/binaries/debian/9/x86_64/ruby-2.7.1.tar.bz2=f66dabdc67725ec330513b5efcf474cad222651a34c0c4a0c96bfef0302686075e62c7dd8e4050b2237ce28171679c4a5dbd1cd545a1f2acef63009b5b9347a6
+https://rvm_io.global.ssl.fastly.net/binaries/debian/9/x86_64/ruby-2.7.2.tar.bz2=2b9f9645c01f62393ec498faff9afbc18b3be80e719bab0609dde2f5d3ae705c7a0e7439094b5e33f41fcb0be1b4292a847e57dbd4ace3266188ff5bedb7110b
 https://rvm_io.global.ssl.fastly.net/binaries/debian/9/x86_64/ruby-3.0.0-preview1.tar.bz2=465c51f9b6f958e9daf2e881a93ac9908d0b771d5a4e261e4e23088b3a4952cd0f6f75b82bcd117cec72d1b5e35c31416cddd16ab7fab81972a2f337e8f2b5e5
 https://rvm_io.global.ssl.fastly.net/binaries/debian/10/x86_64/ruby-2.4.0.tar.bz2=99e5e98b69e5b46d44081be06847005caee31f0837bf312d005d30bda6ec463bf69e13cd0c3517f5ccf95a933720e471b5a2a031c0481c75889e16e620c58edd
 https://rvm_io.global.ssl.fastly.net/binaries/debian/10/x86_64/ruby-2.4.1.tar.bz2=3db44a23cb29901a862adce0aee3be01dfcb4daf96ead2363d803fd12c5e0b79e70716194d54a49ee28f2cbc7e1d9e32786b71e3873b9f0f58d96888ad139821
@@ -405,6 +413,7 @@ https://rvm_io.global.ssl.fastly.net/binaries/debian/10/x86_64/ruby-2.6.5.tar.bz
 https://rvm_io.global.ssl.fastly.net/binaries/debian/10/x86_64/ruby-2.6.6.tar.bz2=1a944edc5b3a6e0aec41ee30e3291f66c6c6e09972f7edf77f4ff850d4c850edec51a11a983f77f0ed35fef81bffd3a18dd78cef4a21a41407540dc1448c57d7
 https://rvm_io.global.ssl.fastly.net/binaries/debian/10/x86_64/ruby-2.7.0.tar.bz2=4fd5d7cec68aceb3abe2720fa124833cc47f9efb36a7cbb6ea39f0eba9ab9c9adc1ff78d18bc536f400dd8132ca7a2f72867be7ae9591fb50278963e048ea5da
 https://rvm_io.global.ssl.fastly.net/binaries/debian/10/x86_64/ruby-2.7.1.tar.bz2=c64148e5aec8e8eef3344c1900eebae445052662c4cf2f2906652a4a33e4cc9726bdc44c05c41d10c1fb94bbcf95c5a7743a95e25d528a85e6f806264756a1b7
+https://rvm_io.global.ssl.fastly.net/binaries/debian/10/x86_64/ruby-2.7.2.tar.bz2=ebed21fddbbfb6ef6e6913212c860fdba01887cbb0cc62190664c2c6eee1c01980e7b1bed26eaf8d3f15294f6f385b58fb93782293344e0df79f2484da2bb168
 https://rvm_io.global.ssl.fastly.net/binaries/debian/10/x86_64/ruby-3.0.0-preview1.tar.bz2=f04bd808b854ca339c0ea257d178351a287f770ba36f1a06d2e28dbce95aa54cb8c8e7164ee6f097e77d56ec24d6e9a2fa9adbc96c541c0a6eabcb546140ccb0
 https://rvm_io.global.ssl.fastly.net/binaries/fedora/17/x86_64/ruby-1.9.3-p429.tar.bz2=f63bac1909e05ef7448afbe395c3e7e9d7a82839f5498b8d650d0ef121706aee17fb1235d566890387336c7fc2fb8df7b73227c09279b526370198f6ff82c450
 https://rvm_io.global.ssl.fastly.net/binaries/fedora/17/x86_64/ruby-1.9.3-p448.tar.bz2=0dabf5af3a9736e10eef283fd6ce49bf4a57452aa11902721c4a5a5579d07d9e35272b07f5577153a25a1db7dc0abb3cc8aca75f4074949be1ce8e8123f2a526
@@ -581,6 +590,7 @@ https://rvm_io.global.ssl.fastly.net/binaries/oracle/7/x86_64/ruby-2.6.5.tar.bz2
 https://rvm_io.global.ssl.fastly.net/binaries/oracle/7/x86_64/ruby-2.6.6.tar.bz2=80d8610328dffc028e443a5a882dd77132c2c539965fcf03b905194c662f26c7dea52491306789ae6e9ffc382f909302b1e6e295f8bdf490ff06b1a7e29f26f0
 https://rvm_io.global.ssl.fastly.net/binaries/oracle/7/x86_64/ruby-2.7.0.tar.bz2=30b1ffde1f4c47bdf0edfd0da4a059b14daa882f1b9948575cf7f99ede6dce98250443c86155c07e84ad6531d5b34b397392584e1d2fc86f44f1bc74cfda703f
 https://rvm_io.global.ssl.fastly.net/binaries/oracle/7/x86_64/ruby-2.7.1.tar.bz2=660547030b0dd4a3c454dacc37a12d06d2d8da279bb1a0a77d696ea56e51ab344fd56a0ae71daf49a80989fdef3c8280023edcdeecd01507176e44814dbc6b9d
+https://rvm_io.global.ssl.fastly.net/binaries/oracle/7/x86_64/ruby-2.7.2.tar.bz2=19f9801bb3b325c8d850c7fa7fe10b23fbd219ed0e2fcdb014f1df2f5da4504f06b2f581d3a79efa524755612afd1478e16fe35416cfdca761177d8ef31a18f1
 https://rvm_io.global.ssl.fastly.net/binaries/oracle/7/x86_64/ruby-3.0.0-preview1.tar.bz2=e456da0dfa5f1cf1495193680dffa1b470a706425e56df0d8532fc995432bdaaef9f9ba6b04de88603b11156f094d16128e22b05b6e1bbb0cec4679e112b572f
 https://rvm_io.global.ssl.fastly.net/binaries/osx/10.10/x86_64/ruby-2.0.0-p451.tar.bz2=e56a56b467157f6255b5a49d16ca658118bf2262c48d8f73a6facdf357a7c505ba20aea070843bd0c1110b54ef19324c23ea84939006a7de22597f48e32e6443
 https://rvm_io.global.ssl.fastly.net/binaries/osx/10.10/x86_64/ruby-2.0.0-p481.tar.bz2=54b0776e3bec895b90aceb61ab9ba1606e684a32508670a7a538ebbbaa4245fb49ac186241ccbee12542e0f40f99669b13992d708b79110a52f722ea42f8bd62
@@ -926,6 +936,7 @@ https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/14.04/x86_64/ruby-2.6.5.tar
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/14.04/x86_64/ruby-2.6.6.tar.bz2=1d7e7d7f39eb7c71ba891c908973e1d439207165f21ca3152d66c54f7f34b5fe2d532fcaf084398771dbc79406bf68183725ef96c4ea3fd82b769b74e9ddeaff
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/14.04/x86_64/ruby-2.7.0.tar.bz2=03fa403e800492f99f0901716285bcf26020bfc9575dfce64c4967610fab0bf14614a9f0e2d0fc89a75fb5fcdeeca4ea971db32423594e798365c03b93413ea9
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/14.04/x86_64/ruby-2.7.1.tar.bz2=eddef51dd73c93deb0846000862253d1ebd46c3f87ef80844e1b983bb52eadacf58bc30fb3f21783440d03a71e7b4cea4452ca41d2413fda1fb0a671584ca41d
+https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/14.04/x86_64/ruby-2.7.2.tar.bz2=a5bbbbe91899388f48d7b19bb4f7bb1866d5f0ca1c73712c9e4cc4471908a072b206e25746c5f5b38ff6c9c49810a480ee87f588d1095b0414852f4559666e14
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/14.04/x86_64/ruby-3.0.0-preview1.tar.bz2=1bf6286090a4e8f87815dea2d07e108f85d70a61b76535d6f8782ffeaae57161e19aa76c9cc9696e2e9a2f2c67395f3fcd1db2ae5dfbfea147cefdfeea9c3309
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/14.10/x86_64/ruby-1.9.3-p551.tar.bz2=26532a0b2c191debd920825d4b271a6bddb0e9405c83cef116f30c0823af22e87c51a30d3067f42d21ca7b98dfdb258e4a143783c029d773d404bbdb4d484885
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/14.10/x86_64/ruby-2.0.0-p598.tar.bz2=e79e1366bf913fdc11818383abe5cd5fd539813345d89db7fd0d93b550e0e53b3a4c954334d2b1a0062aa6de5629f278da377a2484eb650cc3cd9d0ef5720671
@@ -993,6 +1004,7 @@ https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/16.04/x86_64/ruby-2.6.5.tar
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/16.04/x86_64/ruby-2.6.6.tar.bz2=a7de0764c9a8a6a6b00eff5983f6ccc24441512a0ef782820ec7fd260932984a7eb9ef338e2c2bfd053606ae09845a44c55d7ec98b3b844d080d3f8a271045a6
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/16.04/x86_64/ruby-2.7.0.tar.bz2=6f2899f866573fd78b0875c00bf9bdf296126a9d8f55a5e42d7028744b69e86f83b713112dd5f548b7b091674dfb907c3728a89c3b981a198c60f7f38723ab6f
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/16.04/x86_64/ruby-2.7.1.tar.bz2=ad63f201bc06025419dcd4341597b22c5f9afb0031cb09c2530371bbba7a54b6528c802ca7b764fc97d439c0bc798ec1fc43d3cf7bab4fa9db9ec9c2509d21be
+https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/16.04/x86_64/ruby-2.7.2.tar.bz2=81889577a41b982b3d59b4da5f9137453927e1d4776e1c394f7e67c4fbf24fbaaf3444ac623751ea576d6c127d9226bd23e86ea6c09d4c1a76677fd753343ba1
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/16.04/x86_64/ruby-3.0.0-preview1.tar.bz2=76a2dcb3dc48c0fee3f235a2f552af83478b4669346b09241143205d48c0377ca566cee9106e4c5721f38c0fe8b6c4b41b489165e9653326c9d8a89f74334138
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/16.10/x86_64/ruby-1.9.3-p551.tar.bz2=6609231a7dfc6cb3bc4f7b3d9da19856725149bf83b3526ea389722884fba76d2eefc0bab56eda126acc1cad624b1e159975daaa71a9a3a602e99b239385174d
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/16.10/x86_64/ruby-2.0.0-p648.tar.bz2=f8f78e9d6f2f4fe4be2484600bf95012cac675dcad9f6928419b06ca4223c923c60a0cb7de9cd2381ef77f6a196f3f0aaf04fad81230c33d6865eee7361b26ff
@@ -1089,6 +1101,7 @@ https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.6.5.tar
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.6.6.tar.bz2=08cda5ff00b9297b46d1fb620301066b21240951924337b8b87d27526e55024e61121e51d9b35feea2ac5eed4027658b39ff487195140e7abe9158181c3349af
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.7.0.tar.bz2=cada908be34428bc2f302bad6ebd778a2c7a8e979476e00e45c9444b65d7f48f397b838549d56ceb91f0e5593ffd663e9facc4ea5f5c6a4aecda85a5a1136496
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.7.1.tar.bz2=06cb5f2f0c0941802119dbdf34995446d6d69ee59eed9a5e9d7f9e7f0e14de440a9e77eee330357fa305e81ee39a6868651c740ebc91bb9a2085a74b33685f4c
+https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-2.7.2.tar.bz2=23654c65e6e62354857f86098852af0ba50a15643df5e7f6fc8b710e35a3872f6eb7dc1bf9266375361f696d8ded0bcdb9ee9acdc8d0c975955d299292da7e21
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/18.04/x86_64/ruby-3.0.0-preview1.tar.bz2=8fe71fdb37955b031769359dadc5062b6c15e0618fd8961c932212a6a2610829aba8b1dbdcf4bdcc2e133665e043b29088f714874e3ef3a41d688b7beba78928
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/19.10/x86_64/ruby-2.4.0.tar.bz2=172189c66b3c721e7413f0088f50e4eb8dd80d87779c3a4e74231f7036eeaacb8e373b7f5ff017f8aa274c1e1c872066f2f93485a2a369a7e9b442d157840bf2
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/19.10/x86_64/ruby-2.4.1.tar.bz2=829fcc1a3d878ee28e89a58a2f6d4221cec115d241a007b048953672d57548002c3a105ea4e65e344137091baaf5d5c54232a54c116afe03d0f3d61c07547c2c
@@ -1119,6 +1132,7 @@ https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/19.10/x86_64/ruby-2.6.5.tar
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/19.10/x86_64/ruby-2.6.6.tar.bz2=ce912342033f395ba6298051b081c89832f656d61ecf2064e9568692552a938599c816d2cd1fd1f9bee721611f890b8329985c69f4d5b2bdbfa6635b48afe3b1
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/19.10/x86_64/ruby-2.7.0.tar.bz2=cbfc7a1cddff0385187a7bf2eb9dc71a8d14912cbbe4e9529b79414e49e681302ac9009b7c8e6fcf92a9f19a0ca5053a6ed25edfdb510e3e4e247474d471c58c
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/19.10/x86_64/ruby-2.7.1.tar.bz2=29b99b3e04325ceca89b64c7846aeadb412215270f6f7c390fb1e275ebe19b2faef811778c0615b2d4720ddd942a2cc209c72e623f559e6c04e78849cc1c1b1e
+https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/19.10/x86_64/ruby-2.7.2.tar.bz2=f67ab3ac13ae90622fb3664a869b0c584b97df0500384a28bda9c5c36cf2a27ac1f66afafea08bb29bbfbfc1e0ddc444427993ff4163987f5510c4158a90a96d
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/19.10/x86_64/ruby-3.0.0-preview1.tar.bz2=aaeeafee545dd1ba1c4df5b7e46e82f7e89e0dcf4fb10677b7e177e66f86e6825e85fa5ae3e74062363883768b3485495a3378f97693d45f675a6e547e989cba
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/20.04/x86_64/ruby-2.1.0.tar.bz2=3e78b2a73167c3680aebb1ed015c583d4f6c58804d3b272253bee2cef37fd2d1cb3852fd2b408f4af1abca17725d923a1f28d40d2a33896e5cc21c4c6711d7ca
 https://rvm_io.global.ssl.fastly.net/binaries/ubuntu/20.04/x86_64/ruby-2.1.1.tar.bz2=14e7962e180b9ae16607347ba5360b9ec086eb8055b88d2f60b1c9284fafd93fea905aceb441f07d594a34b53647520f9dec38e4e9f6ad3e5a6850750d981a27


### PR DESCRIPTION
- Amazon Linux 2, 2018.03
- Centos 6, 7, 8
- Debian 8, 9, 10
- Oracle Linux 7
- Ubuntu 14.04, 16.04, 18.04, 19.10, 20.04
