### PR TITLE
Use openssl on Void Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Fix detection for SUSE 15 [\#5132](https://github.com/rvm/rvm/pull/5132)
 * Avoid duplicate package instances when querying pkg-config [\#5172](https://github.com/rvm/rvm/pull/5172)
 * Fix building Ruby on Devuan 2 and newer by using libreadline-dev instead of libreadline6-dev [\#5214](https://github.com/rvm/rvm/pull/5214)
+* Fix building Ruby on Void Linux by using openssl instead of libressl [\#5234](https://github.com/rvm/rvm/pull/5234)
 
 #### New interpreters
 

--- a/scripts/functions/requirements/void
+++ b/scripts/functions/requirements/void
@@ -20,7 +20,7 @@ requirements_void_define_base()
   requirements_check "$@" \
     autoconf automake bison ca-certificates curl \
     gdbm-devel glibc-devel gmp-devel \
-    libffi-devel libressl-devel libtool libyaml-devel \
+    libffi-devel openssl-devel libtool libyaml-devel \
     make ncurses-devel \
     patch pkg-config readline-devel \
     sqlite-devel zlib-devel


### PR DESCRIPTION
We require LibreSSL on Void Linux, but Void dropped Libre to return to OpenSSL last year:
https://voidlinux.org/news/2021/02/OpenSSL.html

Switching the dependency to OpenSSL.
