### PR TITLE
Don't warn about empty GEM_PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,8 @@
 * Fix building Ruby on Devuan 2 and newer by using libreadline-dev instead of libreadline6-dev [\#5214](https://github.com/rvm/rvm/pull/5214)
 * Fix building Ruby on Void Linux by using openssl instead of libressl [\#5234](https://github.com/rvm/rvm/pull/5234)
 * Fix building ruby-head by running autogen when available [\#5238](https://github.com/rvm/rvm/pull/5238)
-* Fix building Ruby 2.7 on Fedora 36+ by using openssl1.1 instead of openssl3 [\#5247](https://github.com/rvm/pull/5247)
+* Fix building Ruby 2.7 on Fedora 36+ by using openssl1.1 instead of openssl3 [\#5247](https://github.com/rvm/rvm/pull/5247)
+* Don't warn about empty GEM_PATH [\#5292](https://github.com/rvm/rvm/pull/5292)
 
 #### New interpreters
 

--- a/scripts/rvm
+++ b/scripts/rvm
@@ -224,11 +224,10 @@ then
         fi
       elif
         [[ "${__path_to_ruby}" == "${rvm_path}"* ]] &&
-        [[ -z "${GEM_HOME:-}" || -z "${GEM_PATH:-}" ]]
+        [[ -z "${GEM_HOME:-}" ]]
       then
         echo "
-Warning: PATH set to RVM ruby but GEM_HOME and/or GEM_PATH not set, see:
-    https://github.com/rvm/rvm/issues/3212
+Warning: PATH set to RVM ruby but GEM_HOME not set.
 " >&2
         if
           [[ -n "${SUDO_USER:-}" ]]


### PR DESCRIPTION
The `GEM_PATH` is set to an empty string by bundler when it is used per
```
  bundle install --path vendor/bundle
```
This is intentionally and checked in bundler's specs. See: https://github.com/rubygems/rubygems/blob/77686d0c4c8ffdbcbb8631878eebd0651ed8f90c/bundler/spec/bundler/bundler_spec.rb#L173-L177

However rvm then shows a warning, which is very misleading, since it points to an issue, which is not present at all. Also the warning can turn into a hard error, when the output is used from a subshell. For instance libusb's "make install" fails then, because of "garbage" in the shell output.

> Make sure that your pull request includes entry in the [CHANGELOG](CHANGELOG.md).

This often leads to merge conflicts, so that I didn't add it now. If this PR is OK, then I'll add a CHANGELOG entry.
