### PR TITLE
Fix detection of Homebrew's write permissions when using Workbrew

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * Detect core count on ARM-based machines [\#5498](https://github.com/rvm/rvm/pull/5498)
 * Fix requirement check for Ubuntu [\#5500](https://github.com/rvm/rvm/pull/5500)
 * Update location of homebrew install script on osx [\#5505](https://github.com/rvm/rvm/pull/5505)
+* Fix detection of Homebrew's write permissions when using Workbrew [\#5528](https://github.com/rvm/rvm/pull/5528)
 
 #### New interpreters
 

--- a/scripts/functions/requirements/osx_brew
+++ b/scripts/functions/requirements/osx_brew
@@ -541,6 +541,11 @@ requirements_osx_brew_ensure_brew_can_install()
   \typeset __celar_path
   __celar_path="$(brew --cellar)"
   if
+    [[ -x /opt/workbrew/bin/brew ]]
+  then
+    # Workbrew still installs with a non-writable Homebrew.
+    return 0
+  elif
     [[ ! -w "${__celar_path%/*}/bin" ]]
   then
     rvm_error "ERROR: '${__celar_path%/*}/bin' is not writable - it is required for Homebrew, try 'brew doctor' to fix it!"


### PR DESCRIPTION
We've had a couple of Workbrew users with issues with this RVM check so I figured I'd make a PR. If you'd rather not accept it: no worries.

If Workbrew is installed, it's expected that the Homebrew cellar is not writable by the current user. `brew install <foo>` will still work in this environment, though.

Will add a `CHANGELOG.md` entry if you're 👍🏻.