### PR TITLE
Use pkgconf instead of pkg-config in Solus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * Fix gentoo dependencies moved from sys-devel to dev-build [\#5432](https://github.com/rvm/rvm/pull/5432)
 * Fix truffleruby-head installation on macos-aarch64 [\#5446](https://github.com/rvm/rvm/pull/5446)
 * Fix bug with Bootsnap on Ruby 3.3.1 [\#5457](https://github.com/rvm/rvm/pull/5457)
+* Fix Solus requirements check for pkgconf
 
 #### New interpreters
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@
 * Fix gentoo dependencies moved from sys-devel to dev-build [\#5432](https://github.com/rvm/rvm/pull/5432)
 * Fix truffleruby-head installation on macos-aarch64 [\#5446](https://github.com/rvm/rvm/pull/5446)
 * Fix bug with Bootsnap on Ruby 3.3.1 [\#5457](https://github.com/rvm/rvm/pull/5457)
-* Fix Solus requirements check for pkgconf
+* Fix Solus requirements check for pkgconf [\#5471](https://github.com/rvm/rvm/pull/5471)
 
 #### New interpreters
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@
 * Install openssl gem for Ruby 3.0.6 [\#5340](https://github.com/rvm/rvm/pull/5340)
 * Speed up Solus requirements check by 25x [\#5472](https://github.com/rvm/rvm/pull/5472/)
 
-
 #### Bug fixes
 
 * Remove unsupported libclang, libclang-dev, openssl-dev and zlib-dev from Termux requirements, and fix installation by not calling getent [\#5101](https://github.com/rvm/rvm/pull/5101)
@@ -36,7 +35,7 @@
 * Fix gentoo dependencies moved from sys-devel to dev-build [\#5432](https://github.com/rvm/rvm/pull/5432)
 * Fix truffleruby-head installation on macos-aarch64 [\#5446](https://github.com/rvm/rvm/pull/5446)
 * Fix bug with Bootsnap on Ruby 3.3.1 [\#5457](https://github.com/rvm/rvm/pull/5457)
-* Use pkgconf instead of pkg0-conf in Solus [\#5471](https://github.com/rvm/rvm/pull/5471)
+* Use pkgconf instead of pkg-config in Solus [\#5471](https://github.com/rvm/rvm/pull/5471)
 
 #### New interpreters
 

--- a/scripts/functions/requirements/solus
+++ b/scripts/functions/requirements/solus
@@ -70,7 +70,7 @@ requirements_solus_define()
       fi
       requirements_check autoconf gcc g++ glibc-devel patch readline readline-devel \
         zlib zlib-devel libffi-devel openssl-devel make bzip2 automake libtool \
-        bison sqlite3-devel yaml-devel gmp-devel pkg-config ncurses-devel binutils
+        bison sqlite3-devel yaml-devel gmp-devel pkgconf ncurses-devel binutils
       ;;
   esac
 }


### PR DESCRIPTION
Solus migrated from pkg-config to the more modern pkgconf, s.
https://github.com/getsolus/packages/commit/0949eab4adfffebb988fd0c8448c52fcddd82969#diff-6da1d22dcf408888f8aa5336844f716dd18fac4d39c0be32f5011b9828a6af53R35-R37
