### PR TITLE
Try to fix macOS CI by pinning to a AMD64 macOS image

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-latest
+          - macos-13
     runs-on: ${{ matrix.os }}
     env:
       TERM: ansi


### PR DESCRIPTION
From https://github.com/rvm/rvm/pull/5456#discussion_r1581791227

https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-private-repositories
shows macos-14 (M1) is what `macos-latest` resolves to now.