### PR TITLE
Allow building ruby 2.4-2.6 on Fedora 36+

### DIFF
--- a/scripts/functions/requirements/fedora
+++ b/scripts/functions/requirements/fedora
@@ -14,7 +14,7 @@ requirements_fedora_define_openssl()
         requirements_check openssl-devel
       fi
       ;;
-    (ruby-2.7*|ruby-2.6*)
+    (ruby-2.7*|ruby-2.6*|ruby-2.5*|ruby-2.4*)
       if
         __rvm_version_compare "${_system_version}" -ge 36
       then

--- a/scripts/functions/requirements/fedora
+++ b/scripts/functions/requirements/fedora
@@ -14,7 +14,7 @@ requirements_fedora_define_openssl()
         requirements_check openssl-devel
       fi
       ;;
-    (ruby-2.7*)
+    (ruby-2.7*|ruby-2.6*)
       if
         __rvm_version_compare "${_system_version}" -ge 36
       then


### PR DESCRIPTION
Fixes #5216 

* Changes proposed in this pull request:
  *   Exactly the same approach as in https://github.com/rvm/rvm/pull/5247/ 
  *  add "2.4*, 2.5*, 2.6*" to a condition which requires openssl1.1-devel when trying to build ruby 2.4* - 2.6*  on fedora 36+


Make sure that your pull request includes entry in the [CHANGELOG](CHANGELOG.md).