### PR TITLE
Allow passing a shell name to avoid shell detection

### DIFF
--- a/scripts/rvm
+++ b/scripts/rvm
@@ -9,25 +9,34 @@
 if
   test -n "${BASH_VERSION:-}" -o -n "${ZSH_VERSION:-}" -o -n "${KSH_VERSION:-}"
 then
-  case "`uname`" in
-    (CYGWIN*|MINGW*)
-      __shell_name="`\command \ps -p $$ | \command \awk 'END {print $NF}'` 2>/dev/null" ;;
+  # Allow explicit shell type as first argument to bypass ps command (useful in sandboxed environments)
+  # Usage: source "$HOME/.rvm/scripts/rvm" bash
+  # In .bashrc: [[ -s "$HOME/.rvm/scripts/rvm" ]] && source "$HOME/.rvm/scripts/rvm" bash
+  # In .zshrc: [[ -s "$HOME/.rvm/scripts/rvm" ]] && source "$HOME/.rvm/scripts/rvm" zsh
+  if [[ -n "${1:-}" ]]
+  then
+    __shell_name="$1"
+  else
+    case "`uname`" in
+      (CYGWIN*|MINGW*)
+        __shell_name="`\command \ps -p $$ | \command \awk 'END {print $NF}'` 2>/dev/null" ;;
 
-    (SunOS)
-      __shell_name="`\command \ps -p $$ -o comm=`" ;;
+      (SunOS)
+        __shell_name="`\command \ps -p $$ -o comm=`" ;;
 
-    (Linux)
-      case "$(command uname -o)" in
-        (Android)
-          __shell_name="gawk 'BEGIN{RS=\"\"}; NR==1{print; exit}' /proc/$$/cmdline | tr - '\0'" ;;
+      (Linux)
+        case "$(command uname -o)" in
+          (Android)
+            __shell_name="gawk 'BEGIN{RS=\"\"}; NR==1{print; exit}' /proc/$$/cmdline | tr - '\0'" ;;
 
-        (*)
-          __shell_name="`\command \ps -p $$ -o ucomm=`" ;;
-      esac ;;
+          (*)
+            __shell_name="`\command \ps -p $$ -o ucomm=`" ;;
+        esac ;;
 
-    (*)
-      __shell_name="`\command \ps -p $$ -o ucomm=`" ;;
-  esac
+      (*)
+        __shell_name="`\command \ps -p $$ -o ucomm=`" ;;
+    esac
+  fi
 
   case "$__shell_name" in
     (""|dash|sh|ksh|*/dash|*/sh|*/ksh) return 0 ;; # silently stop in sh shells


### PR DESCRIPTION
Local device agents often run in a sandboxed environment that don't have persion to invoke `/bin/ps`. This change allows for passing the shell name as an argument to allow circumventing dynamic detection. A similar pattern is used in Homebrew.

This is a proposal. If this approach seems good, then I think there might be a change needed for documentation and potentially the installers.

Fixes #5589.