### PR TITLE
Fix requirement check for Ubuntu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,6 @@
 * Detect core count on ARM-based machines [\#5498](https://github.com/rvm/rvm/pull/5498)
 * Fix requirement check for Ubuntu [\#5500](https://github.com/rvm/rvm/pull/5500)
 
-
 #### New interpreters
 
 ##### MRI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@
 * Install `libncurses-dev` instead of `libncurses5-dev` on newer Debian and Ubuntu versions [\#5477](https://github.com/rvm/rvm/pull/5477)
 * Use `zlib-ng-compat` packages for Fedora 40+ [\#5479](https://github.com/rvm/rvm/pull/5479)
 * Detect core count on ARM-based machines [\#5498](https://github.com/rvm/rvm/pull/5498)
+* Fix requirement check for Ubuntu [\#5500](https://github.com/rvm/rvm/pull/5500)
+
 
 #### New interpreters
 

--- a/scripts/functions/requirements/ubuntu
+++ b/scripts/functions/requirements/ubuntu
@@ -7,7 +7,7 @@ requirements_ubuntu_define_libgmp()
   requirements_check libgmp-dev
 }
 
-requirements_debian_define_libncurses()
+requirements_ubuntu_define_libncurses()
 {
   if
     __rvm_version_compare ${_system_version} -ge 24.04


### PR DESCRIPTION
Fix a wrongly named method (`requirements_debian_define_libncurses` -> `requirements_ubuntu_define_libncurses`). I think this was a copy/paste error from #5477.

Fixes this error:

```
$ rvm requirements
Checking requirements for ubuntu.
/usr/local/rvm/scripts/functions/requirements/debian: line 139: requirements_ubuntu_define_libncurses: command not found
Requirements installation successful.
```