### PR TITLE
Fix nounset loading errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 #### Bug fixes
 
+* Fix nounset errors while loading RVM with `set -u` [\#4694](https://github.com/rvm/rvm/issues/4694)
 * Remove unsupported libclang, libclang-dev, openssl-dev and zlib-dev from Termux requirements, and fix installation by not calling getent [\#5101](https://github.com/rvm/rvm/pull/5101)
 * Allow ruby-head to be installed using ruby 3, not truffleruby [\#5115](https://github.com/rvm/rvm/pull/5115)
 * Fix attempts to install/uninstall ruby picking jruby, mruby or truffleruby instead [\#5116](https://github.com/rvm/rvm/pull/5116)

--- a/scripts/functions/db
+++ b/scripts/functions/db
@@ -5,7 +5,18 @@
 __rvm_db_system()
 {
   \typeset __key __message
-  for __key in "${_system_name}_${_system_version}_$1" "${_system_name}_$1" "$1"
+  \typeset -a __keys
+
+  __keys=()
+  if [[ -n "${_system_name:-}" && -n "${_system_version:-}" ]]
+  then __keys+=( "${_system_name}_${_system_version}_$1" )
+  fi
+  if [[ -n "${_system_name:-}" ]]
+  then __keys+=( "${_system_name}_$1" )
+  fi
+  __keys+=( "$1" )
+
+  for __key in "${__keys[@]}"
   do
     if __rvm_db "${__key}_error" __message
     then rvm_error "${__message}"
@@ -13,7 +24,7 @@ __rvm_db_system()
     if __rvm_db "${__key}_warn" __message
     then rvm_warn "${__message}"
     fi
-    if __rvm_db "${__key}" "$2"
+    if __rvm_db "${__key}" "${2:-}"
     then return 0
     fi
   done

--- a/scripts/functions/support
+++ b/scripts/functions/support
@@ -179,8 +179,8 @@ __rvm_setup_utils_functions()
   gnu_utils=( awk cp date find sed tail tar xargs )
   gnu_missing=()
 
-  if is_a_function __rvm_setup_utils_functions_${_system_name}
-  then __rvm_setup_utils_functions_${_system_name} "$@" || return $?
+  if is_a_function __rvm_setup_utils_functions_${_system_name:-}
+  then __rvm_setup_utils_functions_${_system_name:-} "$@" || return $?
   else __rvm_setup_utils_functions_Other "$@" || return $?
   fi
 }

--- a/scripts/rvm
+++ b/scripts/rvm
@@ -137,7 +137,7 @@ else
 fi
 
 # guess rvm_prefix if not set
-if [[ -z "${rvm_prefix}" ]]
+if [[ -z "${rvm_prefix:-}" ]]
 then
   rvm_prefix=$( dirname $rvm_path )
 fi

--- a/tests/fast/nounset_comment_test.sh
+++ b/tests/fast/nounset_comment_test.sh
@@ -1,0 +1,2 @@
+bash -u -c 'unset GEM_HOME GEM_PATH MY_RUBY_HOME; export rvm_path="$PWD"; source scripts/rvm >/dev/null; rvm current' # match=/^system$/
+bash -u -c 'export rvm_path="$PWD" rvm_scripts_path="$PWD/scripts" rvm_user_path="$PWD/user"; source scripts/base >/dev/null; unset _system_name _system_version; __rvm_db_system ruby_version' # match=/^[0-9]+\.[0-9]+\.[0-9]+$/


### PR DESCRIPTION
Fixes #4694.

IssueHunt bounty: https://oss.issuehunt.io/r/rvm/rvm/issues/4694 ($40)

The reported script runs under `set -euo pipefail`, so ordinary RVM loading must not read unset shell variables. I reproduced a current nounset failure locally with:

```sh
bash -u -c 'export rvm_path=$PWD; source scripts/rvm >/tmp/rvm-source-nounset.out; rvm current'
```

This currently fails before `rvm current` because `rvm_prefix` is read without a default. After fixing that, the same nounset path exposed the `_system_name` case in the DB/system setup path, so this also makes the system-key DB lookup tolerate unset detection variables and fall back to the generic key.

Changes:

- Guard `rvm_prefix` while guessing the prefix during `scripts/rvm` load.
- Guard early utility setup before `_system_name` has been detected.
- Make `__rvm_db_system` build system-specific keys only when the relevant system variables are present, then fall back to the generic key.
- Add a fast nounset regression test for both `source scripts/rvm` and the `_system_name` DB fallback path.
- Add changelog entry.

Tests:

- `env rvm_path=$PWD BUNDLE_GEMFILE=$PWD/tests/Gemfile BUNDLE_PATH=/tmp/rvm-tf-bundle bundle exec tf --text tests/fast/nounset_comment_test.sh`
- `bash -u -c 'unset GEM_HOME GEM_PATH MY_RUBY_HOME; export rvm_path=$PWD; source scripts/rvm >/dev/null; rvm current'`
- `bash -u -c 'export rvm_path=$PWD rvm_scripts_path=$PWD/scripts rvm_user_path=$PWD/user; source scripts/base >/dev/null; unset _system_name _system_version; __rvm_db_system ruby_version'`
- `bash -n scripts/rvm scripts/functions/db scripts/functions/support tests/fast/nounset_comment_test.sh`
- `git diff --check -- CHANGELOG.md scripts/rvm scripts/functions/db scripts/functions/support tests/fast/nounset_comment_test.sh`
