### PR TITLE
Install ruby-head with ruby 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 #### Bug fixes
 
 * Remove unsupported libclang, libclang-dev, openssl-dev and zlib-dev from Termux requirements, and fix installation by not calling getent [\#5101](https://github.com/rvm/rvm/pull/5101)
+* Allow ruby-head to be installed using ruby 3, not truffleruby [\#5115](https://github.com/rvm/rvm/pull/5115)
 
 #### New interpreters
 

--- a/scripts/functions/build
+++ b/scripts/functions/build
@@ -306,10 +306,10 @@ __rvm_mono_env()
 __rvm_mri_rubies()
 (
   # find on bsd does not have -not, we need to use \!
-  \typeset versions="${1:-"ruby-1.9|ruby-2"}"
+  \typeset versions="${1:-"ruby-1.9|ruby-2|ruby-3"}"
   __rvm_cd "$rvm_rubies_path" &&
   __rvm_find . -maxdepth 1 -mindepth 1 -type d \! -type l |
-  __rvm_awk -F/ "/$versions/"' {if (system("test -x \""$0"/bin/ruby\"")==0) print $2}' ||
+  __rvm_awk -F/ "/\/($versions)/"' {if (system("test -x \""$0"/bin/ruby\"")==0) print $2}' ||
   return $?
 )
 
@@ -317,7 +317,7 @@ __rvm_mri_rubies()
 # with things like rbx etc which require a ruby be installed.
 __rvm_mri_ruby()
 {
-  __rvm_mri_rubies "${1:-"ruby-1.9|ruby-2"}" |
+  __rvm_mri_rubies "${1:-"ruby-1.9|ruby-2|ruby-3"}" |
   __rvm_version_sort |
   __rvm_awk 'BEGIN{ selected=$0 } /'"$(__rvm_env_string)"'/{ selected=$0 } END {print $0}'
 }
@@ -325,7 +325,7 @@ __rvm_mri_ruby()
 __rvm_ensure_has_mri_ruby()
 {
   \typeset versions
-  versions="${1:-"ruby-1.9|ruby-2"}"
+  versions="${1:-"ruby-1.9|ruby-2|ruby-3"}"
   if
     [[ -z "$(__rvm_mri_ruby $versions)" ]]
   then


### PR DESCRIPTION
Changes proposed in this pull request:
* Adds ruby 3 as an allowed ruby to install ruby-head with.
* Be more specific about checking MRI rubies to exclude non-MRI rubies with the MRI ruby prefix somewhere in the version string.

Fixes #5112.