### PR TITLE
Install openssl gem for Ruby 3.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 #### New features
 
-* Add Support for OpenSSL 1.1/3.0 to older ruby versions [\#5248](https://github.com/rvm/rvm/pull/5248)
+* Add Support for OpenSSL 1.1/3.0 to older ruby versions [\#5248](https://github.com/rvm/rvm/pull/5248) [\#5340](https://github.com/rvm/rvm/pull/5340)
 * Update truffleruby-dev to use builds based on Ubuntu 20.04 [\#5322](https://github.com/rvm/rvm/issues/5322)
 
 #### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 
 #### New features
 
-* Add Support for OpenSSL 1.1/3.0 to older ruby versions [\#5248](https://github.com/rvm/rvm/pull/5248) [\#5340](https://github.com/rvm/rvm/pull/5340)
+* Add Support for OpenSSL 1.1/3.0 to older ruby versions [\#5248](https://github.com/rvm/rvm/pull/5248)
 * Update truffleruby-dev to use builds based on Ubuntu 20.04 [\#5322](https://github.com/rvm/rvm/issues/5322)
+* Install openssl gem for Ruby 3.0.6 [\#5340](https://github.com/rvm/rvm/pull/5340)
 
 #### Bug fixes
 

--- a/gemsets/ruby/3.0.6/global.gems
+++ b/gemsets/ruby/3.0.6/global.gems
@@ -1,0 +1,1 @@
+openssl


### PR DESCRIPTION
Related to https://github.com/rvm/rvm/pull/5309

Changes proposed in this pull request:
* added missing file
