### PR TITLE
Requirement glibc-headers obsolete on Fedora 33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Use libssl-1.0 to install Ree 1.8 on Ubuntu [\#4996](https://github.com/rvm/rvm/pull/4920)
 * Fix broken mergeable config [\#5001](https://github.com/rvm/rvm/pull/5001)
 * Update brew list command to remove deprecation warning [\#4995](https://github.com/rvm/rvm/pull/4995) [\#5022](https://github.com/rvm/rvm/pull/5022)
+* Requirement `glibc-headers` obsolete on Fedora 33 [\#5023](https://github.com/rvm/rvm/pull/5023)
 
 #### New interpreters
 

--- a/scripts/functions/requirements/fedora
+++ b/scripts/functions/requirements/fedora
@@ -22,6 +22,17 @@ requirements_fedora_define_openssl()
   esac
 }
 
+requirements_fedora_define_glibc()
+{
+  if
+    __rvm_version_compare "${_system_version}" -lt 33
+  then
+    requirements_check glibc-headers glibc-devel
+  else
+    requirements_check glibc-devel
+  fi
+}
+
 if
   __rvm_which dnf >/dev/null 2>&1 # should be true for Fedora 22+
 then

--- a/scripts/functions/requirements/fedora_dnf
+++ b/scripts/functions/requirements/fedora_dnf
@@ -83,9 +83,11 @@ requirements_fedora_define()
       ;;
 
     (*)
-      requirements_check autoconf automake bison bzip2 gcc-c++ glibc-headers glibc-devel libffi-devel libtool \
+
+      requirements_check autoconf automake bison bzip2 gcc-c++ libffi-devel libtool \
                          libyaml-devel make patch readline readline-devel sqlite-devel zlib zlib-devel
       requirements_fedora_define_openssl $1
+      requirements_fedora_define_glibc $1
       ;;
   esac
 }

--- a/scripts/functions/requirements/fedora_yum
+++ b/scripts/functions/requirements/fedora_yum
@@ -17,11 +17,6 @@ requirements_fedora_before()
       return $?
 }
 
-requirements_fedora_define_glibc()
-{
-  requirements_check glibc-headers glibc-devel
-}
-
 requirements_fedora_define_libyaml()
 {
   requirements_check libyaml-devel


### PR DESCRIPTION
Fixes #5021 