### PR TITLE
Update truffleruby-dev to use builds based on Ubuntu 20.04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   * 3.2.1 [\#5311](https://github.com/rvm/rvm/pull/5311) and [\#5312](https://github.com/rvm/rvm/pull/5312)
 
 * Add Support for OpenSSL 1.1/3.0 to older ruby versions [\#5248](https://github.com/rvm/rvm/pull/5248)
+* truffleruby-dev builds on Linux are now based on Ubuntu 20.04 rather than Ubuntu 18.04 [\#5321](https://github.com/rvm/rvm/issues/5321)
 
 #### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
   * 3.2.1 [\#5311](https://github.com/rvm/rvm/pull/5311) and [\#5312](https://github.com/rvm/rvm/pull/5312)
 
 * Add Support for OpenSSL 1.1/3.0 to older ruby versions [\#5248](https://github.com/rvm/rvm/pull/5248)
-* truffleruby-dev builds on Linux are now based on Ubuntu 20.04 rather than Ubuntu 18.04 [\#5321](https://github.com/rvm/rvm/issues/5321)
+* Update truffleruby-dev to use builds based on Ubuntu 20.04 [\#5322](https://github.com/rvm/rvm/issues/5322)
 
 #### Bug fixes
 

--- a/scripts/functions/selector_interpreters
+++ b/scripts/functions/selector_interpreters
@@ -266,7 +266,7 @@ __rvm_truffleruby_set_rvm_ruby_url()
 
   if (( ${rvm_head_flag:=0} == 1 )); then
     case "$platform" in
-      linux) platform="ubuntu-18.04" ;;
+      linux) platform="ubuntu-20.04" ;;
       macos) platform="macos-latest" ;;
     esac
 


### PR DESCRIPTION
Ubuntu 18.04 will be end of life soon and TruffleRuby will stop delivering builds based on 18.04 accordingly.

Fixes #5321.

Changes proposed in this pull request:
* Change the _truffleruby-dev_ install tarball from one based on Ubuntu 18.04 to one based on Ubuntu 20.04.