### PR TITLE
Require openssl@3 for Ruby 3.2 and 3.3

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -8,9 +8,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        ruby:
+          - 3.1.6
+          - 3.2.4
+          - 3.3.3
         os:
           - ubuntu-latest
           - macos-13
+          - macos-14
         test:
           # For some reason, after running these tests,
           # `source ~/.rvm/scripts/rvm` fails on macOS, so run them last.
@@ -20,9 +25,11 @@ jobs:
           - "tests/long/truffleruby_comment_test.sh"
         include:
           - os: ubuntu-latest
+            ruby: 3.3.3
             # works on local, but fails in CI, needs to be investigated
             test: "tests/long/named_ruby_and_gemsets_comment_test.sh"
           - os: ubuntu-latest
+            ruby: 3.3.3
             # https://github.com/rvm/rvm/issues/4937
             test: "tests/long/ruby_prepare_mount_comment_test.sh"
     runs-on: ${{ matrix.os }}
@@ -32,6 +39,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: ./install
-      - run: source ~/.rvm/scripts/rvm && rvm use 2.7.7 --install --default
+      - run: source ~/.rvm/scripts/rvm && rvm use ${{ matrix.ruby }} --install --default
       - run: source ~/.rvm/scripts/rvm && gem install tf -v '>=0.4.1'
       - run: source ~/.rvm/scripts/rvm && tf --text ${{ matrix.test }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 #### New features
 
+* Use OpenSSL 3 for Ruby 3.2 and 3.3 [\#5480](https://github.com/rvm/rvm/pull/5480)
 * Add Support for OpenSSL 1.1/3.0 to older ruby versions [\#5248](https://github.com/rvm/rvm/pull/5248)
 * Update truffleruby-dev to use builds based on Ubuntu 20.04 [\#5322](https://github.com/rvm/rvm/issues/5322)
 * Install openssl gem for Ruby 3.0.6 [\#5340](https://github.com/rvm/rvm/pull/5340)

--- a/scripts/functions/requirements/osx_brew
+++ b/scripts/functions/requirements/osx_brew
@@ -318,6 +318,12 @@ requirements_osx_brew_define_openssl()
       brew_openssl_package="openssl"
       ;;
 
+    (ruby-2*|ruby-3.0*)
+      brew_openssl_package="openssl@1.1"
+      # Needed for older openssl: https://bugs.ruby-lang.org/issues/18763
+      export PKG_CONFIG_PATH="$(brew --prefix openssl@1.1)/lib/pkgconfig:$PKG_CONFIG_PATH"
+      ;;
+
     (ree-1.8*)
       brew_openssl_package="openssl"
       ;;
@@ -331,9 +337,8 @@ requirements_osx_brew_define_openssl()
       ;;
 
     (*)
-      brew_openssl_package="openssl@1.1"
-      # Needed for older openssl: https://bugs.ruby-lang.org/issues/18763
-      export PKG_CONFIG_PATH="$(brew --prefix openssl@1.1)/lib/pkgconfig:$PKG_CONFIG_PATH"
+      brew_openssl_package="openssl@3"
+      export PKG_CONFIG_PATH="$(brew --prefix openssl@3)/lib/pkgconfig:$PKG_CONFIG_PATH"
       ;;
   esac
 


### PR DESCRIPTION
Changes proposed in this pull request:
When OSX has both openssl@1.1 and openssl@3 installed, the rvm tries to use 1.1

Fixes #5445, #5444, #5180, #5448, #5422, #5393, #5379, #5367, #5365, #5365, #5278, #5272, #5266, #5261, #5246, #5240, #5229, #5222, #5202, #5152, #5039, #5043, #5047, #5408, #4966