### PR TITLE
Update location of homebrew install script on osx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@
 * Use `zlib-ng-compat` packages for Fedora 40+ [\#5479](https://github.com/rvm/rvm/pull/5479)
 * Detect core count on ARM-based machines [\#5498](https://github.com/rvm/rvm/pull/5498)
 * Fix requirement check for Ubuntu [\#5500](https://github.com/rvm/rvm/pull/5500)
-* Update location of homebrew install script on osx
+* Update location of homebrew install script on osx [\#5505](https://github.com/rvm/rvm/pull/5505)
 
 #### New interpreters
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 * Use `zlib-ng-compat` packages for Fedora 40+ [\#5479](https://github.com/rvm/rvm/pull/5479)
 * Detect core count on ARM-based machines [\#5498](https://github.com/rvm/rvm/pull/5498)
 * Fix requirement check for Ubuntu [\#5500](https://github.com/rvm/rvm/pull/5500)
+* Update location of homebrew install script on osx
 
 #### New interpreters
 

--- a/scripts/functions/requirements/osx_brew
+++ b/scripts/functions/requirements/osx_brew
@@ -459,7 +459,7 @@ requirements_osx_brew_install_brew_setup()
     __rvm_version_compare "${_system_version}" -ge 10.5
   then
     homebrew_repo="Homebrew/brew"
-    homebrew_installer="https://raw.githubusercontent.com/Homebrew/install/master/install"
+    homebrew_installer="https://raw.githubusercontent.com/Homebrew/install/master/install.sh"
     homebrew_name="Homebrew"
   else
     homebrew_repo="mistydemeo/tigerbrew"


### PR DESCRIPTION
The previous location is giving a 404: https://raw.githubusercontent.com/Homebrew/install/master/install
It needs `.sh` on the end: https://raw.githubusercontent.com/Homebrew/install/master/install.sh