### PR TITLE
Fix RVM loading with bash nounset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 * Fix autogen.sh call for MRI's on OpenBSD [\#5620](https://github.com/rvm/rvm/pull/5620)
 * Update TruffleRuby dependencies for TruffleRuby 33+ [\#5632](https://github.com/rvm/rvm/pull/5632)
 * Avoid undefined `rvm_shell_nounset` variable [\#5638](https://github.com/rvm/rvm/pull/5638)
+* Fix Bash nounset failures while loading RVM [\#4694](https://github.com/rvm/rvm/issues/4694)
 
 #### New interpreters
 

--- a/scripts/cd
+++ b/scripts/cd
@@ -35,8 +35,9 @@ case "${rvm_project_rvmrc:-1}" in
     __rvm_do_with_env_after
     return 0
   }
-  [[ " ${chpwd_functions[*]} " == *" __rvm_cd_functions_set "* ]] ||
-  chpwd_functions=( "${chpwd_functions[@]}" __rvm_cd_functions_set )
+  [[ -n "${chpwd_functions+set}" ]] || chpwd_functions=()
+  [[ " ${chpwd_functions[*]-} " == *" __rvm_cd_functions_set "* ]] ||
+  chpwd_functions+=( __rvm_cd_functions_set )
 
   # This functionality is opt-in by setting rvm_cd_complete_flag=1 in ~/.rvmrc
   # Generic bash cd completion seems to work great for most, so this is only

--- a/scripts/functions/support
+++ b/scripts/functions/support
@@ -174,13 +174,14 @@ __rvm_cd()
 
 __rvm_setup_utils_functions()
 {
-  \typeset gnu_tools_path gnu_prefix gnu_util
+  \typeset gnu_tools_path gnu_prefix gnu_util _detected_system_name
   \typeset -a gnu_utils gnu_missing
   gnu_utils=( awk cp date find sed tail tar xargs )
   gnu_missing=()
+  _detected_system_name="${_system_name:-Other}"
 
-  if is_a_function __rvm_setup_utils_functions_${_system_name}
-  then __rvm_setup_utils_functions_${_system_name} "$@" || return $?
+  if is_a_function __rvm_setup_utils_functions_${_detected_system_name}
+  then __rvm_setup_utils_functions_${_detected_system_name} "$@" || return $?
   else __rvm_setup_utils_functions_Other "$@" || return $?
   fi
 }

--- a/scripts/rvm
+++ b/scripts/rvm
@@ -137,7 +137,7 @@ else
 fi
 
 # guess rvm_prefix if not set
-if [[ -z "${rvm_prefix}" ]]
+if [[ -z "${rvm_prefix:-}" ]]
 then
   rvm_prefix=$( dirname $rvm_path )
 fi

--- a/tests/fast/nounset_comment_test.sh
+++ b/tests/fast/nounset_comment_test.sh
@@ -1,0 +1,5 @@
+set -u
+source "$rvm_path/scripts/rvm" # status=0
+rvm use system                # status=0; match=/system/
+[[ ":${SHELLOPTS:-}:" == *":nounset:"* ]]
+# status=0


### PR DESCRIPTION
## Summary

Fixes #4694.

This makes the RVM load path tolerate Bash `set -u`/nounset when no system metadata has been detected yet. The failing Packer/AWS scenario runs RVM from a strict-mode shell, so reads of variables such as `_system_name`, `rvm_prefix`, and `chpwd_functions` should not assume those names have already been initialized.

Changes:

- Guard `rvm_prefix` before deriving it from `rvm_path`.
- Fall back to the generic utility setup before `_system_name` has been detected.
- Initialize and append to `chpwd_functions` without triggering nounset on Bash 3.2.
- Add a fast regression test for sourcing RVM and selecting the system Ruby under nounset.

## Validation

- `bash -n scripts/rvm scripts/functions/support scripts/cd tests/fast/nounset_comment_test.sh`
- `bash -lc 'set -u; export rvm_path=$PWD; source scripts/rvm; rvm use system >/tmp/rvm-use-system.out; cat /tmp/rvm-use-system.out; declare -p chpwd_functions; [[ ":${SHELLOPTS:-}:" == *":nounset:"* ]]'`
- `bash -lc 'set -u; export rvm_path=$PWD; source scripts/rvm; rvm info system >/tmp/rvm-info-system.out; head -n 22 /tmp/rvm-info-system.out; [[ ":${SHELLOPTS:-}:" == *":nounset:"* ]]'`
- `git diff --check`

Note: the local `rvm info system` run on macOS emits existing environment warnings about `/opt/homebrew/bin` permissions and Command Line Tools vs full Xcode, but exits successfully.
