### PR TITLE
ci: enable fast-tests for Ruby 4.0

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -22,6 +22,7 @@ jobs:
           - 3.2
           - 3.3
           - 3.4
+          - '4.0'
         include:
           # TODO: works on local, but fails in CI, needs to be investigated
           - os: ubuntu-latest


### PR DESCRIPTION
Followup of #5611