### PR TITLE
Fix detection for SUSE 15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Fix Termux requirements checking and installation, and the requirements specified [\#5110](https://github.com/rvm/rvm/pull/5110)
 * Fix invalid brew syntax on requirements check [\#5111](https://github.com/rvm/rvm/pull/5111)
 * Skip non-functional prepare/mount tests on macOS [\#5119](https://github.com/rvm/rvm/pull/5119)
+* Fix detection for SUSE 15 [\#5132](https://github.com/rvm/rvm/pull/5132)
 
 #### New interpreters
 

--- a/scripts/functions/detect/system_name/os_release
+++ b/scripts/functions/detect/system_name/os_release
@@ -11,6 +11,12 @@ __rvm_detect_system_from_os_release()
       _system_arch="$( uname -m )"
       ;;
 
+    sles*)
+      _system_name="SuSE"
+      _system_version="$( awk -F'=' '$1=="VERSION_ID"{gsub(/"/,"");print $2}' /etc/os-release | head -n 1 )"
+      _system_arch="$( uname -m )"
+      ;;
+
     opensuse*)
       _system_name="OpenSuSE"
       _system_version="$( awk -F'=' '$1=="VERSION_ID"{gsub(/"/,"");print $2}' /etc/os-release | head -n 1 )"


### PR DESCRIPTION
Newer versions of SUSE no longer use /etc/suse-release.
Adding a check in /etc/os-release.

Fixes #5131 .

Changes proposed in this pull request:
* Update detection for SLES 15.