### PR TITLE
Add support for unversioned libncurses-dev packages on newer Debian-like systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * Fix truffleruby-head installation on macos-aarch64 [\#5446](https://github.com/rvm/rvm/pull/5446)
 * Fix bug with Bootsnap on Ruby 3.3.1 [\#5457](https://github.com/rvm/rvm/pull/5457)
 * Use pkgconf instead of pkg-config in Solus [\#5471](https://github.com/rvm/rvm/pull/5471)
+* Install `libncurses-dev` instead of `libncurses5-dev` on newer Debian and Ubuntu versions [\#5477](https://github.com/rvm/rvm/pull/5477)
 
 #### New interpreters
 

--- a/scripts/functions/requirements/debian
+++ b/scripts/functions/requirements/debian
@@ -79,6 +79,17 @@ requirements_debian_define_libgmp()
   fi
 }
 
+requirements_debian_define_libncurses()
+{
+  if
+    __rvm_version_compare ${_system_version} -ge 13
+  then
+    requirements_check libncurses-dev
+  else
+    requirements_check libncurses5-dev
+  fi
+}
+
 requirements_debian_define_libreadline()
 {
   if
@@ -121,10 +132,11 @@ requirements_debian_define_clang_llvm()
 requirements_debian_define_base()
 {
   requirements_check "$@" \
-    autoconf automake bison ca-certificates curl libc6-dev libffi-dev libgdbm-dev libncurses5-dev \
+    autoconf automake bison ca-certificates curl libc6-dev libffi-dev libgdbm-dev \
     libsqlite3-dev libtool libyaml-dev make openssl patch pkg-config sqlite3 zlib1g zlib1g-dev
 
   requirements_${_system_name_lowercase}_define_libgmp
+  requirements_${_system_name_lowercase}_define_libncurses
   requirements_${_system_name_lowercase}_define_libreadline
 }
 

--- a/scripts/functions/requirements/deepin
+++ b/scripts/functions/requirements/deepin
@@ -7,6 +7,11 @@ requirements_deepin_define_libgmp()
   requirements_check libgmp-dev
 }
 
+requirements_debian_define_libncurses()
+{
+  requirements_check libncurses5-dev
+}
+
 requirements_deepin_define_libreadline()
 {
   requirements_check libreadline-dev

--- a/scripts/functions/requirements/devuan
+++ b/scripts/functions/requirements/devuan
@@ -7,6 +7,11 @@ requirements_devuan_define_libgmp()
   requirements_check libgmp-dev
 }
 
+requirements_debian_define_libncurses()
+{
+  requirements_check libncurses5-dev
+}
+
 requirements_devuan_define_libreadline()
 {
   requirements_check libreadline-dev

--- a/scripts/functions/requirements/elementary
+++ b/scripts/functions/requirements/elementary
@@ -7,6 +7,11 @@ requirements_elementary_define_libgmp()
   requirements_check libgmp-dev
 }
 
+requirements_debian_define_libncurses()
+{
+  requirements_check libncurses5-dev
+}
+
 requirements_elementary_define_libreadline()
 {
   requirements_check libreadline6-dev

--- a/scripts/functions/requirements/kali
+++ b/scripts/functions/requirements/kali
@@ -7,6 +7,11 @@ requirements_kali_define_libgmp()
   requirements_check libgmp-dev
 }
 
+requirements_debian_define_libncurses()
+{
+  requirements_check libncurses5-dev
+}
+
 requirements_kali_define_libreadline()
 {
   requirements_check libreadline6-dev

--- a/scripts/functions/requirements/mint
+++ b/scripts/functions/requirements/mint
@@ -7,6 +7,11 @@ requirements_mint_define_libgmp()
   requirements_check libgmp-dev
 }
 
+requirements_debian_define_libncurses()
+{
+  requirements_check libncurses5-dev
+}
+
 requirements_mint_define_libreadline()
 {
   requirements_check libreadline-dev

--- a/scripts/functions/requirements/trisquel
+++ b/scripts/functions/requirements/trisquel
@@ -7,6 +7,11 @@ requirements_ubuntu_define_libgmp()
   requirements_check libgmp-dev
 }
 
+requirements_debian_define_libncurses()
+{
+  requirements_check libncurses5-dev
+}
+
 requirements_ubuntu_define_libreadline()
 {
   if

--- a/scripts/functions/requirements/ubuntu
+++ b/scripts/functions/requirements/ubuntu
@@ -7,6 +7,17 @@ requirements_ubuntu_define_libgmp()
   requirements_check libgmp-dev
 }
 
+requirements_debian_define_libncurses()
+{
+  if
+    __rvm_version_compare ${_system_version} -ge 24.04
+  then
+    requirements_check libncurses-dev
+  else
+    requirements_check libncurses5-dev
+  fi
+}
+
 requirements_ubuntu_define_libreadline()
 {
   if


### PR DESCRIPTION
I tested this on Ubuntu Noble, Ubuntu Focal, Debian Bookworm, Debian testing (future Trixie), and Debian unstable, and I could install Ruby 3.3 on all systems. I couldn't test all the other distributions, but this shouldn't break anything that wasn't broken before.

This technically doesn't work on Debian testing/unstable, as the numeric version number detection doesn't work, and instead it just discovers the version number as `trixie_sid`, but the old package is still aliased, so installing it works just fine. This will need adjustment when Trixie is released, but that's not going to happen tomorrow.

This fixes #5475.