### PR TITLE
Fix invalid brew syntax on requirements check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 #### Bug fixes
 
 * Remove unsupported libclang, libclang-dev, openssl-dev and zlib-dev from Termux requirements, and fix installation by not calling getent [\#5101](https://github.com/rvm/rvm/pull/5101)
+* Fix bad brew syntax on OSX/Homebrew requirements search [\#5111](https://github.com/rvm/rvm/pull/5111)
 
 #### New interpreters
 

--- a/scripts/functions/requirements/osx_brew
+++ b/scripts/functions/requirements/osx_brew
@@ -53,7 +53,7 @@ requirements_osx_brew_lib_installed()
 
 requirements_osx_brew_lib_available()
 {
-  brew search | __rvm_grep "^${1}$" >/dev/null || return $?
+  brew search "/^${1}$/" | __rvm_grep "^${1}$" >/dev/null || return $?
 }
 
 requirements_osx_brew_libs_error()


### PR DESCRIPTION
Changes proposed in this pull request:

`brew search` now takes a mandatory search criteria parameter. It can
return extra entries from the taps, so we still need to grep to make
sure the correct formula is there.

Fixes #5086.