### PR TITLE
Fix fresh installs of RVM

### DIFF
--- a/scripts/functions/installer
+++ b/scripts/functions/installer
@@ -1417,7 +1417,8 @@ update_gemsets_install_rvm()
             if [[ "${__gem_home}" == *"@*" ]]
             then continue
             fi
-            __rvm_with "${__gem_home##*/}" (gem pristine gem-wrappers --only-plugins || true) && gem wrappers regenerate
+            __rvm_with "${__gem_home##*/}" gem pristine gem-wrappers --only-plugins
+            __rvm_with "${__gem_home##*/}" gem wrappers regenerate
           done
         done | __rvm_dotted "    Regenerating gem wrappers in ${#missing[@]} rubies"
       fi


### PR DESCRIPTION
Fix bug on fresh installs originated by https://github.com/rvm/rvm/pull/5027 . 

The PR https://github.com/rvm/rvm/pull/5027 fixed ruby3 installation on already installed rvms, but breaks new installations of rvm. So, this PR maintains the fix of https://github.com/rvm/rvm/pull/5027, and also fix the break of new installations.

Feedback of bug provided by @teeigeryuh 🤝 

To test this PR, you can use the following command below: `curl -ksSL https://get.rvm.io | bash -s -- --source github.com/pedrofurtado/rvm` 

Now RVM installs like a charm 🌟 !

@pkuczynski @mpapis Your review on this will be awesome 🍹 