### PR TITLE
added railsexpress patches for ruby 3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   * 3.1.1 [\#5190](https://github.com/rvm/rvm/pull/5190)
   * 2.7.6, 3.0.4 and 3.1.2 [\#5207](https://github.com/rvm/rvm/pull/5207)
   * 2.7.7, 3.0.5 and 3.1.3 [\#5273](https://github.com/rvm/rvm/pull/5273)
+  * 3.2.0 [\#5284](https://github.com/rvm/rvm/pull/5284)
 
 #### Bug fixes
 

--- a/patchsets/ruby/3.2.0/railsexpress
+++ b/patchsets/ruby/3.2.0/railsexpress
@@ -1,0 +1,2 @@
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/3.2.0/railsexpress/01-improve-gc-stats.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/3.2.0/railsexpress/02-malloc-trim-patch.patch

--- a/patchsets/ruby/3.2/head/railsexpress
+++ b/patchsets/ruby/3.2/head/railsexpress
@@ -1,0 +1,2 @@
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/3.2/head/railsexpress/01-improve-gc-stats.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/3.2/head/railsexpress/02-malloc-trim-patch.patch


### PR DESCRIPTION
Can you please merge this after I have added the CHANGELOG entry which I can only do after having created the PR because only then I know the correct PR number?

Thx a lot.
