### PR TITLE
Be more specific about selecting a ruby variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 #### Bug fixes
 
 * Remove unsupported libclang, libclang-dev, openssl-dev and zlib-dev from Termux requirements, and fix installation by not calling getent [\#5101](https://github.com/rvm/rvm/pull/5101)
+* Fix attempts to install/uninstall ruby picking jruby, mruby or truffleruby instead [\#5116](https://github.com/rvm/rvm/pull/5116)
 
 #### New interpreters
 

--- a/scripts/functions/selector_parse
+++ b/scripts/functions/selector_parse
@@ -32,6 +32,12 @@ __rvm_ruby_string_fuzzy()
   if [[ -n "${rvm_ruby_name:-}" ]]
   then __search="${__search%${rvm_ruby_name:-}}.*${rvm_ruby_name:-}"
   fi
+  case "${__search}" in
+    # If the pattern starts with one of the ruby names, don't search for the other rubies.
+    (ruby*|rbx*|jruby*|truffleruby*|mruby*|macruby*|ree*|maglev*|ironruby*|opal*|topaz*)
+      __search="^${__search}"
+      ;;
+  esac
   new_ruby_string="$(
     __rvm_list_strings |
     __rvm_grep "${__search//\./\\.}" |
@@ -250,7 +256,7 @@ __rvm_ruby_string_latest()
   \typeset check_ruby_string new_ruby_string
   check_ruby_string=""
   if [[ -n "${rvm_ruby_interpreter}" ]]
-  then check_ruby_string+="${rvm_ruby_interpreter}-"
+  then check_ruby_string+="^${rvm_ruby_interpreter}-"
   fi
   if [[ -n "${rvm_ruby_version}" ]]
   then check_ruby_string+="${rvm_ruby_version//\./\.}.*"


### PR DESCRIPTION
Changes proposed in this pull request:

When installing or selecting a partial ruby spec like ruby-2, it should
get the latest version of that type of ruby. Instead, it was getting
the latest version of the alphabetically last type of ruby that had that
sequence of characters in its version string. The alphabetically last
ruby variant with "ruby" in its name is "truffleruby".

The problem was that the rvm_ruby_interpreter part of the version search
was missing a `^` anchor to indicate the start of the string. Adding that
anchor fixes the search.

This should also fix other occastions where you could select a partial
ruby spec, like rvm use or do.

I also fixed a similar problem with the `--fuzzy` option which made it
find jruby, mruby, or truffleruby, when searching for ruby. This made
rvm uninstall, reinstall and remove do the same because they use the
`--fuzzy` option by default.

Fixes #5114, #4986.