### PR TITLE
Added libssl dependency also to ree 1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 #### Bug fixes
 
 * Use libssl-1.0 to install Ruby 1.8 on Debian 9 [\#4920](https://github.com/rvm/rvm/pull/4920)
+* Use libssl-1.0 to install Ree 1.8 on Ubuntu [\#4996](https://github.com/rvm/rvm/pull/4920)
 
 #### New interpreters
 

--- a/scripts/functions/requirements/ubuntu
+++ b/scripts/functions/requirements/ubuntu
@@ -24,7 +24,7 @@ requirements_ubuntu_define_libssl()
   # starting from Ubuntu 17.10 (Artful Aardvark)
 
   case "$1" in
-    (ruby-2.3*|ruby-2.2*|ruby-2.1*|ruby-2.0*|ruby-1.9*|ruby-1.8*)
+    (ruby-2.3*|ruby-2.2*|ruby-2.1*|ruby-2.0*|ruby-1.9*|ruby-1.8*|ree-1.8*)
       if
         __rvm_version_compare ${_system_version} -ge 17.10
       then


### PR DESCRIPTION
Fixes #4996 

Changes proposed in this pull request:
* Use libssl-1.0 to install Ree 1.8 on Ubuntu
