### PR TITLE
ci: allow failure on macos-15-intel

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -35,6 +35,7 @@ jobs:
             test: tests/fail-in-ci/ruby_prepare_mount_comment_test.sh
 
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.os == 'macos-15-intel' }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
macOS ci continuously fails, so mark as
successful job, but log with warning.

Fixes # .

Changes proposed in this pull request:
*
*
*

Make sure that your pull request includes entry in the [CHANGELOG](CHANGELOG.md).