### PR TITLE
Upgrade github actions and truffleruby version in CI

### DIFF
--- a/.github/workflows/gpg_signature.yml
+++ b/.github/workflows/gpg_signature.yml
@@ -7,7 +7,7 @@ jobs:
   signature-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: sudo apt-get install -y gawk libgmp-dev dirmngr gnupg2
       - run: curl -sSL https://rvm.io/mpapis.asc | gpg --import -
       - run: curl -sSL https://rvm.io/pkuczynski.asc | gpg --import -

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -16,7 +16,7 @@ jobs:
       TERM: ansi
       RVM_SKIP_BREW_UPDATE: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: ./install
       - run: source ~/.rvm/scripts/rvm && rvm use 2.7.7 --install --default
       - run: source ~/.rvm/scripts/rvm && gem install tf -v '>=0.4.1'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * Update location of OpenSSL binary [\#5433](https://github.com/rvm/rvm/pull/5433)
 * Fix gentoo dependencies moved from sys-devel to dev-build [\#5432](https://github.com/rvm/rvm/pull/5432)
 * Fix truffleruby-head installation on macos-aarch64 [\#5446](https://github.com/rvm/rvm/pull/5446)
+* Fix warnings on CI [\#5456](https://github.com/rvm/rvm/pull/5456)
 
 #### New interpreters
 

--- a/tests/long/truffleruby_comment_test.sh
+++ b/tests/long/truffleruby_comment_test.sh
@@ -17,6 +17,6 @@ rvm truffleruby-head do ruby -v # status=0; match=/truffleruby/
 rvm remove truffleruby-head # status=0
 
 ## Test that the right version is installed (#4633)
-rvm install truffleruby-1.0.0-rc13 # status=0; match!=/Already installed/
-rvm truffleruby-1.0.0-rc13 do ruby -v # status=0; match=/truffleruby 1.0.0-rc13/
-rvm remove truffleruby-1.0.0-rc13 # status=0
+rvm install truffleruby-23.1.2 # status=0; match!=/Already installed/
+rvm truffleruby-23.1.2 do ruby -v # status=0; match=/truffleruby 23.1.2/
+rvm remove truffleruby-23.1.2 # status=0


### PR DESCRIPTION
## Pull Request Summary

I changed the `actions/checkout` version because it was outdated.
I also noticed that we still had a problem with failing tests, so I tried to fix it.

## Feedback

If the proposed change with TruffleRuby versions is not ok, I can remove it.

Updated: 
CI testing goes further. Now they fail on `tests/fast/do_comment_test.sh`
