### PR TITLE
Detect core count on ARM machines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@
 * Use pkgconf instead of pkg-config in Solus [\#5471](https://github.com/rvm/rvm/pull/5471)
 * Install `libncurses-dev` instead of `libncurses5-dev` on newer Debian and Ubuntu versions [\#5477](https://github.com/rvm/rvm/pull/5477)
 * Use `zlib-ng-compat` packages for Fedora 40+ [\#5479](https://github.com/rvm/rvm/pull/5479)
-* Detect core count on ARM-based machines
+* Detect core count on ARM-based machines [\#5498](https://github.com/rvm/rvm/pull/5498)
 
 #### New interpreters
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * Use pkgconf instead of pkg-config in Solus [\#5471](https://github.com/rvm/rvm/pull/5471)
 * Install `libncurses-dev` instead of `libncurses5-dev` on newer Debian and Ubuntu versions [\#5477](https://github.com/rvm/rvm/pull/5477)
 * Use `zlib-ng-compat` packages for Fedora 40+ [\#5479](https://github.com/rvm/rvm/pull/5479)
+* Detect core count on ARM-based machines
 
 #### New interpreters
 

--- a/scripts/functions/build_config
+++ b/scripts/functions/build_config
@@ -347,7 +347,18 @@ __rvm_detect_max_threads()
       fi
       ;;
     (*)
-      \command \cat /proc/cpuinfo 2>/dev/null | (\command \grep vendor_id || \command \echo 'one';) | \command \wc -l
+      if
+        __rvm_which nproc >/dev/null
+      then
+        nproc
+      elif
+        __rvm_which lscpu >/dev/null
+      then
+        \command \lscpu | \command \grep "^CPU(s):" | \command \awk '{print $2}'
+      else
+        # Fallback attempts to parse /proc/cpuinfo
+        \command \cat /proc/cpuinfo 2>/dev/null | (\command \grep processor || \command \echo '1';) | \command \wc -l
+      fi
       ;;
   esac
 }
@@ -390,3 +401,4 @@ __rvm_setup_compile_environment_compatibility_flag()
       ;;
   esac
 }
+


### PR DESCRIPTION
Fixes #4945.

Changes proposed in this pull request:
* ARM support for `__rvm_detect_max_threads` in `scripts/functions/build_config`


Explanation:

> The issue you're encountering is likely due to the fact that the `/proc/cpuinfo` file on ARM architectures doesn't contain the same details (like `vendor_id`) that you would expect on x86-based systems. The existing code depends on finding the `vendor_id` in `/proc/cpuinfo`, which is common on x86 processors but not necessarily present on ARM or other architectures.
> 
> Here's what you can do to modify the function to work better across different architectures, including ARM:
> 
> Use `nproc` Command: The `nproc` command typically provides the number of available processing units and works on most platforms, including ARM.
> 
> Fallback to `lscpu`: The `lscpu` command can also provide detailed info about the CPU, and you can grep the number of CPUs from it if necessary.