### PR TITLE
Use pkgconf instead of pkg-config on macOS/homebrew 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 * Fix requirement check for Ubuntu [\#5500](https://github.com/rvm/rvm/pull/5500)
 * Update location of homebrew install script on osx [\#5505](https://github.com/rvm/rvm/pull/5505)
 * Fix detection of Homebrew's write permissions when using Workbrew [\#5528](https://github.com/rvm/rvm/pull/5528)
+* Use pkgconf instead of pkg-config on macOS/Homebrew
 
 #### New interpreters
 

--- a/scripts/functions/requirements/osx_brew
+++ b/scripts/functions/requirements/osx_brew
@@ -348,7 +348,7 @@ requirements_osx_brew_define_openssl()
 requirements_osx_brew_libs_default()
 {
   brew_libs=(
-    autoconf automake libtool pkg-config coreutils
+    autoconf automake libtool pkgconf coreutils
   )
   brew_libs_conf=(
     libyaml libksba readline zlib


### PR DESCRIPTION
Fixes https://github.com/rvm/rvm/issues/5530.

Changes proposed in this pull request:
* use pkgconf instead of pkg-config for macOS systems that use homebrew

Make sure that your pull request includes entry in the [CHANGELOG](CHANGELOG.md).