### PR TITLE
Parallelize GitHub Action jobs in CI

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -11,6 +11,20 @@ jobs:
         os:
           - ubuntu-latest
           - macos-13
+        test:
+          # For some reason, after running these tests,
+          # `source ~/.rvm/scripts/rvm` fails on macOS, so run them last.
+          # See https://github.com/rvm/rvm/pull/5387#issuecomment-2009391015
+          # These tests also change the default ruby, which is another reason to run them last.
+          - "tests/fast/*"
+          - "tests/long/truffleruby_comment_test.sh"
+        include:
+          - os: ubuntu-latest
+            # works on local, but fails in CI, needs to be investigated
+            test: "tests/long/named_ruby_and_gemsets_comment_test.sh"
+          - os: ubuntu-latest
+            # https://github.com/rvm/rvm/issues/4937
+            test: "tests/long/ruby_prepare_mount_comment_test.sh"
     runs-on: ${{ matrix.os }}
     env:
       TERM: ansi
@@ -20,20 +34,4 @@ jobs:
       - run: ./install
       - run: source ~/.rvm/scripts/rvm && rvm use 2.7.7 --install --default
       - run: source ~/.rvm/scripts/rvm && gem install tf -v '>=0.4.1'
-
-      - name: named_ruby_and_gemsets_comment_test
-        if: ${{ !contains(matrix.os, 'macos') }} # works on local, but fails in CI, needs to be investigated
-        run: source ~/.rvm/scripts/rvm && tf --text tests/long/named_ruby_and_gemsets_comment_test.sh
-
-      - name: ruby_prepare_mount_comment_test
-        if: ${{ !contains(matrix.os, 'macos') }} # https://github.com/rvm/rvm/issues/4937
-        run: source ~/.rvm/scripts/rvm && tf --text tests/long/ruby_prepare_mount_comment_test.sh
-
-      - name: truffleruby_comment_test
-        run: source ~/.rvm/scripts/rvm && tf --text tests/long/truffleruby_comment_test.sh
-
-      # For some reason, after running these tests, `source ~/.rvm/scripts/rvm` fails on macOS, so run them last.
-      # See https://github.com/rvm/rvm/pull/5387#issuecomment-2009391015
-      # These tests also change the default ruby, which is another reason to run them last.
-      - name: tests/fast/*
-        run: source ~/.rvm/scripts/rvm && tf --text tests/fast/*
+      - run: source ~/.rvm/scripts/rvm && tf --text ${{ matrix.test }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,7 @@
 
 * Migrate from rvm_io.global.ssl.fastly.net to rvm-io.global.ssl.fastly.net to fix domain fronting report from Fastly [\#5438](https://github.com/rvm/rvm/pull/5438)
 * Upgrade github actions and truffleruby version in CI [\#5456](https://github.com/rvm/rvm/pull/5456)
+* Parallelize GitHub Action jobs in CI [\#5458](https://github.com/rvm/rvm/pull/5458)
 
 ## [1.29.12](https://github.com/rvm/rvm/releases/tag/1.29.12)
 15 January 2021 - [Full Changelog](https://github.com/rvm/rvm/compare/1.29.11...1.29.12)


### PR DESCRIPTION
## Pull Request Summary

CI tests take a long time because they run different cases one after the other. If something fails, no further tests will be run. ~CI tests have not been passed for some time now. Fast tests didn't pass on CI for MacOS. This change is intended to help us solve this problem more easily.~

Changes proposed in this pull request:
* split a long-running tests job into smaller jobs that can be parallelized

## Feedback

The total CI execution time is the same, but the waiting time for the test results is shorter.

### Before

![Screenshot before](https://github.com/rvm/rvm/assets/76075/0ea74dd1-deb6-4948-8f6b-edc84abf5c86)

### After

![Screenshot after](https://github.com/rvm/rvm/assets/76075/a6cc7480-f087-4986-9657-8e0d394facec)
