### PR TITLE
Remove an obsolete patch from the railsexpress patches for Ruby3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,7 @@
 
 #### New features
 
-* Added railsexpress patches for Ruby 2.6.7, 2.7.3, 3.0.1
-  [\#5066](https://github.com/rvm/rvm/pull/5066) and [\#5173](https://github.com/rvm/rvm/pull/5173), 2.6.8, 2.7.4, 3.0.2
-  [\#5117](https://github.com/rvm/rvm/pull/5117), 2.6.9, 2.7.5, 3.0.3 [\#5167](https://github.com/rvm/rvm/pull/5167),
-  [\#5170](https://github.com/rvm/rvm/pull/5170)
+* Added railsexpress patches for Ruby 2.6.7, 2.7.3, 3.0.1 [\#5066](https://github.com/rvm/rvm/pull/5066) and [\#5173](https://github.com/rvm/rvm/pull/5173), 2.6.8, 2.7.4, 3.0.2 [\#5117](https://github.com/rvm/rvm/pull/5117), 2.6.9, 2.7.5, 3.0.3 [\#5167](https://github.com/rvm/rvm/pull/5167), [\#5170](https://github.com/rvm/rvm/pull/5170)
 
 #### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 
 #### New features
 
-* Added railsexpress patches for Ruby 2.6.7, 2.7.3, 3.0.1 [\#5066](https://github.com/rvm/rvm/pull/5066), 2.6.8, 2.7.4, 3.0.2
+* Added railsexpress patches for Ruby 2.6.7, 2.7.3, 3.0.1
+  [\#5066](https://github.com/rvm/rvm/pull/5066) and [\#5173](https://github.com/rvm/rvm/pull/5173), 2.6.8, 2.7.4, 3.0.2
   [\#5117](https://github.com/rvm/rvm/pull/5117), 2.6.9, 2.7.5, 3.0.3 [\#5167](https://github.com/rvm/rvm/pull/5167),
   [\#5170](https://github.com/rvm/rvm/pull/5170)
 

--- a/patchsets/ruby/3.1.0/railsexpress
+++ b/patchsets/ruby/3.1.0/railsexpress
@@ -1,3 +1,2 @@
-https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/3.1.0/railsexpress/01-fix-with-openssl-dir-option.patch
-https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/3.1.0/railsexpress/02-improve-gc-stats.patch
-https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/3.1.0/railsexpress/03-malloc-trim.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/3.1.0/railsexpress/01-improve-gc-stats.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/3.1.0/railsexpress/02-malloc-trim.patch

--- a/patchsets/ruby/3.1/head/railsexpress
+++ b/patchsets/ruby/3.1/head/railsexpress
@@ -1,3 +1,2 @@
-https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/3.1/head/railsexpress/01-fix-with-openssl-dir-option.patch
-https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/3.1/head/railsexpress/02-improve-gc-stats.patch
-https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/3.1/head/railsexpress/03-malloc-trim.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/3.1/head/railsexpress/01-improve-gc-stats.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/3.1/head/railsexpress/02-malloc-trim.patch


### PR DESCRIPTION
Can you please merge?