### PR TITLE
Switch default JRuby to 9.3.1.0

### DIFF
--- a/config/db
+++ b/config/db
@@ -119,7 +119,7 @@ mruby_version=2.0.1
 #
 jruby_repo_url=https://github.com/jruby/jruby.git
 jruby_url=https://repo1.maven.org/maven2/org/jruby/jruby-dist
-jruby_version=9.2.9.0
+jruby_version=9.3.1.0
 maven_version=3.5.0
 #
 # TruffleRuby


### PR DESCRIPTION
Stable was never updated to point at the 9.3 line, so here it is.