### PR TITLE
railsexpress patches for 2.6.9, 2.7.5 and 3.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 
 #### New features
 
-* Added railsexpress patches for Ruby 2.6.7, 2.7.3, 3.0.1 [\#5066](https://github.com/rvm/rvm/pull/5066), 2.6.8, 2.7.4, 3.0.2 [\#5117](https://github.com/rvm/rvm/pull/5117)
+* Added railsexpress patches for Ruby 2.6.7, 2.7.3, 3.0.1 [\#5066](https://github.com/rvm/rvm/pull/5066), 2.6.8, 2.7.4, 3.0.2
+  [\#5117](https://github.com/rvm/rvm/pull/5117), 2.6.9, 2.7.5, 3.0.3 [\#5167](https://github.com/rvm/rvm/pull/5167)
 
 #### Bug fixes
 

--- a/patchsets/ruby/2.6.9/railsexpress
+++ b/patchsets/ruby/2.6.9/railsexpress
@@ -1,0 +1,5 @@
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.6.9/railsexpress/01-fix-with-openssl-dir-option.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.6.9/railsexpress/02-fix-broken-tests-caused-by-ad.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.6.9/railsexpress/03-improve-gc-stats.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.6.9/railsexpress/04-more-detailed-stacktrace.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.6.9/railsexpress/05-malloc-trim.patch

--- a/patchsets/ruby/2.6/head/railsexpress
+++ b/patchsets/ruby/2.6/head/railsexpress
@@ -1,4 +1,5 @@
-https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.6/head/railsexpress/01-fix-broken-tests-caused-by-ad.patch
-https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.6/head/railsexpress/02-improve-gc-stats.patch
-https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.6/head/railsexpress/03-more-detailed-stacktrace.patch
-https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.6/head/railsexpress/04-malloc-trim.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.6/head/railsexpress/01-fix-with-openssl-dir-option.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.6/head/railsexpress/02-fix-broken-tests-caused-by-ad.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.6/head/railsexpress/03-improve-gc-stats.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.6/head/railsexpress/04-more-detailed-stacktrace.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.6/head/railsexpress/05-malloc-trim.patch

--- a/patchsets/ruby/2.7.5/railsexpress
+++ b/patchsets/ruby/2.7.5/railsexpress
@@ -1,0 +1,5 @@
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.7.5/railsexpress/01-fix-with-openssl-dir-option.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.7.5/railsexpress/02-fix-broken-tests-caused-by-ad.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.7.5/railsexpress/03-improve-gc-stats.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.7.5/railsexpress/04-more-detailed-stacktrace.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.7.5/railsexpress/05-malloc-trim.patch

--- a/patchsets/ruby/2.7/head/railsexpress
+++ b/patchsets/ruby/2.7/head/railsexpress
@@ -1,4 +1,5 @@
-https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.7/head/railsexpress/01-fix-broken-tests-caused-by-ad.patch
-https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.7/head/railsexpress/02-improve-gc-stats.patch
-https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.7/head/railsexpress/03-more-detailed-stacktrace.patch
-https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.7/head/railsexpress/04-malloc-trim.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.7/head/railsexpress/01-fix-with-openssl-dir-option.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.7/head/railsexpress/02-fix-broken-tests-caused-by-ad.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.7/head/railsexpress/03-improve-gc-stats.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.7/head/railsexpress/04-more-detailed-stacktrace.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.7/head/railsexpress/05-malloc-trim.patch

--- a/patchsets/ruby/3.0.3/railsexpress
+++ b/patchsets/ruby/3.0.3/railsexpress
@@ -1,0 +1,3 @@
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/3.0.3/railsexpress/01-fix-with-openssl-dir-option.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/3.0.3/railsexpress/02-improve-gc-stats.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/3.0.3/railsexpress/03-malloc-trim.patch

--- a/patchsets/ruby/3.0/head/railsexpress
+++ b/patchsets/ruby/3.0/head/railsexpress
@@ -1,2 +1,3 @@
-https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/3.0/head/railsexpress/01-improve-gc-stats.patch
-https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/3.0/head/railsexpress/02-malloc-trim.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/3.0/head/railsexpress/01-fix-with-openssl-dir-option.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/3.0/head/railsexpress/02-improve-gc-stats.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/3.0/head/railsexpress/03-malloc-trim.patch


### PR DESCRIPTION
Please merge to add railsexpress patches for 2.6.9, 2.7.5 and 3.0.3.