### PR TITLE
Fix zlib packages for Fedora 40+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * Fix truffleruby-head installation on macos-aarch64 [\#5446](https://github.com/rvm/rvm/pull/5446)
 * Fix bug with Bootsnap on Ruby 3.3.1 [\#5457](https://github.com/rvm/rvm/pull/5457)
 * Use pkgconf instead of pkg-config in Solus [\#5471](https://github.com/rvm/rvm/pull/5471)
+* Use `zlib-ng-compat` packages for Fedora 40+ [\#5479](https://github.com/rvm/rvm/pull/5479)
 
 #### New interpreters
 

--- a/scripts/functions/requirements/fedora
+++ b/scripts/functions/requirements/fedora
@@ -44,6 +44,17 @@ requirements_fedora_define_glibc()
   fi
 }
 
+requirements_fedora_define_zlib()
+{
+  if
+    __rvm_version_compare "${_system_version}" -ge 40
+  then
+    requirements_check zlib-ng-compat zlib-ng-compat-devel
+  else
+    requirements_check zlib zlib-devel
+  fi
+}
+
 if
   __rvm_which dnf >/dev/null 2>&1 # should be true for Fedora 22+
 then

--- a/scripts/functions/requirements/fedora_dnf
+++ b/scripts/functions/requirements/fedora_dnf
@@ -61,7 +61,8 @@ requirements_fedora_define()
 
     (rbx*|rubinius*)
       requirements_check automake bison clang-3.6 flex gdbm-devel git libyaml-devel llvm-devel llvm-static \
-                         make ncurses-devel openssl-devel readline-devel ruby-devel rubygems zlib-devel
+                         make ncurses-devel openssl-devel readline-devel ruby-devel rubygems
+      requirements_fedora_define_zlib $1
       ;;
 
     (truffleruby*)
@@ -85,9 +86,10 @@ requirements_fedora_define()
     (*)
 
       requirements_check autoconf automake bison bzip2 gcc-c++ libffi-devel libtool \
-                         libyaml-devel make patch readline readline-devel sqlite-devel zlib zlib-devel
+                         libyaml-devel make patch readline readline-devel sqlite-devel
       requirements_fedora_define_openssl $1
       requirements_fedora_define_glibc $1
+      requirements_fedora_define_zlib $1
       ;;
   esac
 }


### PR DESCRIPTION
I did not touch `yum` for Fedora, because that is shared with CentOS (which is dead and I can't test), and newer Fedora versions default to `dnf` anyway.

Fixes #5478.
