### PR TITLE
Fixing macOS CI and re-enable the truffleruby test on macOS

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -18,16 +18,22 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: ./install
-      - run: source ~/.rvm/scripts/rvm && rvm use 2.7.7 --install --default && gem install tf -v '>=0.4.1'
-      - name: tests/fast/*
-        run: source ~/.rvm/scripts/rvm && tf --text tests/fast/*
+      - run: source ~/.rvm/scripts/rvm && rvm use 2.7.7 --install --default
+      - run: source ~/.rvm/scripts/rvm && gem install tf -v '>=0.4.1'
+
       - name: named_ruby_and_gemsets_comment_test
-        # works on local, but fails in CI, needs to be investigated
-        if: ${{ !contains(matrix.os, 'macos') }}
-        run: source ~/.rvm/scripts/rvm && gem install tf -v '>=0.4.1' && tf --text tests/long/named_ruby_and_gemsets_comment_test.sh
+        if: ${{ !contains(matrix.os, 'macos') }} # works on local, but fails in CI, needs to be investigated
+        run: source ~/.rvm/scripts/rvm && tf --text tests/long/named_ruby_and_gemsets_comment_test.sh
+
       - name: ruby_prepare_mount_comment_test
-        # https://github.com/rvm/rvm/issues/4937
-        if: ${{ !contains(matrix.os, 'macos') }}
+        if: ${{ !contains(matrix.os, 'macos') }} # https://github.com/rvm/rvm/issues/4937
         run: source ~/.rvm/scripts/rvm && tf --text tests/long/ruby_prepare_mount_comment_test.sh
+
       - name: truffleruby_comment_test
         run: source ~/.rvm/scripts/rvm && tf --text tests/long/truffleruby_comment_test.sh
+
+      # For some reason, after running these tests, `source ~/.rvm/scripts/rvm` fails on macOS, so run them last.
+      # See https://github.com/rvm/rvm/pull/5387#issuecomment-2009391015
+      # These tests also change the default ruby, which is another reason to run them last.
+      - name: tests/fast/*
+        run: source ~/.rvm/scripts/rvm && tf --text tests/fast/*

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -29,6 +29,4 @@ jobs:
         if: ${{ !contains(matrix.os, 'macos') }}
         run: source ~/.rvm/scripts/rvm && tf --text tests/long/ruby_prepare_mount_comment_test.sh
       - name: truffleruby_comment_test
-        # works on local, but fails in CI, needs to be investigated
-        if: ${{ !contains(matrix.os, 'macos') }}
         run: source ~/.rvm/scripts/rvm && tf --text tests/long/truffleruby_comment_test.sh

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       TERM: ansi
+      RVM_SKIP_BREW_UPDATE: true
     steps:
       - uses: actions/checkout@v2
       - run: ./install

--- a/scripts/functions/requirements/osx_brew
+++ b/scripts/functions/requirements/osx_brew
@@ -332,6 +332,8 @@ requirements_osx_brew_define_openssl()
 
     (*)
       brew_openssl_package="openssl@1.1"
+      # Needed for older openssl: https://bugs.ruby-lang.org/issues/18763
+      export PKG_CONFIG_PATH="$(brew --prefix openssl@1.1)/lib/pkgconfig:$PKG_CONFIG_PATH"
       ;;
   esac
 

--- a/scripts/functions/requirements/osx_brew
+++ b/scripts/functions/requirements/osx_brew
@@ -434,7 +434,7 @@ After installation open Xcode, go to Downloads and install Command Line Tools.
       return $ret
     }
   fi
-  brew update ||
+  [ -n "$RVM_SKIP_BREW_UPDATE" ] || brew update ||
   {
     \typeset ret=$?
     rvm_error "Failed to update Homebrew, follow instructions at


### PR DESCRIPTION
It was disabled in https://github.com/rvm/rvm/pull/5119
and means this bug was not caught: https://github.com/rvm/rvm/pull/5385