### PR TITLE
Avoid duplicate package instances when querying pkg-config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 * Fix invalid brew syntax on requirements check [\#5111](https://github.com/rvm/rvm/pull/5111)
 * Skip non-functional prepare/mount tests on macOS [\#5119](https://github.com/rvm/rvm/pull/5119)
 * Fix detection for SUSE 15 [\#5132](https://github.com/rvm/rvm/pull/5132)
-* Avoid duplicate package instances when querying pkg-config
+* Avoid duplicate package instances when querying pkg-config [\#5172](https://github.com/rvm/rvm/pull/5172)
 
 #### New interpreters
 https://github.com/rvm/rvm/pull/5137

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Fix invalid brew syntax on requirements check [\#5111](https://github.com/rvm/rvm/pull/5111)
 * Skip non-functional prepare/mount tests on macOS [\#5119](https://github.com/rvm/rvm/pull/5119)
 * Fix detection for SUSE 15 [\#5132](https://github.com/rvm/rvm/pull/5132)
+* Avoid duplicate package instances when querying pkg-config
 
 #### New interpreters
 https://github.com/rvm/rvm/pull/5137

--- a/scripts/functions/pkg
+++ b/scripts/functions/pkg
@@ -30,7 +30,7 @@ requirements_rvm_pkg_after_uniqe_paths()
   \typeset __lib __lib_full_name
   for __lib
   do
-    __lib_full_name=$( requirements_rvm_pkg_config --list-all | __rvm_awk "/^${__lib}[- ]/{print \$1}" )
+    __lib_full_name=$( requirements_rvm_pkg_config --list-all | __rvm_awk "/^${__lib}[- ]/{print \$1}" | sort -u )
     if
       [[ -n "${__lib_full_name}" ]]
     then


### PR DESCRIPTION
Changes proposed in this pull request:
* Avoids duplicate package instances returned by pkg-config
