### PR TITLE
Railsexpress patches for ruby 3.1.2, 3.0.4 and 2.7.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,16 @@
 
 #### New features
 
-* Added railsexpress patches for Ruby
+* New Ruby versions
+  * 2.6.10, 2.7.6, 3.0.4, 3.1.2, 3.2.0 Preview 1 [\#5200](https://github.com/rvm/rvm/pull/5200)
+
+* New railsexpress patches for Ruby
   * 2.6.7, 2.7.3, 3.0.1 [\#5066](https://github.com/rvm/rvm/pull/5066),
   * 2.6.8, 2.7.4, 3.0.2 [\#5117](https://github.com/rvm/rvm/pull/5117),
   * 2.6.9, 2.7.5, 3.0.3 [\#5167](https://github.com/rvm/rvm/pull/5167),
   * 3.1.0 [\#5170](https://github.com/rvm/rvm/pull/5170),
   * 3.1.1 [\#5190](https://github.com/rvm/rvm/pull/5190)
-  * 2.6.10, 2.7.6, 3.0.4, 3.1.2, 3.2.0 Preview 1 [\#5200](https://github.com/rvm/rvm/pull/5200)
+  * 2.7.6, 3.0.4 and 3.1.2 [\#5207](https://github.com/rvm/rvm/pull/5207)
 
 #### Bug fixes
 

--- a/patchsets/ruby/2.7.6/railsexpress
+++ b/patchsets/ruby/2.7.6/railsexpress
@@ -1,0 +1,5 @@
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.7.6/railsexpress/01-fix-with-openssl-dir-option.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.7.6/railsexpress/02-fix-broken-tests-caused-by-ad.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.7.6/railsexpress/03-improve-gc-stats.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.7.6/railsexpress/04-more-detailed-stacktrace.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.7.6/railsexpress/05-malloc-trim.patch

--- a/patchsets/ruby/3.0.4/railsexpress
+++ b/patchsets/ruby/3.0.4/railsexpress
@@ -1,0 +1,3 @@
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/3.0.4/railsexpress/01-fix-with-openssl-dir-option.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/3.0.4/railsexpress/02-improve-gc-stats.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/3.0.4/railsexpress/03-malloc-trim.patch

--- a/patchsets/ruby/3.1.2/railsexpress
+++ b/patchsets/ruby/3.1.2/railsexpress
@@ -1,0 +1,2 @@
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/3.1.2/railsexpress/01-improve-gc-stats.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/3.1.2/railsexpress/02-malloc-trim.patch


### PR DESCRIPTION
This PR adds railsexpress patches for Ruby 3.1.2, 3.0.4 and 2.7.6