### PR TITLE
Speed up requirements check on Solus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@
 * Fix gentoo dependencies moved from sys-devel to dev-build [\#5432](https://github.com/rvm/rvm/pull/5432)
 * Fix truffleruby-head installation on macos-aarch64 [\#5446](https://github.com/rvm/rvm/pull/5446)
 * Fix bug with Bootsnap on Ruby 3.3.1 [\#5457](https://github.com/rvm/rvm/pull/5457)
-* Speed up Solus requirements check by 25x
+* Speed up Solus requirements check by 25x [\#5472](https://github.com/rvm/rvm/pull/5472/)
 
 #### New interpreters
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * Fix gentoo dependencies moved from sys-devel to dev-build [\#5432](https://github.com/rvm/rvm/pull/5432)
 * Fix truffleruby-head installation on macos-aarch64 [\#5446](https://github.com/rvm/rvm/pull/5446)
 * Fix bug with Bootsnap on Ruby 3.3.1 [\#5457](https://github.com/rvm/rvm/pull/5457)
+* Speed up Solus requirements check by 25x
 
 #### New interpreters
 

--- a/scripts/functions/requirements/solus
+++ b/scripts/functions/requirements/solus
@@ -2,7 +2,7 @@
 
 requirements_solus_lib_installed()
 {
-  eopkg li --no-color | __rvm_grep "^$1[[:space:]]\+" > /dev/null 2>&1 || return $?
+  eopkg info --no-color -s $1 | __rvm_grep "^\[inst\][[:space:]]\+$1" > /dev/null 2>&1 || return $?
 }
 
 requirements_solus_lib_available()


### PR DESCRIPTION
Listing all installed packages can be slow with many packages installed.
Asking for specific package is an order of magnitude faster, overall
resulting in >25x improvement on my machine.

Some benchmark results:

```
~ $ time (eopkg info --no-color -s pkgconf | __rvm_grep "^\[inst\][[:space:]]\+pkgconf" > /dev/null 2>&1)

real	0m0.236s
user	0m0.155s
sys	0m0.089s
~ $ time (eopkg li --no-color | __rvm_grep "^pkgconf[[:space:]]\+" > /dev/null 2>&1)

real	0m6.075s
user	0m5.026s
sys	0m0.470s

~ $ # before
~ $ time rvm install 3.3.0
Searching for binary rubies, this might take some time.
No binary rubies available for: solus/4.5/x86_64/ruby-3.3.0.
Continuing with compilation. Please read 'rvm help mount' to get more information on binary rubies.
Checking requirements for solus.
Requirements installation successful.
Installing Ruby from source to: /home/ur5us/.rvm/rubies/ruby-3.3.0, this may take a while depending on your cpu(s)...
ruby-3.3.0 - #downloading ruby-3.3.0, this may take a while depending on your connection...
ruby-3.3.0 - #extracting ruby-3.3.0 to /home/ur5us/.rvm/src/ruby-3.3.0.....
ruby-3.3.0 - #autogen.sh.
ruby-3.3.0 - #configuring.................................................................
ruby-3.3.0 - #post-configuration..
ruby-3.3.0 - #compiling.......................................................................................................
ruby-3.3.0 - #installing......................
ruby-3.3.0 - #making binaries executable...
Installed rubygems 3.5.3 is newer than 3.0.9 provided with installed ruby, skipping installation, use --force to force installation.
ruby-3.3.0 - #gemset created /home/ur5us/.rvm/gems/ruby-3.3.0@global
ruby-3.3.0 - #importing gemset /home/ur5us/.rvm/gemsets/global.gems..........................................................
ruby-3.3.0 - #generating global wrappers........
ruby-3.3.0 - #gemset created /home/ur5us/.rvm/gems/ruby-3.3.0
ruby-3.3.0 - #importing gemsetfile /home/ur5us/.rvm/gemsets/default.gems evaluated to empty gem list
ruby-3.3.0 - #generating default wrappers........
ruby-3.3.0 - #adjusting #shebangs for (gem irb erb ri rdoc testrb rake).
Install of ruby-3.3.0 - #complete
Ruby was built without documentation, to build it run: rvm docs generate-ri

real	7m10.450s
user	16m26.436s
sys	2m44.146s

~ $ # after
~ $ time rvm install 3.3.0
Searching for binary rubies, this might take some time.
No binary rubies available for: solus/4.5/x86_64/ruby-3.3.0.
Continuing with compilation. Please read 'rvm help mount' to get more information on binary rubies.
Checking requirements for solus.
Requirements installation successful.
Installing Ruby from source to: /home/ur5us/.rvm/rubies/ruby-3.3.0, this may take a while depending on your cpu(s)...
ruby-3.3.0 - #downloading ruby-3.3.0, this may take a while depending on your connection...
ruby-3.3.0 - #extracting ruby-3.3.0 to /home/ur5us/.rvm/src/ruby-3.3.0.....
ruby-3.3.0 - #autogen.sh.
ruby-3.3.0 - #configuring.................................................................
ruby-3.3.0 - #post-configuration..
ruby-3.3.0 - #compiling.......................................................................................................
ruby-3.3.0 - #installing......................
ruby-3.3.0 - #making binaries executable...
Installed rubygems 3.5.3 is newer than 3.0.9 provided with installed ruby, skipping installation, use --force to force installation.
ruby-3.3.0 - #gemset created /home/ur5us/.rvm/gems/ruby-3.3.0@global
ruby-3.3.0 - #importing gemset /home/ur5us/.rvm/gemsets/global.gems..........................................................
ruby-3.3.0 - #generating global wrappers........
ruby-3.3.0 - #gemset created /home/ur5us/.rvm/gems/ruby-3.3.0
ruby-3.3.0 - #importing gemsetfile /home/ur5us/.rvm/gemsets/default.gems evaluated to empty gem list
ruby-3.3.0 - #generating default wrappers........
ruby-3.3.0 - #adjusting #shebangs for (gem irb erb ri rdoc testrb rake).
Install of ruby-3.3.0 - #complete
Ruby was built without documentation, to build it run: rvm docs generate-ri

real	4m17.665s
user	13m48.881s
sys	2m38.466s
```

…saving >2m.
