### PR TITLE
Update keyserver in the docs

### DIFF
--- a/scripts/functions/cli
+++ b/scripts/functions/cli
@@ -224,7 +224,7 @@ verify_package_pgp()
     rvm_error "\
 GPG signature verification failed for '$1' - '$3'! Try to install GPG v2 and then fetch the public key:
 
-    ${SUDO_USER:+sudo }${rvm_gpg_command##*/} --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+    ${SUDO_USER:+sudo }${rvm_gpg_command##*/} --keyserver hkp://keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 
 or if it fails:
 


### PR DESCRIPTION
The keyserver `hkp://pool.sks-keyservers.net` has been deprecated. https://unix.stackexchange.com/questions/656205/sks-keyservers-gone-what-to-use-instead

Fixes # .

Changes proposed in this pull request:
*
*
*

Make sure that your pull request includes entry in the [CHANGELOG](CHANGELOG.md).