### PR TITLE
Add ruby-4* matchers for compiling movable Ruby

### DIFF
--- a/scripts/functions/build_config
+++ b/scripts/functions/build_config
@@ -39,7 +39,7 @@ __rvm_setup_compile_environment_movable_early()
       ;;
     (Darwin)
       case "$1" in
-        ruby-2*|ruby-3*|ruby-head*) true ;;
+        ruby-2*|ruby-3*|ruby-4*|ruby-head*) true ;;
         (*)
           if
             (( ${rvm_force_flag:-0} > 0 ))
@@ -66,7 +66,7 @@ please install SMF and switch autolibs to it (make sure to follow any displayed 
       ;;
     (*)
       case "$1" in
-        ruby-1.9.3*|ruby-2*|ruby-3*|ruby-head*) true ;;
+        ruby-1.9.3*|ruby-2*|ruby-3*|ruby-4*|ruby-head*) true ;;
         (*)
           rvm_error "Only MRI Ruby 1.9.3+ can be compiled movable with RVM"
           return 2


### PR DESCRIPTION
Fixes https://github.com/rvm/rvm/issues/5615

Changes proposed in this pull request:
Recognise Ruby 4.0.0 as a valid target for movable compilation