### PR TITLE
Add a patch to fix erratic linker behavior on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@
   * 3.1.1 [\#5190](https://github.com/rvm/rvm/pull/5190)
   * 2.7.6, 3.0.4 and 3.1.2 [\#5207](https://github.com/rvm/rvm/pull/5207)
   * 2.7.7, 3.0.5 and 3.1.3 [\#5273](https://github.com/rvm/rvm/pull/5273)
-  * 3.2.0 [\#5284](https://github.com/rvm/rvm/pull/5284)
-  * 3.2.1 [\#5311](https://github.com/rvm/rvm/pull/5311)
+  * 3.2.0 [\#5284](https://github.com/rvm/rvm/pull/5284) and [\#5312](https://github.com/rvm/rvm/pull/5312)
+  * 3.2.1 [\#5311](https://github.com/rvm/rvm/pull/5311) and [\#5312](https://github.com/rvm/rvm/pull/5312)
 
 #### Bug fixes
 

--- a/patchsets/ruby/3.2.0/railsexpress
+++ b/patchsets/ruby/3.2.0/railsexpress
@@ -1,2 +1,3 @@
 https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/3.2.0/railsexpress/01-improve-gc-stats.patch
 https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/3.2.0/railsexpress/02-malloc-trim-patch.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/3.2.0/railsexpress/03-fix-bigdecimal-linker-problems-on-macos.patch

--- a/patchsets/ruby/3.2.1/railsexpress
+++ b/patchsets/ruby/3.2.1/railsexpress
@@ -1,2 +1,3 @@
 https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/3.2.1/railsexpress/01-improve-gc-stats.patch
 https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/3.2.1/railsexpress/02-malloc-trim-patch.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/3.2.1/railsexpress/03-fix-bigdecimal-linker-problems-on-macos.patch

--- a/patchsets/ruby/3.2/head/railsexpress
+++ b/patchsets/ruby/3.2/head/railsexpress
@@ -1,2 +1,3 @@
 https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/3.2/head/railsexpress/01-improve-gc-stats.patch
 https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/3.2/head/railsexpress/02-malloc-trim-patch.patch
+https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/3.2/head/railsexpress/03-fix-bigdecimal-linker-problems-on-macos.patch


### PR DESCRIPTION
Changes in the MacOS linker and how it is used in ruby 3.2 sometimes lead to failed compiles.

This patch works around the problem.