### PR TITLE
Fix ruby 3 installation+compilation with rubygems v3.2.3+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 #### Bug fixes
 
 * Requirement `glibc-headers` obsolete on Fedora 33 [\#5023](https://github.com/rvm/rvm/pull/5023)
-* Fix unknown command wrappers with rubygems >= 3.2 [\#5027](https://github.com/rvm/rvm/pull/5027)
+* Fix unknown command wrappers with Rubygems >= 3.2 [\#5027](https://github.com/rvm/rvm/pull/5027)
+* Fix errors in compilation+installation of Ruby 3 with Rubygems >= 3.2 [\#5025](https://github.com/rvm/rvm/pull/5030)
 
 ## [1.29.11](https://github.com/rvm/rvm/releases/tag/1.29.11)
 29 December 2020 - [Full Changelog](https://github.com/rvm/rvm/compare/1.29.10...1.29.11)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 * Requirement `glibc-headers` obsolete on Fedora 33 [\#5023](https://github.com/rvm/rvm/pull/5023)
 * Fix unknown command wrappers with Rubygems >= 3.2 [\#5027](https://github.com/rvm/rvm/pull/5027)
-* Fix errors in compilation+installation of Ruby 3 with Rubygems >= 3.2 [\#5025](https://github.com/rvm/rvm/pull/5030)
+* Fix errors in compilation+installation of Ruby 3 with Rubygems >= 3.2 [\#5030](https://github.com/rvm/rvm/pull/5030)
 
 ## [1.29.11](https://github.com/rvm/rvm/releases/tag/1.29.11)
 29 December 2020 - [Full Changelog](https://github.com/rvm/rvm/compare/1.29.10...1.29.11)

--- a/scripts/functions/gemset
+++ b/scripts/functions/gemset
@@ -355,7 +355,7 @@ gemset_initial()
 run_gem_wrappers()
 {
   gem_install gem-wrappers >/dev/null &&
-  gem pristine gem-wrappers --only-plugins > /dev/null 2>&1 &&
+  gem pristine gem-wrappers > /dev/null &&
     gem wrappers "$@" ||
     return $?
 }

--- a/scripts/functions/gemset
+++ b/scripts/functions/gemset
@@ -355,6 +355,7 @@ gemset_initial()
 run_gem_wrappers()
 {
   gem_install gem-wrappers >/dev/null &&
+  gem pristine gem-wrappers --only-plugins >/dev/null &&
     gem wrappers "$@" ||
     return $?
 }

--- a/scripts/functions/gemset
+++ b/scripts/functions/gemset
@@ -355,7 +355,7 @@ gemset_initial()
 run_gem_wrappers()
 {
   gem_install gem-wrappers >/dev/null &&
-  gem pristine gem-wrappers --only-plugins &> /dev/null &&
+  gem pristine gem-wrappers --only-plugins > /dev/null 2>&1 &&
     gem wrappers "$@" ||
     return $?
 }

--- a/scripts/functions/gemset
+++ b/scripts/functions/gemset
@@ -360,6 +360,15 @@ run_gem_wrappers()
     return $?
 }
 
+gem_wrappers_pristine()
+{
+  if [ "$(printf '%s\n' "3.2.0" "$(gem -v)" | sort -V | head -n1)" == "3.2.0" ]
+    gem pristine gem-wrappers --only-plugins > /dev/null || return $?
+  else
+    true
+  fi
+}
+
 __rvm_rubygems_create_link()
 {
   \typeset ruby_lib_gem_path

--- a/scripts/functions/gemset
+++ b/scripts/functions/gemset
@@ -355,7 +355,7 @@ gemset_initial()
 run_gem_wrappers()
 {
   gem_install gem-wrappers >/dev/null &&
-  gem pristine gem-wrappers --only-plugins >/dev/null &&
+  gem pristine gem-wrappers --only-plugins 2>/dev/null &&
     gem wrappers "$@" ||
     return $?
 }

--- a/scripts/functions/gemset
+++ b/scripts/functions/gemset
@@ -355,7 +355,7 @@ gemset_initial()
 run_gem_wrappers()
 {
   gem_install gem-wrappers >/dev/null &&
-  gem pristine gem-wrappers > /dev/null &&
+  ([ "$(printf '%s\n' "3.2.3" "$(gem -v)" | sort -V | head -n1)" == "3.2.3" ] && gem pristine gem-wrappers --only-plugins > /dev/null || exit 0) &&
     gem wrappers "$@" ||
     return $?
 }

--- a/scripts/functions/gemset
+++ b/scripts/functions/gemset
@@ -355,7 +355,7 @@ gemset_initial()
 run_gem_wrappers()
 {
   gem_install gem-wrappers >/dev/null &&
-  ([ "$(printf '%s\n' "3.2.3" "$(gem -v)" | sort -V | head -n1)" == "3.2.3" ] && gem pristine gem-wrappers --only-plugins > /dev/null || exit 0) &&
+  ([ "$(printf '%s\n' "3.2.0" "$(gem -v)" | sort -V | head -n1)" == "3.2.0" ] && gem pristine gem-wrappers --only-plugins > /dev/null || exit 0) &&
     gem wrappers "$@" ||
     return $?
 }

--- a/scripts/functions/gemset
+++ b/scripts/functions/gemset
@@ -355,7 +355,7 @@ gemset_initial()
 run_gem_wrappers()
 {
   gem_install gem-wrappers >/dev/null &&
-  gem pristine gem-wrappers --only-plugins 2>/dev/null &&
+  gem pristine gem-wrappers --only-plugins &> /dev/null &&
     gem wrappers "$@" ||
     return $?
 }

--- a/scripts/functions/gemset
+++ b/scripts/functions/gemset
@@ -355,7 +355,7 @@ gemset_initial()
 run_gem_wrappers()
 {
   gem_install gem-wrappers >/dev/null &&
-  ([ "$(printf '%s\n' "3.2.0" "$(gem -v)" | sort -V | head -n1)" == "3.2.0" ] && gem pristine gem-wrappers --only-plugins > /dev/null || exit 0) &&
+  gem_wrappers_pristine &&
     gem wrappers "$@" ||
     return $?
 }

--- a/scripts/functions/gemset
+++ b/scripts/functions/gemset
@@ -365,7 +365,7 @@ gem_wrappers_pristine()
   if [ "$(printf '%s\n' "3.2.0" "$(gem -v)" | sort -V | head -n1)" == "3.2.0" ]
     gem pristine gem-wrappers --only-plugins > /dev/null || return $?
   else
-    true
+    return true
   fi
 }
 

--- a/scripts/functions/gemset
+++ b/scripts/functions/gemset
@@ -363,9 +363,7 @@ run_gem_wrappers()
 gem_wrappers_pristine()
 {
   if [ "$(printf '%s\n' "3.2.0" "$(gem -v)" | sort -V | head -n1)" == "3.2.0" ]
-    gem pristine gem-wrappers --only-plugins > /dev/null || return $?
-  else
-    return true
+  then gem pristine gem-wrappers --only-plugins > /dev/null
   fi
 }
 


### PR DESCRIPTION
Fixes #5025 . Thanks for reporting, @BrianHawley! 🤝 

I believe that is the last part of a series of fixes (https://github.com/rvm/rvm/pull/5029, https://github.com/rvm/rvm/pull/5027) in rvm codebase, to allow ruby v3 + rubygems v3.2.3 inside it without errors.

Steps for testing:

```
$ curl -ksSL https://get.rvm.io | bash -s -- --branch issue-5025
$ source /etc/profile.d/rvm.sh
$ rvm install 3.0.0

$ ruby -v
$ rvm -v

and also for ruby 2.x ...

$ rvm install 2.7.2
$ rvm install 2.5.1

and so on ...

🎉 🎉 
```