### PR TITLE
Fix URL for truffleruby-head on darwin-aarch64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * Fix truffleruby-23.0.0 installation on macos [\#5385](https://github.com/rvm/rvm/pull/5385)
 * Update location of OpenSSL binary [\#5433](https://github.com/rvm/rvm/pull/5433)
 * Fix gentoo dependencies moved from sys-devel to dev-build [\#5432](https://github.com/rvm/rvm/pull/5432)
+* Fix truffleruby-head installation on macos-aarch64 [\#5446](https://github.com/rvm/rvm/pull/5446)
 
 #### New interpreters
 

--- a/scripts/functions/selector_interpreters
+++ b/scripts/functions/selector_interpreters
@@ -265,9 +265,11 @@ __rvm_truffleruby_set_rvm_ruby_url()
   rvm_ruby_package_name="truffleruby-${truffleruby_version}"
 
   if (( ${rvm_head_flag:=0} == 1 )); then
-    case "$platform" in
-      linux) platform="ubuntu-20.04" ;;
-      macos) platform="macos-latest" ;;
+    case "${platform}-${arch}" in
+      linux-amd64)    platform="ubuntu-20.04" ;;
+      macos-amd64)    platform="macos-latest" ;;
+      macos-aarch64)  platform="macos-13-arm64" ;;
+      *)              fail "Unsupported platform ${platform}-${arch} for truffleruby-head" ;;
     esac
 
     rvm_ruby_package_file="${rvm_ruby_package_name}-${platform}"


### PR DESCRIPTION
Make sure that your pull request includes entry in the [CHANGELOG](CHANGELOG.md).