### PR TITLE
Add a default patch to fix Bootsnap for Ruby 3.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * Update location of OpenSSL binary [\#5433](https://github.com/rvm/rvm/pull/5433)
 * Fix gentoo dependencies moved from sys-devel to dev-build [\#5432](https://github.com/rvm/rvm/pull/5432)
 * Fix truffleruby-head installation on macos-aarch64 [\#5446](https://github.com/rvm/rvm/pull/5446)
+* Fix bug with Bootsnap on Ruby 3.3.1 [\#5457](https://github.com/rvm/rvm/pull/5457)
 
 #### New interpreters
 

--- a/patches/ruby/3.3.1/fix_bootsnap.patch
+++ b/patches/ruby/3.3.1/fix_bootsnap.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/bundled_gems.rb b/lib/bundled_gems.rb
+index e756af61ea..555d1d4cd1 100644
+--- a/lib/bundled_gems.rb
++++ b/lib/bundled_gems.rb
+@@ -98,7 +98,7 @@ def self.warning?(name, specs: nil)
+     # name can be a feature name or a file path with String or Pathname
+     feature = File.path(name)
+     # bootsnap expand `require "csv"` to `require "#{LIBDIR}/csv.rb"`
+-    name = feature.delete_prefix(LIBDIR).chomp(".rb").tr("/", "-")
++    name = feature.delete_prefix(ARCHDIR).delete_prefix(LIBDIR).tr("/", "-")
+     name.sub!(LIBEXT, "")
+     return if specs.include?(name)
+     _t, path = $:.resolve_feature_path(feature)

--- a/patchsets/ruby/3.3.1/default
+++ b/patchsets/ruby/3.3.1/default
@@ -1,0 +1,1 @@
+fix_bootsnap


### PR DESCRIPTION
Fixes https://bugs.ruby-lang.org/issues/20450.

Changes proposed in this pull request:
* Add a minimalist patch that fixes a bug that prevents Ruby 3.3.1 from working with the Bootsnap gem, which ships with Rails.