### PR TITLE
Fix truffleruby-23.0.0 installation on macos

### DIFF
--- a/scripts/functions/selector_interpreters
+++ b/scripts/functions/selector_interpreters
@@ -280,6 +280,8 @@ __rvm_truffleruby_set_rvm_ruby_url()
       linux-aarch64)  truffleruby_artifact_id="FD40BA2367C226B6E0531518000AE71A" ;;
       darwin-amd64)   truffleruby_artifact_id="FD4AB182EA51EDFDE0531518000AF13E" ;;
       darwin-aarch64) truffleruby_artifact_id="FD40BBF6750C366CE0531518000ABEAF" ;;
+      macos-amd64)    truffleruby_artifact_id="FD4AB182EA51EDFDE0531518000AF13E" ;;
+      macos-aarch64)  truffleruby_artifact_id="FD40BBF6750C366CE0531518000ABEAF" ;;
       *)              fail "Unsupported platform ${platform}-${arch}" ;;
     esac
     rvm_ruby_url="${rvm_ruby_repo_url:-https://gds.oracle.com/api/20220101/artifacts/$truffleruby_artifact_id/content}"

--- a/scripts/functions/selector_interpreters
+++ b/scripts/functions/selector_interpreters
@@ -278,8 +278,6 @@ __rvm_truffleruby_set_rvm_ruby_url()
     case "${platform}-${arch}" in
       linux-amd64)    truffleruby_artifact_id="FD4AB182EA4CEDFDE0531518000AF13E" ;;
       linux-aarch64)  truffleruby_artifact_id="FD40BA2367C226B6E0531518000AE71A" ;;
-      darwin-amd64)   truffleruby_artifact_id="FD4AB182EA51EDFDE0531518000AF13E" ;;
-      darwin-aarch64) truffleruby_artifact_id="FD40BBF6750C366CE0531518000ABEAF" ;;
       macos-amd64)    truffleruby_artifact_id="FD4AB182EA51EDFDE0531518000AF13E" ;;
       macos-aarch64)  truffleruby_artifact_id="FD40BBF6750C366CE0531518000ABEAF" ;;
       *)              fail "Unsupported platform ${platform}-${arch}" ;;


### PR DESCRIPTION
Changes proposed in this pull request:
* When installing on an M1 macbook pro, the platform was coming through as macos, so the truffleruby checks did not identify a valid artifact id. That results in the url being invalid and the install failing
* Adding `macos-amd64` and `macos-aarch64` to the case statement with identical artifact ids to their `darwin` counterparts fixes the issue, and truffleruby installs correctly @eregon 

> Make sure that your pull request includes entry in the [CHANGELOG](CHANGELOG.md).

It's not clear to me where I would put an entry in the changelog, or how I would format it, but I am happy to add one! Also happy to add a spec, but it's unclear how i'd do that or what i'd test.

Thanks!